### PR TITLE
feat: add snowflake token auth and config management

### DIFF
--- a/snowflake_utils.py
+++ b/snowflake_utils.py
@@ -20,6 +20,15 @@ def _get_snowflake_connection():
         return None
     if snowflake_connector is None:
         raise RuntimeError("snowflake-connector-python is not installed")
+    if cfg.get("method") == "token":
+        return snowflake_connector.connect(
+            account=cfg.get("account"),
+            warehouse=cfg.get("warehouse"),
+            database=cfg.get("database"),
+            schema=cfg.get("schema"),
+            token=cfg.get("token"),
+            authenticator="oauth",
+        )
     return snowflake_connector.connect(
         user=cfg.get("user"),
         password=cfg.get("password"),

--- a/templates/powerbi_config.html
+++ b/templates/powerbi_config.html
@@ -305,21 +305,47 @@
                         <!-- Snowflake Config Panel -->
                         <div class="tab-pane fade" id="snowflake-panel" role="tabpanel">
                             <div class="p-3">
+                                <div id="snowflakeSavedConfig" class="alert alert-secondary d-flex justify-content-between align-items-center mb-3" style="display:none;">
+                                    <div id="sfSavedDetails"></div>
+                                    <div>
+                                        <button type="button" class="btn btn-sm btn-primary me-2" onclick="editSnowflakeConfig()">Edit</button>
+                                        <button type="button" class="btn btn-sm btn-danger" onclick="deleteSnowflakeConfig()">Delete</button>
+                                    </div>
+                                </div>
                                 <form id="snowflakeForm" autocomplete="off">
-                                    <div class="row g-3 mb-3">
-                                        <div class="col-md-6">
-                                            <label class="form-label small fw-semibold text-secondary">User</label>
-                                            <input type="text" class="form-control form-control-sm" id="sfUser" required>
-                                        </div>
-                                        <div class="col-md-6">
-                                            <label class="form-label small fw-semibold text-secondary">Password</label>
-                                            <div class="input-group input-group-sm">
-                                                <input type="password" class="form-control" id="sfPassword" required>
-                                                <button class="btn btn-outline-secondary" type="button" onclick="togglePasswordVisibility('sfPassword', this)">
-                                                    <i class="fas fa-eye"></i>
-                                                </button>
+                                    <div class="mb-3">
+                                        <label class="form-label small fw-semibold text-secondary">Authentication Method</label>
+                                        <div>
+                                            <div class="form-check form-check-inline">
+                                                <input class="form-check-input" type="radio" name="sfAuthType" id="sfAuthTypePassword" value="password" checked>
+                                                <label class="form-check-label" for="sfAuthTypePassword">User &amp; Password</label>
+                                            </div>
+                                            <div class="form-check form-check-inline">
+                                                <input class="form-check-input" type="radio" name="sfAuthType" id="sfAuthTypeToken" value="token">
+                                                <label class="form-check-label" for="sfAuthTypeToken">Programmatic Access Token</label>
                                             </div>
                                         </div>
+                                    </div>
+                                    <div id="sfUserPasswordFields">
+                                        <div class="row g-3 mb-3">
+                                            <div class="col-md-6">
+                                                <label class="form-label small fw-semibold text-secondary">User</label>
+                                                <input type="text" class="form-control form-control-sm" id="sfUser">
+                                            </div>
+                                            <div class="col-md-6">
+                                                <label class="form-label small fw-semibold text-secondary">Password</label>
+                                                <div class="input-group input-group-sm">
+                                                    <input type="password" class="form-control" id="sfPassword">
+                                                    <button class="btn btn-outline-secondary" type="button" onclick="togglePasswordVisibility('sfPassword', this)">
+                                                        <i class="fas fa-eye"></i>
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div id="sfTokenField" class="mb-3" style="display:none;">
+                                        <label class="form-label small fw-semibold text-secondary">Access Token</label>
+                                        <textarea class="form-control form-control-sm" id="sfToken" rows="2"></textarea>
                                     </div>
                                     <div class="row g-3 mb-3">
                                         <div class="col-md-6">
@@ -2446,9 +2472,12 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Load scheduled refresh settings
     loadScheduledRefreshSettings();
-    
+
     // Load saved report settings
     loadSavedSettings();
+
+    // Load Snowflake configuration
+    loadSnowflakeConfig();
 });
 
 // Save and Load Report Settings Functions
