### PR TITLE
Enable PostgreSQL SSL mode

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -133,11 +133,19 @@ PGDATA=$(sudo -u postgres psql -t -c "SHOW data_directory;" | tr -d ' \n')
 if [ -n "$PGDATA" ]; then
     if [ ! -f "$PGDATA/server.crt" ] || [ ! -f "$PGDATA/server.key" ]; then
         print_status "Generating self-signed certificate..."
+
+        CERT_DOMAIN="${POSTGRES_SSL_CN:-$(hostname -f 2>/dev/null || hostname)}"
+        if [ ${#CERT_DOMAIN} -gt 64 ]; then
+            print_warning "Hostname '${CERT_DOMAIN}' exceeds 64 characters; truncating for CN"
+        fi
+        CERT_CN="${CERT_DOMAIN:0:64}"
+
         sudo openssl req -x509 -nodes -days 365 \
             -newkey rsa:2048 \
             -keyout "$PGDATA/server.key" \
             -out "$PGDATA/server.crt" \
-            -subj "/CN=$(hostname -f 2>/dev/null || hostname)"
+            -subj "/CN=${CERT_CN}" \
+            -addext "subjectAltName=DNS:${CERT_DOMAIN}"
         sudo chown postgres:postgres "$PGDATA/server.key" "$PGDATA/server.crt"
         sudo chmod 600 "$PGDATA/server.key"
     else
@@ -178,7 +186,8 @@ fi
 # Create .env file
 print_status "Creating environment configuration..."
 cat > .env << EOF
-DATABASE_URL=postgresql://novellus_user:novellus_secure_2025@localhost/novellus_loans
+DATABASE_URL=postgresql://novellus_user:novellus_secure_2025@localhost/novellus_loans?sslmode=require
+PG_SSLMODE=require
 SESSION_SECRET=$(python3 -c "import secrets; print(secrets.token_hex(32))")
 FLASK_ENV=production
 FLASK_DEBUG=False

--- a/start.sh
+++ b/start.sh
@@ -157,7 +157,7 @@ EOF
 
     # Override DATABASE_URL for on-premise use
     print_status "Switching to on-premise database configuration..."
-    export DATABASE_URL="postgresql://novellus_user:novellus_secure_2025@localhost:5432/novellus_loans"
+    export DATABASE_URL="postgresql://novellus_user:novellus_secure_2025@localhost:5432/novellus_loans?sslmode=require"
     export PGHOST="localhost"
     export PGPORT="5432"
     export PGDATABASE="novellus_loans"
@@ -178,7 +178,7 @@ if [ -f ".env" ]; then
 SESSION_SECRET=novellus-loan-management-secret-key-2025
 
 # On-Premise PostgreSQL Database Configuration
-DATABASE_URL=postgresql://novellus_user:novellus_secure_2025@localhost:5432/novellus_loans
+DATABASE_URL=postgresql://novellus_user:novellus_secure_2025@localhost:5432/novellus_loans?sslmode=require
 
 # PostgreSQL connection parameters for Power BI external access
 PGHOST=localhost
@@ -188,7 +188,7 @@ PGUSER=novellus_user
 PGPASSWORD=novellus_secure_2025
 
 # Power BI SSL Configuration
-PG_SSLMODE=prefer
+PG_SSLMODE=require
 ALLOW_EXTERNAL_CONNECTIONS=true
 
 FLASK_ENV=development
@@ -254,15 +254,14 @@ fi
 # Get server IP for Power BI connection info
 SERVER_IP=$(hostname -I | awk '{print $1}' 2>/dev/null || echo "localhost")
 
-# Detect PostgreSQL SSL certificate and configure connection mode
+# Force PostgreSQL connections to use SSL
 PGDATA=$(sudo -u postgres psql -t -c "SHOW data_directory;" 2>/dev/null | tr -d ' \n')
 if [ -f "$PGDATA/server.crt" ]; then
     print_status "PostgreSQL SSL certificate detected"
-    PG_SSLMODE_VALUE="require"
 else
-    print_warning "No PostgreSQL SSL certificate found - Power BI may require 'SSL Mode=Disable'"
-    PG_SSLMODE_VALUE="disable"
+    print_warning "PostgreSQL SSL certificate not found - SSL connections may fail"
 fi
+PG_SSLMODE_VALUE="require"
 print_status "Setting PG_SSLMODE=$PG_SSLMODE_VALUE for Power BI connections"
 
 # Persist SSL mode choice for other scripts


### PR DESCRIPTION
## Summary
- enforce SSL requirement in generated DATABASE_URL and configuration
- ensure start script uses sslmode=require and forces PostgreSQL connections to use SSL
- allow custom domain when generating PostgreSQL certificates and truncate overly long hostnames

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy'; No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_689b6bb364cc832098b3652f00496a0b