### PR TITLE
Fix end LTV calculation for capital repayment option

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -395,6 +395,21 @@ class LoanCalculator:
                     closing_balance = Decimal(str(closing_balance_raw).replace('£', '').replace(',', ''))
                 except Exception:
                     closing_balance = Decimal('0')
+
+                # For capital_payment_only we want the LTV based on the
+                # outstanding balance *before* the final payment is applied.
+                # The detailed schedule sets the final closing balance to 0
+                # (after repayment plus any interest refund), which results in
+                # an end LTV of 0 even though there was an outstanding balance
+                # at the start of that period.  Use the opening balance of the
+                # final schedule entry when the closing balance is 0.
+                if repayment_option == 'capital_payment_only' and closing_balance == 0:
+                    opening_balance_raw = last_entry.get('opening_balance') or last_entry.get('openingBalance') or 0
+                    try:
+                        closing_balance = Decimal(str(opening_balance_raw).replace('£', '').replace(',', ''))
+                    except Exception:
+                        closing_balance = Decimal('0')
+
                 updated_end_ltv = float((closing_balance / property_value * 100)) if property_value > 0 else 0
                 calculation['endLTV'] = updated_end_ltv
                 calculation['endLtv'] = updated_end_ltv
@@ -690,6 +705,19 @@ class LoanCalculator:
                     closing_balance = Decimal(str(closing_balance_raw).replace('£', '').replace(',', ''))
                 except Exception:
                     closing_balance = Decimal('0')
+
+                # Mirror bridge loan logic: for capital_payment_only the final
+                # schedule entry has a closing balance of 0 after applying the
+                # last capital repayment (and any interest refund).  Use the
+                # opening balance of that entry to reflect the outstanding
+                # balance prior to repayment when calculating End LTV.
+                if repayment_option == 'capital_payment_only' and closing_balance == 0:
+                    opening_balance_raw = last_entry.get('opening_balance') or last_entry.get('openingBalance') or 0
+                    try:
+                        closing_balance = Decimal(str(opening_balance_raw).replace('£', '').replace(',', ''))
+                    except Exception:
+                        closing_balance = Decimal('0')
+
                 updated_end_ltv = float((closing_balance / property_value * 100)) if property_value > 0 else 0
                 calculation['endLTV'] = updated_end_ltv
                 calculation['endLtv'] = updated_end_ltv

--- a/test_end_ltv.py
+++ b/test_end_ltv.py
@@ -49,7 +49,13 @@ def test_capital_payment_only_end_ltv():
     }
     result = calc.calculate_bridge_loan(params)
     assert result['startLTV'] == pytest.approx(50.0)
-    assert result['endLTV'] == pytest.approx(0.0)
+
+    assert 'detailed_payment_schedule' in result and result['detailed_payment_schedule'], "schedule missing"
+    last = result['detailed_payment_schedule'][-1]
+    opening_balance = parse_currency(last.get('opening_balance') or last.get('openingBalance'))
+    expected_end_ltv = float((opening_balance / Decimal('200000')) * 100)
+
+    assert result['endLTV'] == pytest.approx(expected_end_ltv)
     # Alias fields should mirror the primary LTV values
     assert result['startLtv'] == pytest.approx(result['startLTV'])
     assert result['endLtv'] == pytest.approx(result['endLTV'])


### PR DESCRIPTION
## Summary
- compute end LTV using opening balance when closing balance is zero for capital repayment schedules
- align frontend end LTV calculation with backend logic
- extend tests to validate new end LTV behaviour

## Testing
- `pytest -q test_end_ltv.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy'; ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_689b026255888320986e31e6c999b78a