### PR TITLE
Compute periodic interest payments for loan summary

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -476,6 +476,12 @@ class LoanCalculator:
                 gross_amount, annual_rate, payment_frequency
             )
             calculation['periodicInterest'] = float(periodic_interest)
+            if payment_frequency == 'quarterly':
+                calculation['quarterlyPayment'] = float(periodic_interest)
+                calculation['monthlyPayment'] = 0
+            else:
+                calculation['monthlyPayment'] = float(periodic_interest)
+                calculation['quarterlyPayment'] = 0
 
         # Generate payment schedule
         try:
@@ -763,6 +769,12 @@ class LoanCalculator:
                 gross_amount, annual_rate, payment_frequency
             )
             calculation['periodicInterest'] = float(periodic_interest)
+            if payment_frequency == 'quarterly':
+                calculation['quarterlyPayment'] = float(periodic_interest)
+                calculation['monthlyPayment'] = 0
+            else:
+                calculation['monthlyPayment'] = float(periodic_interest)
+                calculation['quarterlyPayment'] = 0
 
         # Generate payment schedule
         try:

--- a/routes.py
+++ b/routes.py
@@ -1899,6 +1899,8 @@ def get_saved_loans():
                 'loan_term': loan.loan_term,
                 'interest_rate': float(loan.interest_rate) if loan.interest_rate else 0,
                 'repayment_option': loan.repayment_option,
+                'monthlyPayment': float(loan.monthly_payment) if loan.monthly_payment else 0,
+                'quarterlyPayment': float(loan.quarterly_payment) if loan.quarterly_payment else 0,
                 
                 # Additional data needed for editing
                 'amountInputType': loan.amount_input_type if loan.amount_input_type else 'gross',
@@ -2000,6 +2002,8 @@ def get_loan_details(loan_id):
             # Payment parameters
             'payment_timing': loan.payment_timing if loan.payment_timing else 'advance',
             'payment_frequency': loan.payment_frequency if loan.payment_frequency else 'monthly',
+            'paymentTiming': loan.payment_timing if loan.payment_timing else 'advance',
+            'paymentFrequency': loan.payment_frequency if loan.payment_frequency else 'monthly',
             'capital_repayment': float(loan.capital_repayment) if loan.capital_repayment else 0,
             'flexible_payment': float(loan.flexible_payment) if loan.flexible_payment else 0,
             
@@ -2018,6 +2022,7 @@ def get_loan_details(loan_id):
             'netAdvance': float(loan.net_advance) if loan.net_advance else 0,
             'totalNetAdvance': float(loan.total_net_advance) if loan.total_net_advance else 0,
             'monthlyPayment': float(loan.monthly_payment) if loan.monthly_payment else 0,
+            'quarterlyPayment': float(loan.quarterly_payment) if loan.quarterly_payment else 0,
             'propertyValue': float(loan.property_value) if loan.property_value else 0,
             'legalFees': float(loan.legal_costs) if loan.legal_costs else 1500,
             'siteVisitFee': float(loan.site_visit_fee) if loan.site_visit_fee else 500,

--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -675,6 +675,19 @@ class LoanHistoryManager {
                                     <td class="text-end py-2 px-3" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;">12.00% ${currencySymbol}</td>
                                     <td class="fw-bold py-2 px-3 text-end" style="color: #000 !important; background: #f8f9fa;">${(loan.totalInterest || 0).toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2})}</td>
                                 </tr>
+                                ${loan.paymentFrequency === 'quarterly' ? `
+                                <tr style="border: 1px solid #000;">
+                                    <td class="py-2 px-3" style="color: #000 !important; border-right: 1px solid #000; background: white;">Quarterly Interest Payment</td>
+                                    <td class="text-end py-2 px-3" style="color: #000 !important; border-right: 1px solid #000; background: white;">${currencySymbol}</td>
+                                    <td class="fw-bold py-2 px-3 text-end" style="color: #000 !important; background: white;">${(loan.quarterlyPayment || 0).toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2})}</td>
+                                </tr>
+                                ` : `
+                                <tr style="border: 1px solid #000;">
+                                    <td class="py-2 px-3" style="color: #000 !important; border-right: 1px solid #000; background: white;">Monthly Interest Payment</td>
+                                    <td class="text-end py-2 px-3" style="color: #000 !important; border-right: 1px solid #000; background: white;">${currencySymbol}</td>
+                                    <td class="fw-bold py-2 px-3 text-end" style="color: #000 !important; background: white;">${(loan.monthlyPayment || 0).toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2})}</td>
+                                </tr>
+                                `}
                                 <tr style="border: 1px solid #000;">
                                     <td class="py-2 px-3" style="color: #000 !important; border-right: 1px solid #000; background: white;">Net Advance</td>
                                     <td class="text-end py-2 px-3" style="color: #000 !important; border-right: 1px solid #000; background: white;">${currencySymbol}</td>


### PR DESCRIPTION
## Summary
- compute periodic interest amounts based on payment frequency and store as monthly or quarterly payments for bridge and term loans
- expose periodic payments in saved-loan APIs
- display monthly/quarterly interest payments on loan summary page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6fe241d488320b017b7798b3adf1c