### PR TITLE
Add optional Snowflake sync support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The start script will:
 
 ### 💾 Database Management
 - **PostgreSQL Database**: Production-ready database with SSL support
+- **Optional Snowflake Sync**: Configure Snowflake and push data in real time
 - **Loan History**: Complete storage of all calculations and parameters
 - **Version Control**: Automatic versioning of loan modifications
 - **Search & Filter**: Advanced search capabilities across loan history
@@ -291,6 +292,31 @@ The system can be containerized using the provided Python dependencies and SQLit
 - **Calculation Caching**: Efficient financial computation caching
 - **File Processing**: Optimized document generation
 - **Server Options**: Production-ready server configurations
+
+## 🧊 Snowflake Integration
+
+The application stores data in PostgreSQL by default. To optionally sync data to Snowflake:
+
+1. Configure the connection:
+   ```http
+   POST /api/snowflake/config
+   {
+     "user": "<username>",
+     "password": "<password>",
+     "account": "<account>",
+     "warehouse": "<warehouse>",
+     "database": "<database>",
+     "schema": "<schema>"
+   }
+   ```
+2. Sync records in real time:
+   ```http
+   POST /api/snowflake/sync
+   {
+     "table": "target_table",
+     "data": {"column": "value"}
+   }
+   ```
 
 ## 🆘 Support
 

--- a/Requirements.txt
+++ b/Requirements.txt
@@ -23,3 +23,4 @@ matplotlib>=3.10.3
 xlsxwriter>=3.2.5
 numpy>=2.3.1
 selenium
+snowflake-connector-python>=3.11.0

--- a/app.py
+++ b/app.py
@@ -43,6 +43,9 @@ app.config["JWT_ACCESS_TOKEN_EXPIRES"] = False
 app.config["MAX_CONTENT_LENGTH"] = 16 * 1024 * 1024  # 16MB max file size
 app.config["UPLOAD_FOLDER"] = "uploads"
 
+# Snowflake configuration placeholder
+app.config["SNOWFLAKE_CONFIG"] = None
+
 # Initialize extensions
 db = SQLAlchemy(model_class=Base)
 db.init_app(app)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,4 +36,5 @@ dependencies = [
     "chromedriver-autoinstaller>=0.6.4",
     "schedule>=1.2.2",
     "apscheduler>=3.11.0",
+    "snowflake-connector-python>=3.11.0",
 ]

--- a/routes.py
+++ b/routes.py
@@ -21,6 +21,7 @@ from utils import (
     validate_quote_data, generate_payment_schedule_csv, format_currency,
     parse_currency_amount, generate_application_reference, validate_email
 )
+from snowflake_utils import set_snowflake_config, sync_data_to_snowflake
 
 # Import Power BI and Scenario Comparison modules
 try:
@@ -3220,12 +3221,45 @@ def export_scenario_comparison():
             'success': True,
             'export_data': export_data
         })
-        
+
     except Exception as e:
         app.logger.error(f"Scenario comparison export failed: {str(e)}")
         return jsonify({
             'success': False,
             'error': str(e)
         }), 500
+
+
+@app.route('/api/snowflake/config', methods=['POST'])
+@cross_origin()
+def configure_snowflake():
+    """Configure Snowflake connection from frontend."""
+    try:
+        config = request.json or {}
+        required = ['user', 'password', 'account']
+        if not all(k in config for k in required):
+            return jsonify({'success': False, 'error': 'Missing required Snowflake parameters'}), 400
+        set_snowflake_config(config)
+        return jsonify({'success': True})
+    except Exception as e:
+        app.logger.error(f"Snowflake config failed: {str(e)}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@app.route('/api/snowflake/sync', methods=['POST'])
+@cross_origin()
+def snowflake_sync():
+    """Sync provided data to Snowflake."""
+    try:
+        payload = request.json or {}
+        table = payload.get('table')
+        data = payload.get('data')
+        if not table or data is None:
+            return jsonify({'success': False, 'error': 'Missing table or data'}), 400
+        sync_data_to_snowflake(table, data)
+        return jsonify({'success': True})
+    except Exception as e:
+        app.logger.error(f"Snowflake sync failed: {str(e)}")
+        return jsonify({'success': False, 'error': str(e)}), 500
 
 

--- a/snowflake_utils.py
+++ b/snowflake_utils.py
@@ -1,0 +1,68 @@
+from flask import current_app
+
+try:
+    import snowflake.connector as snowflake_connector
+except Exception:  # pragma: no cover - dependency may be missing in some environments
+    snowflake_connector = None
+
+
+def set_snowflake_config(config: dict) -> None:
+    """Store Snowflake connection configuration in the Flask app config."""
+    current_app.config["SNOWFLAKE_CONFIG"] = config
+
+
+def _get_snowflake_connection():
+    cfg = current_app.config.get("SNOWFLAKE_CONFIG")
+    if not cfg:
+        return None
+    if snowflake_connector is None:
+        raise RuntimeError("snowflake-connector-python is not installed")
+    return snowflake_connector.connect(
+        user=cfg.get("user"),
+        password=cfg.get("password"),
+        account=cfg.get("account"),
+        warehouse=cfg.get("warehouse"),
+        database=cfg.get("database"),
+        schema=cfg.get("schema"),
+    )
+
+
+def sync_data_to_snowflake(table: str, rows):
+    """Insert rows into the given Snowflake table.
+
+    Parameters
+    ----------
+    table: str
+        Destination table name.
+    rows: dict or list[dict]
+        Data to insert. Each dict represents a row.
+    """
+    conn = _get_snowflake_connection()
+    if conn is None:
+        raise RuntimeError("Snowflake connection is not configured")
+
+    if isinstance(rows, dict):
+        rows = [rows]
+    if not rows:
+        return
+
+    columns = list(rows[0].keys())
+    create_stmt = "create table if not exists {0} ({1})".format(
+        table,
+        ", ".join(f"{c} variant" for c in columns),
+    )
+    insert_stmt = "insert into {0} ({1}) values ({2})".format(
+        table,
+        ", ".join(columns),
+        ", ".join(["%s"] * len(columns)),
+    )
+
+    cs = conn.cursor()
+    try:
+        cs.execute(create_stmt)
+        for row in rows:
+            cs.execute(insert_stmt, [row.get(col) for col in columns])
+        conn.commit()
+    finally:
+        cs.close()
+        conn.close()


### PR DESCRIPTION
## Summary
- add Snowflake connector dependency and helper utilities
- allow configuring Snowflake connection and syncing data via new endpoints
- document Snowflake integration

## Testing
- `pip install snowflake-connector-python` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_689b731ffca883209d2ecd5bb9157fa5