### PR TITLE
Add loan calculation breakdown modal

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -812,8 +812,9 @@
 </div>
 <!-- Summary Table (Loan Summary Format) -->
 <div class="card">
-<div class="card-header" data-currency="GBP" style="background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%); color: white; text-align: center; font-weight: bold; border: 1px solid #000;">
-                    Loan Summary
+<div class="card-header d-flex align-items-center" data-currency="GBP" style="background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%); color: white; font-weight: bold; border: 1px solid #000;">
+                    <span class="flex-grow-1 text-center">Loan Summary</span>
+                    <button type="button" class="btn btn-sm btn-light ms-2" id="viewBreakdownBtn" data-bs-toggle="modal" data-bs-target="#calculationBreakdownModal">View Details</button>
                 </div>
 <div class="card-body p-0">
 <table class="table" style="border: 1px solid #000; border-collapse: collapse;">
@@ -1014,6 +1015,25 @@
 <h5 class="text-muted">Enter loan details to see calculations</h5>
 <p class="text-muted">Fill out the form on the left to generate detailed loan calculations and payment schedules.</p>
 </div>
+
+<!-- Calculation Breakdown Modal -->
+<div class="modal fade" id="calculationBreakdownModal" tabindex="-1" aria-labelledby="calculationBreakdownLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="calculationBreakdownLabel">Calculation Details</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body" id="calculationBreakdownContent">
+                <!-- Content injected by calculator.js -->
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add View Details button to loan summary card
- show step-by-step loan calculation in a scrollable modal
- wire up client-side logic to populate modal with fees, interest, tranches and schedule

## Testing
- `pytest` *(fails: command not found)*
- `pip install pytest` *(fails: externally-managed-environment)*

------
https://chatgpt.com/codex/tasks/task_e_6899cf5ee6488320b629430f74fd73b9