### PR TITLE
Add Snowflake connection test endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,14 @@ The application stores data in PostgreSQL by default. To optionally sync data to
      "schema": "<schema>"
    }
    ```
-2. Sync records in real time:
+2. Test the connection:
+   ```http
+   POST /api/snowflake/test
+   ```
+3. Save a loan calculation. The application will create the `loan_summary`
+   and `payment_schedule` tables if they don't exist and insert the saved
+   data automatically.
+4. (Optional) Manually sync arbitrary records:
    ```http
    POST /api/snowflake/sync
    {

--- a/install.sh
+++ b/install.sh
@@ -169,19 +169,24 @@ fi
 
 # Install Python dependencies
 print_status "Installing Python dependencies..."
+# Install dependencies
 if [ -f "deploy_requirements.txt" ]; then
     pip install -r deploy_requirements.txt
 elif [ -f "requirements.txt" ]; then
     pip install -r requirements.txt
 else
     # Install core dependencies with specific versions for compatibility
-    pip install "flask>=2.3.0" "flask-sqlalchemy>=3.0.0" "flask-login>=0.6.0" "flask-cors>=4.0.0" 
+    pip install "flask>=2.3.0" "flask-sqlalchemy>=3.0.0" "flask-login>=0.6.0" "flask-cors>=4.0.0"
     pip install "psycopg2-binary>=2.9.0" "python-dotenv>=1.0.0" "gunicorn>=21.0.0"
-    pip install "pandas>=2.0.0" "numpy>=1.24.0" "openpyxl>=3.1.0" "xlsxwriter>=3.1.0" 
+    pip install "pandas>=2.0.0" "numpy>=1.24.0" "openpyxl>=3.1.0" "xlsxwriter>=3.1.0"
     pip install "reportlab>=4.0.0" "python-docx>=0.8.11" "mammoth>=1.6.0"
     # WeasyPrint optional - may fail on some systems
     pip install weasyprint || print_warning "WeasyPrint installation failed, but system will work without it"
 fi
+
+# Install Snowflake connector for Snowflake testing feature
+print_status "Installing Snowflake connector..."
+pip install snowflake-connector-python
 
 # Create .env file
 print_status "Creating environment configuration..."
@@ -206,7 +211,7 @@ python database_init.py
 
 # Test installation
 print_status "Testing installation..."
-if python -c "import flask, psycopg2, pandas, numpy; from app import app; print('All dependencies imported successfully')"; then
+if python -c "import flask, psycopg2, pandas, numpy, snowflake.connector; from app import app; print('All dependencies imported successfully')"; then
     print_status "✅ Installation completed successfully!"
     echo ""
     echo "============================================================"

--- a/routes.py
+++ b/routes.py
@@ -21,7 +21,12 @@ from utils import (
     validate_quote_data, generate_payment_schedule_csv, format_currency,
     parse_currency_amount, generate_application_reference, validate_email
 )
-from snowflake_utils import set_snowflake_config, sync_data_to_snowflake
+from snowflake_utils import (
+    set_snowflake_config,
+    sync_data_to_snowflake,
+    test_snowflake_connection,
+    model_to_dict,
+)
 
 # Import Power BI and Scenario Comparison modules
 try:
@@ -1702,7 +1707,9 @@ def save_loan():
         
         db.session.add(loan_summary)
         db.session.flush()  # Get the ID
-        
+
+        snowflake_payments = []
+
         # Save payment schedule if available
         if 'detailed_payment_schedule' in fresh_calculation and fresh_calculation['detailed_payment_schedule']:
             for i, payment in enumerate(fresh_calculation['detailed_payment_schedule']):
@@ -1721,17 +1728,25 @@ def save_loan():
                         interest_calculation=payment.get('interest_calculation', '')
                     )
                     db.session.add(payment_record)
+                    snowflake_payments.append(model_to_dict(payment_record))
                 except Exception as pe:
                     app.logger.warning(f"Error saving payment {i+1}: {pe}")
                     continue
-        
+
         db.session.commit()
-        
+
+        try:
+            sync_data_to_snowflake('loan_summary', model_to_dict(loan_summary))
+            if snowflake_payments:
+                sync_data_to_snowflake('payment_schedule', snowflake_payments)
+        except Exception as se:
+            app.logger.warning(f"Snowflake sync failed: {se}")
+
         app.logger.info(f"Loan saved successfully: {loan_name}")
