### PR TITLE
Add close button to payment schedule modal

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1003,6 +1003,9 @@
           </div>
         </div>
       </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Add missing close button to payment schedule tabular report modal to match other report modals.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_689b5aae6df88320b31533614a7f346f