### PR TITLE
Revert tranche input changes and normalize tranche values

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -5967,15 +5967,17 @@ class LoanCalculator:
         for month in range(1, loan_term + 1):
             summary = monthly_summary[month]
             
-            # CRITICAL FIX: Check for user's tranche release for this month
-            user_tranche_release = 0
+            # Check for user's tranche release for this month
+            user_tranche_release = 0.0
             for tranche in user_tranches:
-                if tranche.get('month') == month:
+                if int(tranche.get('month', 0)) == month:
                     user_tranche_release = float(tranche.get('amount', 0))
                     break
-            
+
             # Use user's tranche release if available, otherwise use calculated amount
-            actual_tranche_release = user_tranche_release if user_tranche_release > 0 else summary['new_tranche_release']
+            actual_tranche_release = float(
+                user_tranche_release if user_tranche_release > 0 else summary['new_tranche_release']
+            )
             
             # Calculate total principal amounts
             total_principal_start = (day1_advance if month == 1 else float(day1_advance)) + (summary['progressive_balance'] - actual_tranche_release if month > 1 else 0)

--- a/routes.py
+++ b/routes.py
@@ -354,15 +354,26 @@ def api_calculate():
         capital_repayment = safe_float(data.get('capital_repayment'), 0)
         flexible_payment = safe_float(data.get('flexible_payment'), 0)
         
-        # Handle development loan tranches - CRITICAL FIX for user tranche input
-        tranches = data.get('tranches', data.get('user_tranches', []))
-        
+        # Handle development loan tranches
+        raw_tranches = data.get('tranches', [])
+        tranches = []
+        for idx, tranche in enumerate(raw_tranches, start=1):
+            tranches.append({
+                'amount': safe_float(tranche.get('amount'), 0),
+                'month': int(tranche.get('month', idx)),
+                'date': tranche.get('date'),
+                'rate': safe_float(tranche.get('rate'), 0),
+                'description': tranche.get('description', '')
+            })
+
         # Debug logging to see what tranches data we received
         import logging
         logging.info(f"ROUTES.PY TRANCHE DEBUG: Received {len(tranches)} tranches from API request")
         if tranches:
             for i, tranche in enumerate(tranches[:3]):  # Show first 3 for debugging
-                logging.info(f"  Tranche {i+1}: Amount=£{tranche.get('amount', 0):,.2f}, Date={tranche.get('date', 'N/A')}")
+                logging.info(
+                    f"  Tranche {i+1}: Amount=£{tranche.get('amount', 0):,.2f}, Date={tranche.get('date', 'N/A')}"
+                )
         
         # Day 1 advance for development loans - using safe conversion
         day1_advance = safe_float(data.get('day1_advance'), 0)

