### PR TITLE
Persist Snowflake configuration between sessions

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -23,6 +23,7 @@ from utils import (
 )
 from snowflake_utils import (
     set_snowflake_config,
+    get_snowflake_config,
     sync_data_to_snowflake,
     test_snowflake_connection,
     model_to_dict,
@@ -3373,11 +3374,15 @@ def configure_snowflake():
     """Configure Snowflake connection from frontend."""
     try:
         if request.method == 'GET':
-            cfg = current_app.config.get('SNOWFLAKE_CONFIG', {})
+            cfg = get_snowflake_config()
             return jsonify({'config': cfg})
 
         if request.method == 'DELETE':
             current_app.config.pop('SNOWFLAKE_CONFIG', None)
+            try:
+                os.remove('snowflake_config.json')
+            except FileNotFoundError:
+                pass
             return jsonify({'success': True})
 
         config = request.json or {}

--- a/snowflake_utils.py
+++ b/snowflake_utils.py
@@ -1,5 +1,9 @@
+"""Utility helpers for optional Snowflake integration."""
+
 from datetime import date, datetime
 from decimal import Decimal
+import json
+import os
 
 from flask import current_app
 
@@ -9,13 +13,56 @@ except Exception:  # pragma: no cover - dependency may be missing in some enviro
     snowflake_connector = None
 
 
+# Path where Snowflake configuration is persisted for reuse across requests
+SNOWFLAKE_CONFIG_FILE = "snowflake_config.json"
+
+
 def set_snowflake_config(config: dict) -> None:
-    """Store Snowflake connection configuration in the Flask app config."""
+    """Store Snowflake connection configuration and persist to disk.
+
+    Parameters
+    ----------
+    config: dict
+        Configuration values received from the frontend.
+    """
+
     current_app.config["SNOWFLAKE_CONFIG"] = config
+
+    # Persist configuration so it survives application restarts or
+    # cross-process requests. Failures here shouldn't break the request.
+    try:  # pragma: no cover - IO failures are non-critical
+        with open(SNOWFLAKE_CONFIG_FILE, "w") as f:
+            json.dump(config, f)
+    except Exception as exc:
+        current_app.logger.warning(f"Failed to persist Snowflake config: {exc}")
+
+
+def get_snowflake_config() -> dict:
+    """Return the current Snowflake configuration.
+
+    The configuration is first looked up in ``current_app.config`` and, if not
+    present, loaded from the persisted JSON file. This allows the application
+    to reuse saved settings even after a restart.
+    """
+
+    cfg = current_app.config.get("SNOWFLAKE_CONFIG")
+    if cfg:
+        return cfg
+
+    if os.path.exists(SNOWFLAKE_CONFIG_FILE):
+        try:  # pragma: no cover - IO failures are non-critical
+            with open(SNOWFLAKE_CONFIG_FILE, "r") as f:
+                cfg = json.load(f)
+            current_app.config["SNOWFLAKE_CONFIG"] = cfg
+            return cfg
+        except Exception as exc:
+            current_app.logger.warning(f"Failed to load Snowflake config: {exc}")
+
+    return {}
 
 
 def _get_snowflake_connection():
-    cfg = current_app.config.get("SNOWFLAKE_CONFIG")
+    cfg = get_snowflake_config()
     if not cfg:
         return None
     if snowflake_connector is None:

--- a/test_snowflake_config_persistence.py
+++ b/test_snowflake_config_persistence.py
@@ -1,0 +1,43 @@
+import os
+import json
+from flask import current_app
+
+from app import app
+from snowflake_utils import SNOWFLAKE_CONFIG_FILE
+
+
+def test_snowflake_config_persisted(tmp_path):
+    """Saving Snowflake config should persist to disk and reload."""
+    client = app.test_client()
+
+    # Ensure clean state
+    if os.path.exists(SNOWFLAKE_CONFIG_FILE):
+        os.remove(SNOWFLAKE_CONFIG_FILE)
+
+    payload = {
+        'method': 'password',
+        'user': 'u',
+        'password': 'p',
+        'account': 'acc'
+    }
+    res = client.post('/api/snowflake/config', json=payload)
+    assert res.get_json()['success'] is True
+
+    # File should now exist with same contents
+    assert os.path.exists(SNOWFLAKE_CONFIG_FILE)
+    with open(SNOWFLAKE_CONFIG_FILE) as f:
+        data = json.load(f)
+    assert data['account'] == 'acc'
+
+    # Simulate new process by clearing config
+    with app.app_context():
+        current_app.config.pop('SNOWFLAKE_CONFIG', None)
+
+    # GET should reload from file
+    res = client.get('/api/snowflake/config')
+    assert res.get_json()['config']['account'] == 'acc'
+
+    # Delete config
+    res = client.delete('/api/snowflake/config')
+    assert res.get_json()['success'] is True
+    assert not os.path.exists(SNOWFLAKE_CONFIG_FILE)


### PR DESCRIPTION
## Summary
- Persist Snowflake connection settings to `snowflake_config.json`
- Load saved Snowflake config automatically and clean up file on delete
- Add regression test ensuring Snowflake config is persisted and reloaded

## Testing
- `pip install flask flask_sqlalchemy flask_login flask_jwt_extended flask_cors python-dotenv pytest -q` *(fails: Could not find a version that satisfies the requirement flask)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68addd0e99d08320a677b964f0c9ab96