### PR TITLE
Align scenario comparison inputs with calculator

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1791,8 +1791,15 @@ function openScenarioComparison() {
         const params = new URLSearchParams({
             loan_type: formData.loan_type || 'bridge',
             gross_amount: formData.gross_amount || formData.net_amount || 1000000,
+            net_amount: formData.net_amount || 0,
+            gross_amount_type: formData.gross_amount_type || 'fixed',
+            gross_amount_percentage: formData.gross_amount_percentage || 0,
             annual_rate: formData.annual_rate || (formData.monthly_rate ? formData.monthly_rate * 12 : 12),
+            monthly_rate: formData.monthly_rate || 0,
+            rate_input_type: formData.rate_input_type || 'annual',
             loan_term: formData.loan_term || 12,
+            start_date: formData.start_date || '',
+            end_date: formData.end_date || '',
             property_value: formData.property_value || 2000000,
             currency: formData.currency || 'GBP',
             amount_input_type: formData.amount_input_type || 'gross',
@@ -1803,7 +1810,11 @@ function openScenarioComparison() {
             repayment_option: formData.repayment_option || 'none',
             interest_type: formData.interest_type || 'simple',
             payment_timing: formData.payment_timing || 'arrears',
-            payment_frequency: formData.payment_frequency || 'monthly'
+            payment_frequency: formData.payment_frequency || 'monthly',
+            capital_repayment: formData.capital_repayment || 0,
+            flexible_payment: formData.flexible_payment || 0,
+            day1_advance: formData.day1_advance || 0,
+            use_360_days: formData.use_360_days || 'false'
         });
         
         // Open scenario comparison in new tab with current parameters

--- a/templates/scenario_comparison.html
+++ b/templates/scenario_comparison.html
@@ -197,6 +197,9 @@
                                         <input type="hidden" id="baseMonthlyRate" value="0">
                                         <input type="hidden" id="baseAmountInputType" value="gross">
                                         <input type="hidden" id="baseRateInputType" value="annual">
+                                        <input type="hidden" id="baseNetAmount" value="0">
+                                        <input type="hidden" id="baseGrossAmountType" value="fixed">
+                                        <input type="hidden" id="baseGrossAmountPercentage" value="0">
                                     </div>
                                 </div>
                                 
@@ -536,8 +539,19 @@
             if (urlParams.get('loan_type')) {
                 document.getElementById('baseLoanType').value = urlParams.get('loan_type');
             }
-            if (urlParams.get('gross_amount')) {
+            if (urlParams.get('amount_input_type') === 'net' && urlParams.get('net_amount')) {
+                document.getElementById('baseLoanAmount').value = urlParams.get('net_amount');
+            } else if (urlParams.get('gross_amount')) {
                 document.getElementById('baseLoanAmount').value = urlParams.get('gross_amount');
+            }
+            if (urlParams.get('net_amount')) {
+                document.getElementById('baseNetAmount').value = urlParams.get('net_amount');
+            }
+            if (urlParams.get('gross_amount_type')) {
+                document.getElementById('baseGrossAmountType').value = urlParams.get('gross_amount_type');
+            }
+            if (urlParams.get('gross_amount_percentage')) {
+                document.getElementById('baseGrossAmountPercentage').value = urlParams.get('gross_amount_percentage');
             }
             if (urlParams.get('annual_rate')) {
                 document.getElementById('baseInterestRate').value = urlParams.get('annual_rate');
@@ -630,6 +644,9 @@
             return {
                 loan_type: urlParams.get('loan_type') || document.getElementById('baseLoanType').value,
                 gross_amount: parseFloat(urlParams.get('gross_amount') || document.getElementById('baseLoanAmount').value),
+                net_amount: parseFloat(urlParams.get('net_amount') || document.getElementById('baseNetAmount')?.value || '0'),
+                gross_amount_type: urlParams.get('gross_amount_type') || document.getElementById('baseGrossAmountType')?.value || 'fixed',
+                gross_amount_percentage: parseFloat(urlParams.get('gross_amount_percentage') || document.getElementById('baseGrossAmountPercentage')?.value || '0'),
                 annual_rate: parseFloat(urlParams.get('annual_rate') || document.getElementById('baseInterestRate').value),
                 monthly_rate: parseFloat(urlParams.get('monthly_rate') || document.getElementById('baseMonthlyRate')?.value || '0'),
                 loan_term: parseInt(urlParams.get('loan_term') || document.getElementById('baseLoanTerm').value),


### PR DESCRIPTION
## Summary
- Pass full calculator form data to scenario comparison page
- Sync scenario comparison form with calculator inputs via hidden fields and URL handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8fb45e29c8320972b99861167dd10