### PR TITLE
Add interest line to balance visualization

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -2977,22 +2977,49 @@ class LoanCalculator {
             return 0;
         });
 
+        const interestData = schedule.map(entry => {
+            const interestRaw = entry.interest_amount || entry.interest || 0;
+            if (typeof interestRaw === 'number') {
+                return interestRaw;
+            } else if (typeof interestRaw === 'string') {
+                return parseFloat(interestRaw.replace(/[£€,]/g, '')) || 0;
+            }
+            return 0;
+        });
+
         const data = {
             labels: labels,
-            datasets: [{
-                label: 'Remaining Balance',
-                data: balanceData,
-                borderColor: 'rgba(184, 134, 11, 1)', // Novellus gold
-                backgroundColor: 'rgba(184, 134, 11, 0.1)',
-                borderWidth: 2,
-                fill: true,
-                tension: 0.1,
-                pointRadius: 3,
-                pointHoverRadius: 6,
-                pointBackgroundColor: 'rgba(184, 134, 11, 1)',
-                pointBorderColor: '#fff',
-                pointBorderWidth: 2
-            }]
+            datasets: [
+                {
+                    label: 'Remaining Balance',
+                    data: balanceData,
+                    borderColor: 'rgba(184, 134, 11, 1)', // Novellus gold
+                    backgroundColor: 'rgba(184, 134, 11, 0.1)',
+                    borderWidth: 2,
+                    fill: true,
+                    tension: 0.1,
+                    pointRadius: 3,
+                    pointHoverRadius: 6,
+                    pointBackgroundColor: 'rgba(184, 134, 11, 1)',
+                    pointBorderColor: '#fff',
+                    pointBorderWidth: 2
+                },
+                {
+                    label: 'Interest Payment',
+                    data: interestData,
+                    borderColor: 'rgba(70, 130, 180, 1)',
+                    backgroundColor: 'rgba(70, 130, 180, 0.1)',
+                    borderWidth: 2,
+                    fill: false,
+                    tension: 0.1,
+                    pointRadius: 3,
+                    pointHoverRadius: 6,
+                    pointBackgroundColor: 'rgba(70, 130, 180, 1)',
+                    pointBorderColor: '#fff',
+                    pointBorderWidth: 2,
+                    yAxisID: 'y1'
+                }
+            ]
         };
 
         console.log('Creating Balance Over Time chart with', balanceData.length, 'data points');
@@ -3026,12 +3053,23 @@ class LoanCalculator {
                                     text: `Balance (${results.currencySymbol || results.currency_symbol || '£'})`
                                 },
                                 beginAtZero: true
+                            },
+                            y1: {
+                                title: {
+                                    display: true,
+                                    text: `Interest (${results.currencySymbol || results.currency_symbol || '£'})`
+                                },
+                                position: 'right',
+                                beginAtZero: true,
+                                grid: {
+                                    drawOnChartArea: false
+                                }
                             }
                         },
                         plugins: {
                             title: {
                                 display: true,
-                                text: 'Loan Balance Over Time',
+                                text: 'Loan Balance & Interest Over Time',
                                 font: {
                                     size: 14,
                                     weight: 'bold'

--- a/static/js/charts.js
+++ b/static/js/charts.js
@@ -194,35 +194,52 @@ class ChartManager {
 
         const labels = schedule.map(payment => `Month ${payment.month}`);
         const balanceData = schedule.map(payment => payment.balance || 0);
+        const interestData = schedule.map(payment => payment.interest || payment.interest_amount || 0);
 
         const config = {
             type: 'line',
             data: {
                 labels: labels,
-                datasets: [{
-                    label: 'Outstanding Balance',
-                    data: balanceData,
-                    backgroundColor: this.addTransparency(this.defaultColors.primary, 0.1),
-                    borderColor: this.defaultColors.primary,
-                    borderWidth: 3,
-                    fill: true,
-                    tension: 0.4,
-                    pointBackgroundColor: this.defaultColors.primary,
-                    pointBorderColor: '#fff',
-                    pointBorderWidth: 2,
-                    pointRadius: 4
-                }]
+                datasets: [
+                    {
+                        label: 'Outstanding Balance',
+                        data: balanceData,
+                        backgroundColor: this.addTransparency(this.defaultColors.primary, 0.1),
+                        borderColor: this.defaultColors.primary,
+                        borderWidth: 3,
+                        fill: true,
+                        tension: 0.4,
+                        pointBackgroundColor: this.defaultColors.primary,
+                        pointBorderColor: '#fff',
+                        pointBorderWidth: 2,
+                        pointRadius: 4
+                    },
+                    {
+                        label: 'Interest Payment',
+                        data: interestData,
+                        backgroundColor: this.addTransparency(this.defaultColors.secondary, 0.1),
+                        borderColor: this.defaultColors.secondary,
+                        borderWidth: 3,
+                        fill: false,
+                        tension: 0.4,
+                        pointBackgroundColor: this.defaultColors.secondary,
+                        pointBorderColor: '#fff',
+                        pointBorderWidth: 2,
+                        pointRadius: 4,
+                        yAxisID: 'y1'
+                    }
+                ]
             },
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
                 plugins: {
                     legend: {
-                        display: false
+                        display: true
                     },
                     title: {
                         display: true,
-                        text: options.title || 'Loan Balance Over Time',
+                        text: options.title || 'Loan Balance & Interest Over Time',
                         font: {
                             size: 16,
                             weight: 'bold'
@@ -233,7 +250,7 @@ class ChartManager {
                             label: function(context) {
                                 const value = context.parsed.y;
                                 const currency = options.currency || '£';
-                                return `Balance: ${currency}${value.toLocaleString('en-GB', {minimumFractionDigits: 2})}`;
+                                return `${context.dataset.label}: ${currency}${value.toLocaleString('en-GB', {minimumFractionDigits: 2})}`;
                             }
                         }
                     }
@@ -249,6 +266,22 @@ class ChartManager {
                         title: {
                             display: true,
                             text: 'Outstanding Balance'
+                        },
+                        ticks: {
+                            callback: function(value) {
+                                const currency = options.currency || '£';
+                                return currency + value.toLocaleString('en-GB');
+                            }
+                        }
+                    },
+                    y1: {
+                        title: {
+                            display: true,
+                            text: 'Interest Payment'
+                        },
+                        position: 'right',
+                        grid: {
+                            drawOnChartArea: false
                         },
                         ticks: {
                             callback: function(value) {


### PR DESCRIPTION
## Summary
- Overlay interest payment on Balance Over Time chart
- Expose interest axis in generic loan balance chart utility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8faaa44c483208055afec507da02f