### PR TITLE
Align interest-only totals for capital and flexible payments

### DIFF
--- a/test_interest_only_total.py
+++ b/test_interest_only_total.py
@@ -29,3 +29,63 @@ def test_service_capital_interest_only_matches_service_only():
         use_360_days=True,
     )
     assert res_sc['interestOnlyTotal'] == pytest.approx(res_io['totalInterest'])
+
+
+def test_capital_payment_only_interest_only_matches_interest_only():
+    calc = LoanCalculator()
+    gross_amount = Decimal('100000')
+    annual_rate = Decimal('12')
+    loan_term = 12
+    fees = {'arrangementFee': Decimal('0'), 'totalLegalFees': Decimal('0')}
+    capital_repayment = Decimal('1000')
+
+    res_cp = calc._calculate_term_capital_payment_only(
+        gross_amount,
+        annual_rate,
+        loan_term,
+        capital_repayment,
+        fees,
+        loan_term_days=None,
+        use_360_days=True,
+    )
+    res_io = calc._calculate_term_interest_only(
+        gross_amount,
+        annual_rate,
+        loan_term,
+        fees,
+        loan_start_date='2024-01-01',
+        loan_term_days=None,
+        use_360_days=True,
+    )
+    assert res_cp['interestOnlyTotal'] == pytest.approx(res_io['totalInterest'])
+
+
+def test_flexible_payment_interest_only_matches_interest_only():
+    calc = LoanCalculator()
+    gross_amount = Decimal('100000')
+    annual_rate = Decimal('12')
+    loan_term = 12
+    fees = {'arrangementFee': Decimal('0'), 'totalLegalFees': Decimal('0')}
+    flexible_payment = Decimal('1000')
+
+    res_fp = calc._calculate_term_flexible_payment(
+        gross_amount,
+        annual_rate,
+        loan_term,
+        flexible_payment,
+        'monthly',
+        fees,
+        loan_start_date='2024-01-01',
+        loan_term_days=None,
+        use_360_days=True,
+    )
+    res_io = calc._calculate_term_interest_only(
+        gross_amount,
+        annual_rate,
+        loan_term,
+        fees,
+        loan_start_date='2024-01-01',
+        loan_term_days=None,
+        use_360_days=True,
+    )
+    assert res_fp['interestOnlyTotal'] == pytest.approx(res_io['totalInterest'])


### PR DESCRIPTION
## Summary
- ensure capital-payment-only interest uses same daily method as interest-only schedules
- compute flexible-payment interest-only baseline with matching day-count logic
- cover capital-payment-only and flexible-payment cases with regression tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a78d63c35c8320b84551d9fd7da282