### PR TITLE
Increase calculation precision to four decimals for summary totals

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -26,8 +26,18 @@ class LoanCalculator:
         return float(value.quantize(quantize_value, rounding=ROUND_HALF_UP))
 
     def _two_dp(self, value) -> float:
-        """Round a numeric value to two decimal places using HALF_UP."""
-        return self._round(value, 2)
+        """Round a numeric value to four decimal places using HALF_UP.
+
+        Historically the calculator rounded values to two decimal places at
+        each step of the calculation.  This introduced small cumulative
+        rounding errors on the summary page – totals such as the overall
+        interest could end up a penny short (e.g. ``11999.99`` instead of the
+        expected ``12000``).  To ensure the summary totals are mathematically
+        consistent we now maintain four decimal places of precision throughout
+        the calculation pipeline and only let the presentation layer decide how
+        many decimals to display.
+        """
+        return self._round(value, 4)
 
     def _add_months(self, start: datetime, months: int) -> datetime:
         """Add months to a date while preserving day when possible."""

--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -698,17 +698,18 @@ class LoanCalculator {
         const day1Advance = results.day1Advance || results.netDay1Advance || 0;
         
         // Update the display elements
-        if (valuationEl) valuationEl.textContent = propertyValue.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
-        if (grossAmountEl) grossAmountEl.textContent = grossAmount.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+        const moneyFormat = {minimumFractionDigits: 4, maximumFractionDigits: 4};
+        if (valuationEl) valuationEl.textContent = propertyValue.toLocaleString('en-GB', moneyFormat);
+        if (grossAmountEl) grossAmountEl.textContent = grossAmount.toLocaleString('en-GB', moneyFormat);
         if (startDateEl) startDateEl.textContent = this.formatDate(startDate);
         if (endDateEl) endDateEl.textContent = this.formatDate(endDate);
         if (loanTermEl) loanTermEl.textContent = loanTerm.toFixed(2);
         if (loanTermDaysEl) loanTermDaysEl.textContent = loanTermDays;
-        if (arrangementFeeEl) arrangementFeeEl.textContent = arrangementFee.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
-        if (legalCostsEl) legalCostsEl.textContent = legalCosts.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
-        if (siteVisitFeeEl) siteVisitFeeEl.textContent = siteVisitFee.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
-        if (titleInsuranceEl) titleInsuranceEl.textContent = titleInsurance.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
-        if (totalInterestEl) totalInterestEl.textContent = totalInterest.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+        if (arrangementFeeEl) arrangementFeeEl.textContent = arrangementFee.toLocaleString('en-GB', moneyFormat);
+        if (legalCostsEl) legalCostsEl.textContent = legalCosts.toLocaleString('en-GB', moneyFormat);
+        if (siteVisitFeeEl) siteVisitFeeEl.textContent = siteVisitFee.toLocaleString('en-GB', moneyFormat);
+        if (titleInsuranceEl) titleInsuranceEl.textContent = titleInsurance.toLocaleString('en-GB', moneyFormat);
+        if (totalInterestEl) totalInterestEl.textContent = totalInterest.toLocaleString('en-GB', moneyFormat);
         
         // For development loans, show user input Day 1 advance for display purposes
         if (netDay1AdvanceEl) {


### PR DESCRIPTION
## Summary
- maintain four decimal places in LoanCalculator to prevent cumulative rounding errors in interest calculations
- display monetary values on the calculator summary page with four decimal places for clearer totals

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ade04850408320a5f35ee8ba0b00dd