### PR TITLE
fix: preserve zero values when editing loans

### DIFF
--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -779,44 +779,44 @@ class LoanHistoryManager {
     buildEditParams(loan) {
         const params = {
             // Core loan parameters
-            loan_type: loan.loan_type || 'bridge',
-            amount_input_type: loan.amountInputType || loan.amount_input_type || 'gross',
-            gross_amount: loan.grossAmount || loan.gross_amount || '',
-            net_amount: loan.netAmount || loan.net_amount || '',
-            property_value: loan.propertyValue || loan.property_value || '',
-            annual_rate: loan.interestRate || loan.interest_rate || '',
-            loan_term: loan.loanTerm || loan.loan_term || '',
-            start_date: loan.startDate || loan.start_date || '',
-            end_date: loan.endDate || loan.end_date || '',
-            
+            loan_type: loan.loan_type ?? 'bridge',
+            amount_input_type: loan.amountInputType ?? loan.amount_input_type ?? 'gross',
+            gross_amount: loan.grossAmount ?? loan.gross_amount ?? '',
+            net_amount: loan.netAmount ?? loan.net_amount ?? '',
+            property_value: loan.propertyValue ?? loan.property_value ?? '',
+            annual_rate: loan.interestRate ?? loan.interest_rate ?? '',
+            loan_term: loan.loanTerm ?? loan.loan_term ?? '',
+            start_date: loan.startDate ?? loan.start_date ?? '',
+            end_date: loan.endDate ?? loan.end_date ?? '',
+
             // Repayment and fee parameters
-            repayment_option: loan.repaymentOption || loan.repayment_option || 'none',
-            arrangement_fee_percentage: loan.arrangementFeePercentage || loan.arrangement_fee_percentage || '2',
-            legal_fees: loan.legalFees || loan.legal_fees || '1500',
-            site_visit_fee: loan.siteVisitFee || loan.site_visit_fee || '500',
-            title_insurance_rate: loan.titleInsuranceRate || loan.title_insurance_rate || '0.01',
-            
+            repayment_option: loan.repaymentOption ?? loan.repayment_option ?? 'none',
+            arrangement_fee_percentage: loan.arrangementFeePercentage ?? loan.arrangement_fee_percentage ?? '2',
+            legal_fees: loan.legalFees ?? loan.legal_fees ?? '1500',
+            site_visit_fee: loan.siteVisitFee ?? loan.site_visit_fee ?? '500',
+            title_insurance_rate: loan.titleInsuranceRate ?? loan.title_insurance_rate ?? '0.01',
+
             // Payment parameters
-            payment_timing: loan.paymentTiming || loan.payment_timing || 'advance',
-            payment_frequency: loan.paymentFrequency || loan.payment_frequency || 'monthly',
-            capital_repayment: loan.capitalRepayment || loan.capital_repayment || '',
-            flexible_payment: loan.flexiblePayment || loan.flexible_payment || '',
-            
+            payment_timing: loan.paymentTiming ?? loan.payment_timing ?? 'advance',
+            payment_frequency: loan.paymentFrequency ?? loan.payment_frequency ?? 'monthly',
+            capital_repayment: loan.capitalRepayment ?? loan.capital_repayment ?? '',
+            flexible_payment: loan.flexiblePayment ?? loan.flexible_payment ?? '',
+
             // Development loan parameters
-            day1_advance: loan.day1Advance || loan.day1_advance || '',
-            tranche_mode: loan.trancheMode || loan.tranche_mode || 'manual',
-            
+            day1_advance: loan.day1Advance ?? loan.day1_advance ?? '',
+            tranche_mode: loan.trancheMode ?? loan.tranche_mode ?? 'manual',
+
             // Currency
-            currency: loan.currency || 'GBP'
+            currency: loan.currency ?? 'GBP'
         };
         
         // Handle tranches for development loans
         if (loan.loan_type === 'development' && loan.tranches && Array.isArray(loan.tranches)) {
             loan.tranches.forEach((tranche, index) => {
-                params[`tranche_amounts[${index}]`] = tranche.amount || '';
-                params[`tranche_dates[${index}]`] = tranche.date || '';
-                params[`tranche_rates[${index}]`] = tranche.rate || '';
-                params[`tranche_descriptions[${index}]`] = tranche.description || '';
+                params[`tranche_amounts[${index}]`] = tranche.amount ?? '';
+                params[`tranche_dates[${index}]`] = tranche.date ?? '';
+                params[`tranche_rates[${index}]`] = tranche.rate ?? '';
+                params[`tranche_descriptions[${index}]`] = tranche.description ?? '';
             });
         }
         


### PR DESCRIPTION
## Summary
- ensure loan edit parameters retain zero-valued fields
- avoid defaulting to preset values that alter recalculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c964de0a48320a7ea4e8eadd964fe