### PR TITLE
Use actual day counts for bridge non-retained interest

### DIFF
--- a/test_bridge_day_count_non_retained.py
+++ b/test_bridge_day_count_non_retained.py
@@ -1,0 +1,27 @@
+from decimal import Decimal
+from calculations import LoanCalculator
+
+def test_service_capital_uses_actual_days():
+    calc = LoanCalculator()
+    params = {
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 1,
+        'repayment_option': 'service_and_capital',
+        'capital_repayment': 0,
+        'start_date': '2025-01-01',
+        'end_date': '2025-02-01',
+    }
+    result_31 = calc.calculate_bridge_loan(params)
+    interest_31 = Decimal(str(result_31['totalInterest']))
+
+    params['end_date'] = '2025-01-31'
+    result_30 = calc.calculate_bridge_loan(params)
+    interest_30 = Decimal(str(result_30['totalInterest']))
+
+    expected_31 = Decimal('100000') * Decimal('0.12') / Decimal('365') * Decimal('31')
+    expected_30 = Decimal('100000') * Decimal('0.12') / Decimal('365') * Decimal('30')
+
+    assert abs(interest_31 - expected_31) < Decimal('1')
+    assert abs(interest_30 - expected_30) < Decimal('1')
+    assert interest_31 > interest_30


### PR DESCRIPTION
## Summary
- calculate bridge service+capital payments with daily interest when loan_term_days is provided
- apply same day-level interest logic to bridge flexible payments
- test that service+capital option honours actual day counts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a48e8c73748320b960f53b481a019b