-        
+
         # Trigger Power BI refresh after successful save
         #trigger_powerbi_on_save()
-        
+
         return jsonify({
             'success': True,
             'message': f'Loan saved successfully as "{loan_name}"',
@@ -3243,6 +3258,18 @@ def configure_snowflake():
         return jsonify({'success': True})
     except Exception as e:
         app.logger.error(f"Snowflake config failed: {str(e)}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@app.route('/api/snowflake/test', methods=['POST'])
+@cross_origin()
+def test_snowflake():
+    """Test the configured Snowflake connection."""
+    try:
+        test_snowflake_connection()
+        return jsonify({'success': True})
+    except Exception as e:
+        app.logger.error(f"Snowflake connection test failed: {str(e)}")
         return jsonify({'success': False, 'error': str(e)}), 500
 
 

--- a/snowflake_utils.py
+++ b/snowflake_utils.py
@@ -1,3 +1,6 @@
+from datetime import date, datetime
+from decimal import Decimal
+
 from flask import current_app
 
 try:
@@ -25,6 +28,20 @@ def _get_snowflake_connection():
         database=cfg.get("database"),
         schema=cfg.get("schema"),
     )
+
+
+def test_snowflake_connection() -> None:
+    """Attempt to connect to Snowflake using current configuration.
+
+    Raises
+    ------
+    RuntimeError
+        If the connection configuration is missing or the connection fails.
+    """
+    conn = _get_snowflake_connection()
+    if conn is None:
+        raise RuntimeError("Snowflake connection is not configured")
+    conn.close()
 
 
 def sync_data_to_snowflake(table: str, rows):
@@ -66,3 +83,17 @@ def sync_data_to_snowflake(table: str, rows):
     finally:
         cs.close()
         conn.close()
+
+
+def model_to_dict(model) -> dict:
+    """Convert a SQLAlchemy model to a plain dict suitable for Snowflake."""
+    result = {}
+    for column in model.__table__.columns:  # type: ignore[attr-defined]
+        value = getattr(model, column.name)
+        if isinstance(value, Decimal):
+            value = float(value)
+        elif isinstance(value, (date, datetime)):
+            value = value.isoformat()
+        result[column.name] = value
+    return result
+

--- a/templates/powerbi_config.html
+++ b/templates/powerbi_config.html
@@ -342,6 +342,9 @@
                                         </div>
                                     </div>
                                     <div class="text-end">
+                                        <button type="button" class="btn btn-sm btn-primary me-2" id="testSnowflakeBtn" onclick="testSnowflakeConnection()">
+                                            <i class="fas fa-vial me-1"></i>Test
+                                        </button>
                                         <button type="button" class="btn btn-sm btn-dark" onclick="saveSnowflakeConfig()">
                                             <i class="fas fa-save me-1"></i>Save
                                         </button>
@@ -2707,6 +2710,26 @@ function saveSnowflakeConfig() {
     .catch(err => {
         showNotification(`Failed to save Snowflake config: ${err.message}`, 'error');
     });
+}
+
+async function testSnowflakeConnection() {
+    const btn = document.getElementById('testSnowflakeBtn');
+    btn.disabled = true;
+    btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Testing...';
+    try {
+        const resp = await fetch('/api/snowflake/test', { method: 'POST' });
+        const data = await resp.json();
+        if (data.success) {
+            showNotification('Snowflake connection successful', 'success');
+        } else {
+            showNotification(`Connection failed: ${data.error}`, 'error');
+        }
+    } catch (err) {
+        showNotification(`Connection error: ${err.message}`, 'error');
+    } finally {
+        btn.disabled = false;
+        btn.innerHTML = '<i class="fas fa-vial me-1"></i>Test';
+    }
 }
 
 // Enhanced clear form to handle saved settings


### PR DESCRIPTION
## Summary
- add utility to test Snowflake connection
- expose POST /api/snowflake/test API endpoint
- enable testing Snowflake connection from web UI and document endpoint
- ensure `snowflake-connector-python` is installed during setup
- automatically create Snowflake tables and sync saved loan data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b96acd7d883208b6a6ad5efeb41ee