### PR TITLE
Fix undefined model_to_dict in Snowflake sync

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -25,7 +25,7 @@ from snowflake_utils import (
     set_snowflake_config,
     sync_data_to_snowflake,
     test_snowflake_connection,
-
+    model_to_dict,
 )
 
 # Import Power BI and Scenario Comparison modules


### PR DESCRIPTION
## Summary
- Import `model_to_dict` from `snowflake_utils` so payment records and loan summaries can sync to Snowflake without NameError

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ba1b0673083209f0cfe9e3f7c469c