### PR TITLE
Add service-only period details and client-side interest calc

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -3839,6 +3839,12 @@ class LoanCalculator:
 
                 # Calculate days in this interest period
                 days_in_period = (period_ends[i] - period_starts[i]).days
+
+                # Determine period start/end for display (end is inclusive)
+                period_start = period_starts[i]
+                period_end = period_ends[i] - timedelta(days=1)
+                days_held = days_in_period
+
                 interest_amount = self.calculate_simple_interest_by_days(
                     gross_amount, annual_rate, days_in_period, use_360_days)
 
@@ -3862,6 +3868,9 @@ class LoanCalculator:
 
                 detailed_schedule.append({
                     'payment_date': payment_date.strftime('%d/%m/%Y'),
+                    'start_period': period_start.strftime('%d/%m/%Y'),
+                    'end_period': period_end.strftime('%d/%m/%Y'),
+                    'days_held': int(days_held),
                     'opening_balance': f"{currency_symbol}{remaining_balance:,.2f}",
                     'tranche_release': f"{currency_symbol}0.00",
                     'interest_calculation': interest_calc,

--- a/calculatordev.js
+++ b/calculatordev.js
@@ -779,14 +779,18 @@ class LoanCalculator {
         const periodicInterestEl = document.getElementById('periodicInterestResult');
         const periodicInterestLabel = document.getElementById('periodicInterestLabel');
         
-        console.log(`Periodic interest check: loanType=${loanType}, repaymentOption=${repaymentOption}, periodicInterest=${results.periodicInterest}`);
-        if ((loanType === 'term' || loanType === 'bridge') && repaymentOption === 'service_only' && results.periodicInterest) {
-            console.log('Showing periodic interest row');
+        console.log(`Periodic interest check: loanType=${loanType}, repaymentOption=${repaymentOption}`);
+        if ((loanType === 'term' || loanType === 'bridge') && repaymentOption === 'service_only') {
+            const annualRate = results.interestRate || results.annual_rate || 0;
+            const grossAmountForInterest = results.grossAmount || 0;
+            const divisor = paymentFrequency === 'quarterly' ? 4 : 12;
+            const periodicInterest = grossAmountForInterest * (annualRate / 100) / divisor;
+
             if (periodicInterestRow) periodicInterestRow.style.display = 'table-row';
             if (periodicInterestEl) {
-                periodicInterestEl.textContent = results.periodicInterest.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+                periodicInterestEl.textContent = periodicInterest.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
             }
-            
+
             // Update label based on payment frequency
             if (periodicInterestLabel) {
                 const label = paymentFrequency === 'quarterly' ? 'Quarterly Interest Payment' : 'Monthly Interest Payment';

--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -850,15 +850,18 @@ class LoanCalculator {
         const periodicInterestEl = document.getElementById('periodicInterestResult');
         const periodicInterestLabel = document.getElementById('periodicInterestLabel');
         
-        console.log(`Periodic interest check: loanType=${loanType}, repaymentOption=${repaymentOption}, periodicInterest=${results.periodicInterest}`);
-        if ((loanType === 'term' || loanType === 'bridge') && repaymentOption === 'service_only' && results.periodicInterest) {
-            console.log('Showing periodic interest row');
+        console.log(`Periodic interest check: loanType=${loanType}, repaymentOption=${repaymentOption}`);
+        if ((loanType === 'term' || loanType === 'bridge') && repaymentOption === 'service_only') {
+            const annualRate = results.interestRate || results.annual_rate || 0;
+            const grossAmountForInterest = results.grossAmount || 0;
+            const divisor = paymentFrequency === 'quarterly' ? 4 : 12;
+            const periodicInterest = grossAmountForInterest * (annualRate / 100) / divisor;
+
             if (periodicInterestRow) periodicInterestRow.style.display = 'table-row';
             if (periodicInterestEl) {
-                periodicInterestEl.textContent = results.periodicInterest.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+                periodicInterestEl.textContent = periodicInterest.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
             }
-            
-            // Update label based on payment frequency
+
             if (periodicInterestLabel) {
                 const label = paymentFrequency === 'quarterly' ? 'Quarterly Interest Payment' : 'Monthly Interest Payment';
                 periodicInterestLabel.textContent = label;


### PR DESCRIPTION
## Summary
- populate period start, end, and days held for service-only bridge payment schedules
- compute periodic interest client-side using annual rate and gross amount

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4a534da308320a9f25394a55a9a15