### PR TITLE
Fix net advance for bridge capital-only loans

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -2214,10 +2214,14 @@ class LoanCalculator:
     def _calculate_bridge_capital_only(self, gross_amount: Decimal, annual_rate: Decimal,
                                      loan_term: int, capital_repayment: Decimal, fees: Dict, interest_type: str = 'simple') -> Dict:
         """Calculate bridge loan with capital only payments (interest refunded)"""
-        
-        # Interest is retained then refunded proportionally
-        net_advance = gross_amount - fees['arrangementFee'] - fees['totalLegalFees']
-        
+
+        # Interest for the first month is retained upfront then refunded through
+        # the capital-only payments. Include this retained interest when
+        # calculating the initial net advance to ensure the borrower receives
+        # the correct net amount.
+        monthly_interest = gross_amount * (annual_rate / Decimal('100') / Decimal('12'))
+        net_advance = gross_amount - fees['arrangementFee'] - fees['totalLegalFees'] - monthly_interest
+
         return {
             'monthlyPayment': float(capital_repayment),
             'totalInterest': 0,  # Interest is refunded

--- a/test_bridge_capital_only_net.py
+++ b/test_bridge_capital_only_net.py
@@ -1,0 +1,48 @@
+from decimal import Decimal
+import pytest
+from calculations import LoanCalculator
+
+
+def test_bridge_capital_only_net_matches_input():
+    calc = LoanCalculator()
+    net_amount = Decimal('95000')
+    annual_rate = Decimal('12')
+    loan_term = 12
+    arrangement_fee_rate = Decimal('2')
+    legal_fees = Decimal('1000')
+    site_visit_fee = Decimal('500')
+    title_insurance_rate = Decimal('1')
+    loan_term_days = 365
+    capital_repayment = Decimal('1000')
+
+    gross = calc._calculate_gross_from_net_bridge(
+        net_amount,
+        annual_rate,
+        loan_term,
+        'capital_payment_only',
+        arrangement_fee_rate,
+        legal_fees,
+        site_visit_fee,
+        title_insurance_rate,
+        loan_term_days,
+        use_360_days=False,
+    )
+
+    fees = calc._calculate_fees(
+        gross,
+        arrangement_fee_rate,
+        legal_fees,
+        site_visit_fee,
+        title_insurance_rate,
+        Decimal('0'),
+    )
+
+    res = calc._calculate_bridge_capital_only(
+        gross,
+        annual_rate,
+        loan_term,
+        capital_repayment,
+        fees,
+    )
+
+    assert res['netAdvance'] == pytest.approx(float(net_amount))


### PR DESCRIPTION
## Summary
- deduct first month's retained interest when computing bridge loan net advance for capital-only payments
- add regression test validating capital-only net-to-gross conversion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7960812048320800520f3972b0c5f