### PR TITLE
Align term loan with bridge logic and round loan summaries

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -698,7 +698,7 @@ class LoanCalculator {
         const day1Advance = results.day1Advance || results.netDay1Advance || 0;
         
         // Update the display elements
-        const moneyFormat = {minimumFractionDigits: 4, maximumFractionDigits: 4};
+        const moneyFormat = {minimumFractionDigits: 2, maximumFractionDigits: 2};
         if (valuationEl) valuationEl.textContent = propertyValue.toLocaleString('en-GB', moneyFormat);
         if (grossAmountEl) grossAmountEl.textContent = grossAmount.toLocaleString('en-GB', moneyFormat);
         if (startDateEl) startDateEl.textContent = this.formatDate(startDate);

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -28,8 +28,8 @@ Novellus.utils = {
         return new Intl.NumberFormat(config.locale, {
             style: 'currency',
             currency: currency,
-            minimumFractionDigits: 0,
-            maximumFractionDigits: 0
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
         }).format(amount);
     },
 


### PR DESCRIPTION
## Summary
- Use bridge-loan algorithms for term loans and limit to service interest or service+capital repayments
- Round all loan summary figures to two decimals via frontend formatting and backend processing

## Testing
- `pytest` *(fails: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68aecb256a0c832087a13668ff731416