--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -503,24 +503,27 @@ class LoanCalculator {
         if (data.loan_type === 'development' || data.loan_type === 'development2') {
             const tranches = [];
             const trancheContainer = document.getElementById('tranchesContainer');
+            
             if (trancheContainer) {
-                const rows = trancheContainer.querySelectorAll('tr[data-index]');
-                rows.forEach((row, index) => {
-                    const amountInput = row.querySelector("input[name='tranche_amounts[]']");
-                    const dateInput = row.querySelector("input[name='tranche_dates[]']");
-                    const rateInput = row.querySelector("input[name='tranche_rates[]']");
-                    const descInput = row.querySelector("input[name='tranche_descriptions[]']");
-
-                    const amount = parseFloat(amountInput?.value) || 0;
-                    const date = dateInput?.value || '';
-                    const rate = parseFloat(rateInput?.value) || parseFloat(data.annual_rate) || 12;
-                    const description = descInput?.value || `Tranche ${index + 1}`;
-
-                    if (amount > 0 && date) {
-                        tranches.push({ amount, date, rate, description });
+                const trancheInputs = trancheContainer.querySelectorAll('.tranche-item');
+                
+                trancheInputs.forEach((trancheItem, index) => {
+                    const amountInput = trancheItem.querySelector('.tranche-amount');
+                    const dateInput = trancheItem.querySelector('.tranche-date');
+                    const rateInput = trancheItem.querySelector('.tranche-rate');
+                    const descriptionInput = trancheItem.querySelector('.tranche-description');
+                    
+                    if (amountInput && dateInput && parseFloat(amountInput.value) > 0) {
+                        tranches.push({
+                            amount: parseFloat(amountInput.value),
+                            date: dateInput.value,
+                            rate: parseFloat(rateInput.value) || parseFloat(data.annual_rate) || 12,
+                            description: descriptionInput.value || `Tranche ${index + 1}`
+                        });
                     }
                 });
             }
+            
             if (tranches.length > 0) {
                 data.tranches = tranches;
             }

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -735,59 +735,48 @@
 </div>
 </div>
 <!-- Manual Tranche Controls -->
-<div id="manualTrancheControls" class="mb-3">
-    <div class="d-flex justify-content-between align-items-center">
-        <span>Tranche Schedule</span>
-        <button type="button" class="btn btn-sm btn-primary" id="addTrancheBtn"><i class="fas fa-plus me-1"></i>Add Tranche</button>
-    </div>
-    <table class="table mt-2" id="tranchesTable" style="display: none;">
-        <thead>
-            <tr>
-                <th>Amount</th>
-                <th>Release Date</th>
-                <th>Rate (%)</th>
-                <th>Description</th>
-                <th></th>
-            </tr>
-        </thead>
-        <tbody id="tranchesContainer"></tbody>
-    </table>
+<div class="d-flex justify-content-between align-items-center" id="manualTrancheControls">
+<span>Number of Tranches</span>
+<div class="btn-group" role="group">
+<button class="btn btn-outline-secondary btn-sm" id="decreaseTranches" type="button">-</button>
+<span class="btn btn-outline-secondary btn-sm" id="trancheCount">1</span>
+<button class="btn btn-outline-secondary btn-sm" id="increaseTranches" type="button">+</button>
 </div>
-<!-- Tranche Modal -->
-<div class="modal fade" id="trancheModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Tranche</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <div class="mb-3">
-          <label class="form-label">Tranche Amount</label>
-          <div class="input-group">
-            <span class="input-group-text currency-symbol">£</span>
-            <input type="number" class="form-control" id="modalTrancheAmount" min="0" step="0.0001">
-          </div>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Release Date</label>
-          <input type="date" class="form-control" id="modalTrancheDate">
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Interest Rate (%)</label>
-          <input type="number" class="form-control" id="modalTrancheRate" min="0" max="50" step="0.0001">
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Description</label>
-          <input type="text" class="form-control" id="modalTrancheDescription">
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="button" class="btn btn-primary" id="saveTrancheBtn">Save Tranche</button>
-      </div>
-    </div>
-  </div>
+</div>
+<div id="tranchesContainer">
+<div class="tranche-item" data-tranche="1">
+<div class="card">
+<div class="card-header">
+<h6 class="">Tranche 1</h6>
+</div>
+<div class="card-body">
+<div class="row">
+<div class="col-md-6">
+<label class="form-label">Tranche Amount</label>
+<div class="input-group">
+<span class="input-group-text currency-symbol">£</span>
+<input class="form-control tranche-amount" min="0" name="tranche_amounts[]" placeholder="0" step="0.0001" type="number"/>
+</div>
+</div>
+<div class="col-md-6">
+<label class="form-label">Release Date</label>
+<input class="form-control tranche-date" name="tranche_dates[]" type="date"/>
+</div>
+</div>
+<div class="row">
+<div class="col-md-6">
+<label class="form-label">Interest Rate (%)</label>
+<input class="form-control tranche-rate" max="50" min="0" name="tranche_rates[]" placeholder="Annual rate" step="0.0001" type="number"/>
+</div>
+<div class="col-md-6">
+<label class="form-label">Description</label>
+<input class="form-control tranche-description" name="tranche_descriptions[]" placeholder="e.g., Land Purchase" type="text"/>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
 </div>
 <!-- Calculate Button -->
 <div class="d-grid gap-2">


### PR DESCRIPTION
## Summary
- Revert previous merge that modified tranche input handling
- Parse tranche amounts from requests and include month, rate, and description
- Use parsed tranche amounts in development loan calculations

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests'; No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_689a0ecfae848320a0f96680ec60915f