### PR TITLE
Add LTV targeting simulation for bridge and term loans

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -676,6 +676,31 @@
 </div>
 <small class="form-text text-muted">Amount will adjust based on payment frequency</small>
 </div>
+
+<div class="" id="ltvSimulationSection" style="display: none;">
+  <div class="form-check mb-2">
+    <input class="form-check-input" type="checkbox" id="ltvTargetCheckbox"/>
+    <label class="form-check-label" for="ltvTargetCheckbox">LTV Targeting Simulation</label>
+  </div>
+  <div id="ltvTargetInputs" style="display: none;">
+    <div class="mb-2">
+      <label class="form-label" for="targetLTVExit">Target LTV % on Exit</label>
+      <div class="input-group">
+        <input class="form-control" id="targetLTVExit" min="0" max="100" step="0.01" type="number" placeholder="e.g. 40"/>
+        <span class="input-group-text">%</span>
+      </div>
+    </div>
+    <div class="mb-2">
+      <label class="form-label">Progressive LTV Targets</label>
+      <div id="progressiveLTVList"></div>
+      <button type="button" class="btn btn-sm btn-outline-secondary" id="addLTVTarget">Add Target</button>
+    </div>
+    <div class="mt-2">
+      <strong>Total Capital Needed:</strong> <span id="ltvTotalCapital">£0</span>
+      <div id="ltvCapitalSchedule" class="mt-2"></div>
+    </div>
+  </div>
+</div>
 </div>
 <!-- Development Loan Tranches -->
 <div class="" id="developmentTrancheSection" style="display: none;">


### PR DESCRIPTION
## Summary
- add UI for LTV targeting with exit and progressive LTV inputs
- compute monthly capital repayments required to meet LTV targets
- expose LTV simulation only for bridge and term loans with service+capital, capital payment, or flexible repayment options

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install sqlalchemy psycopg2-binary` *(fails: Could not find a version that satisfies the requirement sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_689aeae86fc48320a547f83cb031d79c