### PR TITLE
Add modal-based Snowflake configuration page with PAT support

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -2411,6 +2411,10 @@ def download_working_report(filename):
 def powerbi_config():
     return render_template('powerbi_config.html')
 
+@app.route('/snowflake-config')
+def snowflake_config():
+    return render_template('snowflake_config.html')
+
 @app.route('/powerbi-scheduler')
 @login_required
 def powerbi_scheduler():

--- a/snowflake_utils.py
+++ b/snowflake_utils.py
@@ -20,7 +20,8 @@ def _get_snowflake_connection():
         return None
     if snowflake_connector is None:
         raise RuntimeError("snowflake-connector-python is not installed")
-    if cfg.get("method") in ("token", "pat"):
+    method = cfg.get("method")
+    if method == "token":
         return snowflake_connector.connect(
             account=cfg.get("account"),
             warehouse=cfg.get("warehouse"),
@@ -29,9 +30,12 @@ def _get_snowflake_connection():
             token=cfg.get("token"),
             authenticator="oauth",
         )
+    password = cfg.get("password")
+    if method == "pat":
+        password = cfg.get("token")
     return snowflake_connector.connect(
         user=cfg.get("user"),
-        password=cfg.get("password"),
+        password=password,
         account=cfg.get("account"),
         warehouse=cfg.get("warehouse"),
         database=cfg.get("database"),

--- a/templates/base.html
+++ b/templates/base.html
@@ -86,6 +86,11 @@
                                 <i class="fas fa-cog me-1"></i>Power BI Config
                             </a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('snowflake_config') }}">
+                                <i class="fas fa-database me-1"></i>Snowflake Config
+                            </a>
+                        </li>
                     {% endif %}
                 </ul>
                 
@@ -93,6 +98,9 @@
                 <div class="d-flex align-items-center gap-2 ms-auto">
                     <a class="btn btn-info text-white nav-btn" href="{{ url_for('powerbi_config') }}">
                         <i class="fas fa-cog me-1"></i>Power BI Configuration
+                    </a>
+                    <a class="btn btn-info text-white nav-btn" href="{{ url_for('snowflake_config') }}">
+                        <i class="fas fa-database me-1"></i>Snowflake Config
                     </a>
                     <a class="btn btn-secondary text-white nav-btn" href="{{ url_for('user_manual') }}">
                         <i class="fas fa-book me-1"></i>User Manual

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,8 +20,11 @@
                     <a href="{{ url_for('login') }}" class="btn btn-outline-light btn-lg me-3">
                         <i class="fas fa-sign-in-alt me-2"></i>Login
                     </a>
-                    <a href="{{ url_for('powerbi_config') }}" class="btn btn-warning btn-lg">
+                    <a href="{{ url_for('powerbi_config') }}" class="btn btn-warning btn-lg me-2">
                         <i class="fas fa-cog me-2"></i>Power BI Config
+                    </a>
+                    <a href="{{ url_for('snowflake_config') }}" class="btn btn-primary btn-lg">
+                        <i class="fas fa-database me-2"></i>Snowflake Config
                     </a>
                 </div>
             </div>
@@ -33,6 +36,9 @@
                     </a>
                     <a href="{{ url_for('powerbi_config') }}" class="btn btn-warning btn-lg me-2">
                         <i class="fas fa-cog me-2"></i>Power BI Config
+                    </a>
+                    <a href="{{ url_for('snowflake_config') }}" class="btn btn-primary btn-lg me-2">
+                        <i class="fas fa-database me-2"></i>Snowflake Config
                     </a>
                     <a href="{{ url_for('powerbi_scheduler') }}" class="btn btn-success btn-lg">
                         <i class="fas fa-clock me-2"></i>Power BI Scheduler

--- a/templates/snowflake_config.html
+++ b/templates/snowflake_config.html
@@ -1,0 +1,114 @@
+{% extends "base.html" %}
+
+{% block title %}Snowflake Configuration{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <h2 class="mb-3">Snowflake Configuration</h2>
+    <p>Store your Snowflake connection settings and verify the connection.</p>
+    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#snowflakeModal">
+        <i class="fas fa-database me-1"></i>Configure Snowflake
+    </button>
+    <div id="testResult" class="mt-3"></div>
+</div>
+
+<!-- Modal -->
+<div class="modal fade" id="snowflakeModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <form id="snowflakeForm" class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Snowflake Connection</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+            <label class="form-label">Account</label>
+            <input type="text" class="form-control" name="account" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">User</label>
+            <input type="text" class="form-control" name="user" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Warehouse</label>
+            <input type="text" class="form-control" name="warehouse" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Database</label>
+            <input type="text" class="form-control" name="database" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Schema</label>
+            <input type="text" class="form-control" name="schema" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">PAT Token</label>
+            <input type="password" class="form-control" name="token" required>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="submit" class="btn btn-primary">Save</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    loadConfig();
+    document.getElementById('snowflakeForm').addEventListener('submit', saveConfig);
+});
+
+async function loadConfig() {
+    const resp = await fetch('/api/snowflake/config');
+    if (!resp.ok) return;
+    const data = await resp.json();
+    if (!data) return;
+    const form = document.getElementById('snowflakeForm');
+    form.account.value = data.account || '';
+    form.user.value = data.user || '';
+    form.warehouse.value = data.warehouse || '';
+    form.database.value = data.database || '';
+    form.schema.value = data.schema || '';
+    form.token.value = data.token || '';
+}
+
+async function saveConfig(e) {
+    e.preventDefault();
+    const form = e.target;
+    const payload = {
+        method: 'pat',
+        account: form.account.value,
+        user: form.user.value,
+        warehouse: form.warehouse.value,
+        database: form.database.value,
+        schema: form.schema.value,
+        token: form.token.value
+    };
+    const resp = await fetch('/api/snowflake/config', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    });
+    if (resp.ok) {
+        await testConnection();
+        bootstrap.Modal.getInstance(document.getElementById('snowflakeModal')).hide();
+    }
+}
+
+async function testConnection() {
+    const resultDiv = document.getElementById('testResult');
+    try {
+        const resp = await fetch('/api/snowflake/test', {method: 'POST'});
+        if (resp.ok) {
+            resultDiv.innerHTML = '<div class="alert alert-success">Connection successful.</div>';
+        } else {
+            const text = await resp.text();
+            resultDiv.innerHTML = '<div class="alert alert-danger">Connection failed: ' + text + '</div>';
+        }
+    } catch (err) {
+        resultDiv.innerHTML = '<div class="alert alert-danger">Connection failed.</div>';
+    }
+}
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add dedicated Snowflake configuration page with modal form and connection testing
- Support PAT-based authentication in Snowflake utilities
- Expose new Snowflake config route and navigation links

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad7d8405648320bd11a4eee9523306