### PR TITLE
Use calendar day counts for loan calculations

### DIFF
--- a/calculatordev.html
+++ b/calculatordev.html
@@ -1128,8 +1128,13 @@ function recalculateLoanTerm() {
         } else if (daysDiff >= 720 && daysDiff <= 740) {
             loanTerm = 24; // 24-month loan (around 730 days)
         } else {
-            // For other day ranges, approximate to months
-            loanTerm = Math.round(daysDiff / 30.44); // Average days per month
+            // For other ranges, calculate exact month difference
+            let monthsDiff = (endDate.getFullYear() - startDate.getFullYear()) * 12 +
+                             (endDate.getMonth() - startDate.getMonth());
+            if (endDate.getDate() < startDate.getDate()) {
+                monthsDiff -= 1;
+            }
+            loanTerm = Math.max(1, monthsDiff);
         }
         
         if (loanTerm > 0) {

--- a/static/js/calculator_backup.js
+++ b/static/js/calculator_backup.js
@@ -230,13 +230,18 @@ class LoanCalculator {
                 const timeDiff = endDate.getTime() - startDate.getTime();
                 const daysDiff = Math.ceil(timeDiff / (1000 * 3600 * 24));
                 
-                // Convert days to months using average days per month (30.44)
-                const monthsFromDays = Math.max(1, Math.round(daysDiff / 30.44));
-                
+                // Calculate exact months difference
+                let monthsDiff = (endDate.getFullYear() - startDate.getFullYear()) * 12 +
+                                 (endDate.getMonth() - startDate.getMonth());
+                if (endDate.getDate() < startDate.getDate()) {
+                    monthsDiff -= 1;
+                }
+                monthsDiff = Math.max(1, monthsDiff);
+
                 // Update loan term based on actual days calculation
-                loanTermElement.value = monthsFromDays;
-                
-                console.log(`Date change: ${daysDiff} days = ${monthsFromDays} months`);
+                loanTermElement.value = monthsDiff;
+
+                console.log(`Date change: ${daysDiff} days = ${monthsDiff} months`);
                 
                 // Trigger a change event on the loan term field to update any dependent calculations
                 loanTermElement.dispatchEvent(new Event('input', { bubbles: true }));

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1239,8 +1239,13 @@ function recalculateLoanTerm() {
         } else if (daysDiff >= 720 && daysDiff <= 740) {
             loanTerm = 24; // 24-month loan (around 730 days)
         } else {
-            // For other day ranges, approximate to months
-            loanTerm = Math.round(daysDiff / 30.44); // Average days per month
+            // For other ranges, calculate exact month difference
+            let monthsDiff = (endDate.getFullYear() - startDate.getFullYear()) * 12 +
+                             (endDate.getMonth() - startDate.getMonth());
+            if (endDate.getDate() < startDate.getDate()) {
+                monthsDiff -= 1;
+            }
+            loanTerm = Math.max(1, monthsDiff);
         }
         
         if (loanTerm > 0) {


### PR DESCRIPTION
## Summary
- calculate bridge and term loan interest using exact calendar day counts
- update net-to-gross helpers to accept explicit day counts
- derive loan terms on the frontend by measuring calendar months instead of dividing by 30.44 days

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a47dba395c8320a99faec020912002