### PR TITLE
Align scenario comparison with calculator engine

### DIFF
--- a/scenario_comparison.py
+++ b/scenario_comparison.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 class ScenarioComparison:
     def __init__(self):
+        # Use the same loan calculation engine as the main calculator page
         self.calculation_engine = LoanCalculator()
         self.scenarios = []
         

--- a/templates/scenario_comparison.html
+++ b/templates/scenario_comparison.html
@@ -1,12 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>One-Click Scenario Comparison - Novellus Loan Management</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon.png') }}">
+{% extends "base.html" %}
+
+{% block title %}One-Click Scenario Comparison - Novellus Loan Management{% endblock %}
+
+{% block head %}
+{{ super() }}
     <style>
         :root {
             --novellus-gold: #B8860B;
@@ -172,26 +169,9 @@
             z-index: 1050;
         }
     </style>
-</head>
-<body>
-    <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark">
-        <div class="container">
-            <a class="navbar-brand d-flex align-items-center" href="{{ url_for('index') }}">
-                <img src="{{ url_for('static', filename='novellus_logo.png') }}" alt="Novellus" height="40" class="me-2">
-                <span class="fw-bold">Novellus Loan Management</span>
-            </a>
-            <div class="d-flex">
-                <a href="{{ url_for('calculator_page') }}" class="btn btn-outline-light me-2">
-                    <i class="fas fa-calculator"></i> Calculator
-                </a>
-                <a href="{{ url_for('loan_history') }}" class="btn btn-outline-light">
-                    <i class="fas fa-history"></i> History
-                </a>
-            </div>
-        </div>
-    </nav>
+{% endblock %}
 
+{% block content %}
     <!-- Main Content -->
     <div class="container-fluid">
         <div class="container">
@@ -631,8 +611,10 @@
         </div>
     </div>
 
-    <!-- Scripts -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
     <script>
         let currentComparison = null;
         
@@ -1683,5 +1665,4 @@
             }
         }
     </script>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Ensure scenario comparison reuses the same `LoanCalculator` engine as the main calculator
- Clean up scenario comparison module formatting
- Switch scenario comparison page to base template for a layout consistent with the calculator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cf6312f1483209440f66c680c8169