### PR TITLE
style: prevent overlap between input and results

### DIFF
--- a/static/css/novellus-theme.css
+++ b/static/css/novellus-theme.css
@@ -620,6 +620,17 @@ h4, h5, h6 {
     box-shadow: 0 4px 12px rgba(30, 43, 58, 0.06);
 }
 
+@media (max-width: 991.98px) {
+    /* Add separation between the calculator inputs and results on smaller screens */
+    .calculator-section {
+        margin-bottom: 2rem;
+    }
+
+    .results-section {
+        margin-top: 2rem;
+    }
+}
+
 /* Hero Section */
 .hero-section {
     background: linear-gradient(135deg, var(--novellus-navy) 0%, var(--novellus-navy-dark) 100%);


### PR DESCRIPTION
## Summary
- add responsive spacing between calculator inputs and results to avoid overlap on narrow screens

## Testing
- `pytest` *(fails: No module named 'sqlalchemy')*
- `pip install sqlalchemy requests psycopg2-binary` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6899fb6bfb888320b94fa0f3f85ed11a