@@ -2679,17 +2708,27 @@ function refreshAllReports() {
 }
 
 function saveSnowflakeConfig() {
+    const method = document.querySelector('input[name="sfAuthType"]:checked').value;
     const payload = {
-        user: document.getElementById('sfUser').value.trim(),
-        password: document.getElementById('sfPassword').value.trim(),
+        method: method,
         account: document.getElementById('sfAccount').value.trim(),
         warehouse: document.getElementById('sfWarehouse').value.trim(),
         database: document.getElementById('sfDatabase').value.trim(),
         schema: document.getElementById('sfSchema').value.trim()
     };
-    if (!payload.user || !payload.password || !payload.account) {
-        showNotification('User, password and account are required', 'error');
-        return;
+    if (method === 'token') {
+        payload.token = document.getElementById('sfToken').value.trim();
+        if (!payload.token || !payload.account) {
+            showNotification('Token and account are required', 'error');
+            return;
+        }
+    } else {
+        payload.user = document.getElementById('sfUser').value.trim();
+        payload.password = document.getElementById('sfPassword').value.trim();
+        if (!payload.user || !payload.password || !payload.account) {
+            showNotification('User, password and account are required', 'error');
+            return;
+        }
     }
 
     fetch('/api/snowflake/config', {
@@ -2703,6 +2742,7 @@ function saveSnowflakeConfig() {
     .then(data => {
         if (data.success) {
             showNotification('Snowflake configuration saved', 'success');
+            loadSnowflakeConfig();
         } else {
             showNotification(`Failed to save Snowflake config: ${data.error}`, 'error');
         }
@@ -2711,6 +2751,75 @@ function saveSnowflakeConfig() {
         showNotification(`Failed to save Snowflake config: ${err.message}`, 'error');
     });
 }
+
+function loadSnowflakeConfig() {
+    fetch('/api/snowflake/config')
+        .then(resp => resp.json())
+        .then(data => {
+            const cfg = data.config || {};
+            const form = document.getElementById('snowflakeForm');
+            const savedDiv = document.getElementById('snowflakeSavedConfig');
+            if (!cfg.method) {
+                form.reset();
+                savedDiv.style.display = 'none';
+                form.style.display = 'block';
+                toggleSfAuthFields();
+                return;
+            }
+            document.getElementById('sfAccount').value = cfg.account || '';
+            document.getElementById('sfWarehouse').value = cfg.warehouse || '';
+            document.getElementById('sfDatabase').value = cfg.database || '';
+            document.getElementById('sfSchema').value = cfg.schema || '';
+            if (cfg.method === 'token') {
+                document.getElementById('sfAuthTypeToken').checked = true;
+                document.getElementById('sfToken').value = cfg.token || '';
+            } else {
+                document.getElementById('sfAuthTypePassword').checked = true;
+                document.getElementById('sfUser').value = cfg.user || '';
+                document.getElementById('sfPassword').value = cfg.password || '';
+            }
+            toggleSfAuthFields();
+            const summary = cfg.method === 'token'
+                ? `Token connection for account ${cfg.account}`
+                : `User ${cfg.user} on account ${cfg.account}`;
+            document.getElementById('sfSavedDetails').textContent = summary;
+            savedDiv.style.display = 'flex';
+            form.style.display = 'none';
+        });
+}
+
+function editSnowflakeConfig() {
+    document.getElementById('snowflakeSavedConfig').style.display = 'none';
+    const form = document.getElementById('snowflakeForm');
+    form.style.display = 'block';
+}
+
+function deleteSnowflakeConfig() {
+    if (!confirm('Delete Snowflake configuration?')) return;
+    fetch('/api/snowflake/config', { method: 'DELETE' })
+        .then(resp => resp.json())
+        .then(data => {
+            if (data.success) {
+                showNotification('Snowflake configuration deleted', 'success');
+                loadSnowflakeConfig();
+            } else {
+                showNotification(`Failed to delete config: ${data.error}`, 'error');
+            }
+        })
+        .catch(err => {
+            showNotification(`Failed to delete config: ${err.message}`, 'error');
+        });
+}
+
+function toggleSfAuthFields() {
+    const method = document.querySelector('input[name="sfAuthType"]:checked').value;
+    document.getElementById('sfUserPasswordFields').style.display = method === 'password' ? 'block' : 'none';
+    document.getElementById('sfTokenField').style.display = method === 'token' ? 'block' : 'none';
+}
+
+document.querySelectorAll('input[name="sfAuthType"]').forEach(el => {
+    el.addEventListener('change', toggleSfAuthFields);
+});
 
 async function testSnowflakeConnection() {
     const btn = document.getElementById('testSnowflakeBtn');


### PR DESCRIPTION
## Summary
- allow connecting to Snowflake with a programmatic access token
- expose Snowflake config via GET/DELETE and validate auth methods
- add UI to choose auth type and manage saved Snowflake connections

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689baa01b2f48320bc915d3c9e83c941