### PR TITLE
Apply dark palette to loan breakdown chart

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -2624,13 +2624,17 @@ class LoanCalculator {
         const totalInterest = results.totalInterest || 0;
         const totalNetAdvance = results.totalNetAdvance || 0;
 
+        // Dark palette colors for loan breakdown chart
+        const darkPalette = ['#0b0b16', '#b49b5c', '#ffffff', '#3a3a3a', '#6b6b6b', '#9e9e9e'];
+
         const data = {
             labels: ['Total Net Advance', 'Arrangement Fee', 'Legal Costs', 'Site Visit Fee', 'Title Insurance', 'Total Interest'],
             datasets: [{
                 data: [totalNetAdvance, arrangementFee, legalFees, siteVisitFee, titleInsurance, totalInterest],
-                backgroundColor: this.getCurrentThemeColors(results.currency).gradient,
+                backgroundColor: darkPalette,
                 borderWidth: 2,
-                borderColor: '#fff'
+                borderColor: '#0b0b16',
+                hoverOffset: 20
             }]
         };
 


### PR DESCRIPTION
## Summary
- style loan breakdown chart with dark palette colors
- add hover offset so slices pop up when hovered

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8f69583748320b38853f4fc153297