### PR TITLE
Add Snowflake connection test endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,11 @@ The application stores data in PostgreSQL by default. To optionally sync data to
      "schema": "<schema>"
    }
    ```
-2. Sync records in real time:
+2. Test the connection:
+   ```http
+   POST /api/snowflake/test
+   ```
+3. Sync records in real time:
    ```http
    POST /api/snowflake/sync
    {

--- a/routes.py
+++ b/routes.py
@@ -21,7 +21,11 @@ from utils import (
     validate_quote_data, generate_payment_schedule_csv, format_currency,
     parse_currency_amount, generate_application_reference, validate_email
 )
-from snowflake_utils import set_snowflake_config, sync_data_to_snowflake
+from snowflake_utils import (
+    set_snowflake_config,
+    sync_data_to_snowflake,
+    test_snowflake_connection,
+)
 
 # Import Power BI and Scenario Comparison modules
 try:
@@ -3243,6 +3247,18 @@ def configure_snowflake():
         return jsonify({'success': True})
     except Exception as e:
         app.logger.error(f"Snowflake config failed: {str(e)}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@app.route('/api/snowflake/test', methods=['POST'])
+@cross_origin()
+def test_snowflake():
+    """Test the configured Snowflake connection."""
+    try:
+        test_snowflake_connection()
+        return jsonify({'success': True})
+    except Exception as e:
+        app.logger.error(f"Snowflake connection test failed: {str(e)}")
         return jsonify({'success': False, 'error': str(e)}), 500
 
 

--- a/snowflake_utils.py
+++ b/snowflake_utils.py
@@ -27,6 +27,20 @@ def _get_snowflake_connection():
     )
 
 
+def test_snowflake_connection() -> None:
+    """Attempt to connect to Snowflake using current configuration.
+
+    Raises
+    ------
+    RuntimeError
+        If the connection configuration is missing or the connection fails.
+    """
+    conn = _get_snowflake_connection()
+    if conn is None:
+        raise RuntimeError("Snowflake connection is not configured")
+    conn.close()
+
+
 def sync_data_to_snowflake(table: str, rows):
     """Insert rows into the given Snowflake table.
 

--- a/templates/powerbi_config.html
+++ b/templates/powerbi_config.html
@@ -342,6 +342,9 @@
                                         </div>
                                     </div>
                                     <div class="text-end">
+                                        <button type="button" class="btn btn-sm btn-primary me-2" id="testSnowflakeBtn" onclick="testSnowflakeConnection()">
+                                            <i class="fas fa-vial me-1"></i>Test
+                                        </button>
                                         <button type="button" class="btn btn-sm btn-dark" onclick="saveSnowflakeConfig()">
                                             <i class="fas fa-save me-1"></i>Save
                                         </button>
@@ -2707,6 +2710,26 @@ function saveSnowflakeConfig() {
     .catch(err => {
         showNotification(`Failed to save Snowflake config: ${err.message}`, 'error');
     });
+}
+
+async function testSnowflakeConnection() {
+    const btn = document.getElementById('testSnowflakeBtn');
+    btn.disabled = true;
+    btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Testing...';
+    try {
+        const resp = await fetch('/api/snowflake/test', { method: 'POST' });
+        const data = await resp.json();
+        if (data.success) {
+            showNotification('Snowflake connection successful', 'success');
+        } else {
+            showNotification(`Connection failed: ${data.error}`, 'error');
+        }
+    } catch (err) {
+        showNotification(`Connection error: ${err.message}`, 'error');
+    } finally {
+        btn.disabled = false;
+        btn.innerHTML = '<i class="fas fa-vial me-1"></i>Test';
+    }
 }
 
 // Enhanced clear form to handle saved settings


### PR DESCRIPTION
## Summary
- add utility to test Snowflake connection
- expose POST /api/snowflake/test API endpoint
- enable testing Snowflake connection from web UI and document endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b96acd7d883208b6a6ad5efeb41ee