### PR TITLE
Fix LTV targeting for flexible payments and allow 4 decimal inputs

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -1109,7 +1109,7 @@ class LoanCalculator {
             try {
                 const formattedValue = numericValue.toLocaleString('en-GB', {
                     minimumFractionDigits: 0,
-                    maximumFractionDigits: 2
+                    maximumFractionDigits: 4
                 });
                 input.value = formattedValue;
             } catch (error) {
@@ -3465,11 +3465,24 @@ LoanCalculator.prototype.calculateLTVSimulation = function(results) {
         });
     }
 
-    // Auto-populate capital repayment field when a single LTV target is provided
-    const capitalInput = document.getElementById('capitalRepayment');
-    if (capitalInput && schedule.length === 1) {
-        capitalInput.value = (schedule[0].monthly || 0).toFixed(2);
-        // Trigger input event so calculation updates immediately
-        capitalInput.dispatchEvent(new Event('input', { bubbles: true }));
+    // Auto-populate repayment field when a single LTV target is provided
+    const repaymentOption = document.getElementById('repaymentOption')?.value;
+    const amount = schedule[0]?.monthly || 0;
+    if (schedule.length === 1) {
+        if (repaymentOption === 'flexible_payment') {
+            const flexInput = document.getElementById('flexiblePayment');
+            if (flexInput) {
+                flexInput.value = amount.toFixed(4);
+                // Trigger input event so calculation updates immediately
+                flexInput.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+        } else {
+            const capitalInput = document.getElementById('capitalRepayment');
+            if (capitalInput) {
+                capitalInput.value = amount.toFixed(4);
+                // Trigger input event so calculation updates immediately
+                capitalInput.dispatchEvent(new Event('input', { bubbles: true }));
+            }
+        }
     }
 };


### PR DESCRIPTION
## Summary
- Re-run LTV targeting when flexible repayment is selected by updating the flexible payment input.
- Allow 4 decimal places for monetary inputs and LTV targeting auto-fill values.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy'; ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_689b140dfac88320a9bd534338d071ca