### PR TITLE
Add Snowflake connection test endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,11 @@ The application stores data in PostgreSQL by default. To optionally sync data to
      "schema": "<schema>"
    }
    ```
-2. Sync records in real time:
+2. Test the connection:
+   ```http
+   POST /api/snowflake/test
+   ```
+3. Sync records in real time:
    ```http
    POST /api/snowflake/sync
    {

--- a/install.sh
+++ b/install.sh
@@ -169,19 +169,24 @@ fi
 
 # Install Python dependencies
 print_status "Installing Python dependencies..."
+# Install dependencies
 if [ -f "deploy_requirements.txt" ]; then
     pip install -r deploy_requirements.txt
 elif [ -f "requirements.txt" ]; then
     pip install -r requirements.txt
 else
     # Install core dependencies with specific versions for compatibility
-    pip install "flask>=2.3.0" "flask-sqlalchemy>=3.0.0" "flask-login>=0.6.0" "flask-cors>=4.0.0" 
+    pip install "flask>=2.3.0" "flask-sqlalchemy>=3.0.0" "flask-login>=0.6.0" "flask-cors>=4.0.0"
     pip install "psycopg2-binary>=2.9.0" "python-dotenv>=1.0.0" "gunicorn>=21.0.0"
-    pip install "pandas>=2.0.0" "numpy>=1.24.0" "openpyxl>=3.1.0" "xlsxwriter>=3.1.0" 
+    pip install "pandas>=2.0.0" "numpy>=1.24.0" "openpyxl>=3.1.0" "xlsxwriter>=3.1.0"
     pip install "reportlab>=4.0.0" "python-docx>=0.8.11" "mammoth>=1.6.0"
     # WeasyPrint optional - may fail on some systems
     pip install weasyprint || print_warning "WeasyPrint installation failed, but system will work without it"
 fi
+
+# Install Snowflake connector for Snowflake testing feature
+print_status "Installing Snowflake connector..."
+pip install snowflake-connector-python
 
 # Create .env file
 print_status "Creating environment configuration..."
@@ -206,7 +211,7 @@ python database_init.py
 
 # Test installation
 print_status "Testing installation..."
-if python -c "import flask, psycopg2, pandas, numpy; from app import app; print('All dependencies imported successfully')"; then
+if python -c "import flask, psycopg2, pandas, numpy, snowflake.connector; from app import app; print('All dependencies imported successfully')"; then
     print_status "✅ Installation completed successfully!"
     echo ""
     echo "============================================================"

--- a/routes.py
+++ b/routes.py
@@ -21,7 +21,11 @@ from utils import (
     validate_quote_data, generate_payment_schedule_csv, format_currency,
     parse_currency_amount, generate_application_reference, validate_email
 )
-from snowflake_utils import set_snowflake_config, sync_data_to_snowflake
+from snowflake_utils import (
+    set_snowflake_config,
+    sync_data_to_snowflake,
+    test_snowflake_connection,
+)
 
 # Import Power BI and Scenario Comparison modules
 try:
@@ -3243,6 +3247,18 @@ def configure_snowflake():
         return jsonify({'success': True})
     except Exception as e:
         app.logger.error(f"Snowflake config failed: {str(e)}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@app.route('/api/snowflake/test', methods=['POST'])
+@cross_origin()
+def test_snowflake():
+    """Test the configured Snowflake connection."""
+    try:
+        test_snowflake_connection()
+        return jsonify({'success': True})
+    except Exception as e:
+        app.logger.error(f"Snowflake connection test failed: {str(e)}")
         return jsonify({'success': False, 'error': str(e)}), 500
 
 

--- a/snowflake_utils.py
+++ b/snowflake_utils.py
@@ -27,6 +27,20 @@ def _get_snowflake_connection():
     )
 
 
+def test_snowflake_connection() -> None:
+    """Attempt to connect to Snowflake using current configuration.
+
+    Raises
+    ------
+    RuntimeError
+        If the connection configuration is missing or the connection fails.
+    """
+    conn = _get_snowflake_connection()
+    if conn is None:
+        raise RuntimeError("Snowflake connection is not configured")
+    conn.close()
+
+
 def sync_data_to_snowflake(table: str, rows):
     """Insert rows into the given Snowflake table.
 

--- a/templates/powerbi_config.html
+++ b/templates/powerbi_config.html
@@ -342,6 +342,9 @@
                                         </div>
                                     </div>
                                     <div class="text-end">
+                                        <button type="button" class="btn btn-sm btn-primary me-2" id="testSnowflakeBtn" onclick="testSnowflakeConnection()">
+                                            <i class="fas fa-vial me-1"></i>Test
+                                        </button>
                                         <button type="button" class="btn btn-sm btn-dark" onclick="saveSnowflakeConfig()">
                                             <i class="fas fa-save me-1"></i>Save
                                         </button>
@@ -2707,6 +2710,26 @@ function saveSnowflakeConfig() {
     .catch(err => {
         showNotification(`Failed to save Snowflake config: ${err.message}`, 'error');
     });
+}
+
+async function testSnowflakeConnection() {
+    const btn = document.getElementById('testSnowflakeBtn');
+    btn.disabled = true;
+    btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Testing...';
+    try {
+        const resp = await fetch('/api/snowflake/test', { method: 'POST' });
+        const data = await resp.json();
+        if (data.success) {
+            showNotification('Snowflake connection successful', 'success');
+        } else {
+            showNotification(`Connection failed: ${data.error}`, 'error');
+        }
+    } catch (err) {
+        showNotification(`Connection error: ${err.message}`, 'error');
+    } finally {
+        btn.disabled = false;
+        btn.innerHTML = '<i class="fas fa-vial me-1"></i>Test';
+    }
 }
 
 // Enhanced clear form to handle saved settings


### PR DESCRIPTION
## Summary
- add utility to test Snowflake connection
- expose POST /api/snowflake/test API endpoint
- enable testing Snowflake connection from web UI and document endpoint
- ensure `snowflake-connector-python` is installed during setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b96acd7d883208b6a6ad5efeb41ee