### PR TITLE
Add simple wizard view for loan calculator

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -278,6 +278,12 @@ def calculator_page():
     """Loan calculator page"""
     return render_template('calculator.html')
 
+
+@app.route('/calculator-wizard')
+def calculator_wizard_page():
+    """Wizard-based loan calculator page"""
+    return render_template('calculator_wizard.html')
+
 @app.route('/api/calculate', methods=['POST'])
 def api_calculate():
     """API endpoint for loan calculations"""

--- a/static/js/calculator_wizard.js
+++ b/static/js/calculator_wizard.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const steps = Array.from(document.querySelectorAll('.form-step'));
+  let current = 0;
+
+  function showStep(index) {
+    steps.forEach((step, i) => {
+      step.classList.toggle('active', i === index);
+    });
+  }
+
+  document.querySelectorAll('.next-step').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (current < steps.length - 1) {
+        current++;
+        showStep(current);
+      }
+    });
+  });
+
+  document.querySelectorAll('.prev-step').forEach(btn => {
+    btn.addEventListener('click', () => {
+      if (current > 0) {
+        current--;
+        showStep(current);
+      }
+    });
+  });
+
+  showStep(current);
+});

--- a/templates/calculator_wizard.html
+++ b/templates/calculator_wizard.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+
+{% block title %}Loan Calculator Wizard - Novellus{% endblock %}
+
+{% block head %}
+<link href="{{ url_for('static', filename='css/novellus-theme.css') }}" rel="stylesheet"/>
+<style>
+  .form-step { display: none; }
+  .form-step.active { display: block; }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+  <h1 class="mb-4">Loan Calculator Wizard</h1>
+  <form id="wizardForm">
+    <!-- Step 1: Loan Details -->
+    <div class="form-step active" data-step="1">
+      <h4 class="mb-3">Loan Details</h4>
+      <div class="mb-3">
+        <label for="loanName" class="form-label">Loan Name</label>
+        <input type="text" class="form-control" id="loanName" required>
+      </div>
+      <div class="mb-3">
+        <label for="loanType" class="form-label">Loan Type</label>
+        <select id="loanType" class="form-select" required>
+          <option value="bridge">Bridge Loan</option>
+          <option value="term">Term Loan</option>
+          <option value="development">Development Loan</option>
+        </select>
+      </div>
+      <div class="d-flex justify-content-end">
+        <button type="button" class="btn btn-primary next-step">Next</button>
+      </div>
+    </div>
+
+    <!-- Step 2: Amounts -->
+    <div class="form-step" data-step="2">
+      <h4 class="mb-3">Amounts</h4>
+      <div class="mb-3">
+        <label for="propertyValue" class="form-label">Property Value</label>
+        <input type="number" class="form-control" id="propertyValue" required>
+      </div>
+      <div class="mb-3">
+        <label for="grossAmount" class="form-label">Gross Amount</label>
+        <input type="number" class="form-control" id="grossAmount" required>
+      </div>
+      <div class="d-flex justify-content-between">
+        <button type="button" class="btn btn-secondary prev-step">Back</button>
+        <button type="button" class="btn btn-primary next-step">Next</button>
+      </div>
+    </div>
+
+    <!-- Step 3: Rates & Term -->
+    <div class="form-step" data-step="3">
+      <h4 class="mb-3">Rates & Term</h4>
+      <div class="mb-3">
+        <label for="interestRate" class="form-label">Annual Interest Rate (%)</label>
+        <input type="number" class="form-control" id="interestRate" required>
+      </div>
+      <div class="mb-3">
+        <label for="termMonths" class="form-label">Term (months)</label>
+        <input type="number" class="form-control" id="termMonths" required>
+      </div>
+      <div class="d-flex justify-content-between">
+        <button type="button" class="btn btn-secondary prev-step">Back</button>
+        <button type="submit" class="btn btn-success">Calculate</button>
+      </div>
+    </div>
+  </form>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/calculator_wizard.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add multi-step wizard template for loan calculator input
- Include small JavaScript helper to navigate between wizard steps
- Register `/calculator-wizard` route to serve the new wizard page

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy'; No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_689b22c529f88320b833e89e42bdcc1e