### PR TITLE
Ensure CSV uses explicit delimiter and newline

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -143,7 +143,12 @@ def generate_payment_schedule_csv(schedule: List[Dict], currency: str = 'GBP') -
     else:
         fieldnames = ["Month", "Payment", "Principal", "Interest", "Balance"]
     
-    writer = csv.DictWriter(output, fieldnames=fieldnames)
+    writer = csv.DictWriter(
+        output,
+        fieldnames=fieldnames,
+        delimiter=',',
+        lineterminator='\n'
+    )
     writer.writeheader()
     
     symbol = '£' if currency == 'GBP' else '€' if currency == 'EUR' else '$'


### PR DESCRIPTION
## Summary
- Specify comma delimiter and newline terminator when generating payment schedule CSVs to prevent all data appearing in a single column

## Testing
- `pytest -q` *(fails: No module named 'sqlalchemy'; No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_689a70ca8ff483208ca8c6c7a506ee68