### PR TITLE
Make detail modals fullscreen and closable

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -303,6 +303,15 @@ body {
     font-weight: 600;
 }
 
+/* Fullscreen modal table support */
+.modal-fullscreen .modal-body {
+    padding: 0;
+}
+
+.modal-fullscreen .table {
+    width: 100%;
+}
+
 /* Footer */
 footer {
     margin-top: auto;

--- a/templates/applications.html
+++ b/templates/applications.html
@@ -227,13 +227,13 @@
 
 <!-- Application Detail Modal -->
 <div class="modal fade" id="applicationModal" tabindex="-1">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
+    <div class="modal-dialog modal-fullscreen modal-dialog-scrollable">
+        <div class="modal-content h-100">
             <div class="modal-header">
                 <h5 class="modal-title">Application Details</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
-            <div class="modal-body" id="applicationModalBody">
+            <div class="modal-body p-0 overflow-auto" id="applicationModalBody">
                 <!-- Application details will be loaded here -->
             </div>
             <div class="modal-footer">

--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -123,13 +123,13 @@
 
 <!-- Loan Details Modal -->
 <div class="modal fade" id="loanDetailsModal" tabindex="-1" aria-labelledby="loanDetailsModalLabel" aria-hidden="true">
-    <div class="modal-dialog" style="max-width: 95%; margin: 1rem auto; min-height: 80vh;">
-        <div class="modal-content" style="height: 90vh; overflow-y: auto;">
+    <div class="modal-dialog modal-fullscreen modal-dialog-scrollable">
+        <div class="modal-content h-100">
             <div class="modal-header bg-novellus-navy text-white">
                 <h5 class="modal-title" id="loanDetailsModalLabel">Loan Details</h5>
                 <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body p-4" id="loanDetailsContent" style="max-height: 75vh; overflow-y: auto;">
+            <div class="modal-body p-0 overflow-auto" id="loanDetailsContent">
                 <div class="text-center py-4">
                     <div class="spinner-border text-novellus-gold" role="status">
                         <span class="visually-hidden">Loading...</span>

--- a/templates/quotes.html
+++ b/templates/quotes.html
@@ -244,13 +244,13 @@
 
 <!-- Quote Detail Modal -->
 <div class="modal fade" id="quoteModal" tabindex="-1">
-    <div class="modal-dialog modal-xl">
-        <div class="modal-content">
+    <div class="modal-dialog modal-fullscreen modal-dialog-scrollable">
+        <div class="modal-content h-100">
             <div class="modal-header">
                 <h5 class="modal-title">Quote Details</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
             </div>
-            <div class="modal-body" id="quoteModalBody">
+            <div class="modal-body p-0 overflow-auto" id="quoteModalBody">
                 <!-- Quote details will be loaded here -->
             </div>
             <div class="modal-footer">


### PR DESCRIPTION
## Summary
- Expand detail modals to fullscreen for loan details, quotes, and applications
- Add overflow handling and zero padding so tabular data fills the page
- Include stylesheet rules for fullscreen modal tables

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy'; ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_689b587259fc8320a3cd3ebd1f6cec0e