### PR TITLE
Keep Snowflake config visible with test button

### DIFF
--- a/templates/powerbi_config.html
+++ b/templates/powerbi_config.html
@@ -330,11 +330,15 @@
                         <!-- Snowflake Config Panel -->
                         <div class="tab-pane fade" id="snowflake-panel" role="tabpanel">
                             <div class="p-3">
-                                <div id="snowflakeSavedConfig" class="alert alert-light border text-dark d-flex justify-content-between align-items-center mb-3" style="display:none;">
-                                    <div id="sfSavedDetails"></div>
-                                    <div>
-                                        <button type="button" class="btn btn-sm btn-primary me-2" onclick="editSnowflakeConfig()">Edit</button>
-                                        <button type="button" class="btn btn-sm btn-danger" onclick="deleteSnowflakeConfig()">Delete</button>
+                                <div id="snowflakeSavedConfig" class="card border mb-3" style="display:none;">
+                                    <div class="card-body d-flex justify-content-between align-items-center">
+                                        <div id="sfSavedDetails"></div>
+                                        <div class="d-flex gap-2">
+                                            <button type="button" class="btn btn-sm btn-primary" onclick="testSnowflakeConnection(this)" title="Test Connection">
+                                                <i class="fas fa-vial"></i>
+                                            </button>
+                                            <button type="button" class="btn btn-sm btn-danger" onclick="deleteSnowflakeConfig()">Delete</button>
+                                        </div>
                                     </div>
                                 </div>
                                 <form id="snowflakeForm" autocomplete="off">
@@ -2775,14 +2779,7 @@ function loadSnowflakeConfig() {
                 : `User ${cfg.user} on account ${cfg.account}`;
             document.getElementById('sfSavedDetails').textContent = summary;
             savedDiv.style.display = 'flex';
-            form.style.display = 'none';
         });
-}
-
-function editSnowflakeConfig() {
-    document.getElementById('snowflakeSavedConfig').style.display = 'none';
-    const form = document.getElementById('snowflakeForm');
-    form.style.display = 'block';
 }
 
 function deleteSnowflakeConfig() {
@@ -2813,8 +2810,10 @@ document.querySelectorAll('input[name="sfAuthType"]').forEach(el => {
     el.addEventListener('change', toggleSfAuthFields);
 });
 
-async function testSnowflakeConnection() {
-    const btn = document.getElementById('testSnowflakeBtn');
+async function testSnowflakeConnection(btnElem) {
+    const btn = btnElem || document.getElementById('testSnowflakeBtn');
+    if (!btn) return;
+    const originalHtml = btn.innerHTML;
     btn.disabled = true;
     btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Testing...';
     try {
@@ -2835,7 +2834,7 @@ async function testSnowflakeConnection() {
         showNotification(`Connection error: ${err.message}`, 'error');
     } finally {
         btn.disabled = false;
-        btn.innerHTML = '<i class="fas fa-vial me-1"></i>Test';
+        btn.innerHTML = originalHtml;
     }
 }
 


### PR DESCRIPTION
## Summary
- Display saved Snowflake configuration in a card and keep form accessible
- Add test button for existing Snowflake settings and support multiple test triggers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad75c8e4108320a40c95a36085799c