### PR TITLE
Fix amount input type persistence on loan save

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -1725,7 +1725,7 @@ def save_loan():
             loan_summary.version = (loan_summary.version or 1) + 1
             loan_summary.loan_type = loan_type
             loan_summary.currency = data.get('currency', 'GBP')
-            loan_summary.amount_input_type = data.get('amountInputType', 'gross')
+            loan_summary.amount_input_type = data.get('amountInputType') or data.get('amount_input_type', 'gross')
             loan_summary.gross_amount = fresh_calculation.get('grossAmount', 0)
             loan_summary.net_amount = fresh_calculation.get('netAmount', 0)
             loan_summary.property_value = fresh_calculation.get('propertyValue', 0)
@@ -1774,7 +1774,7 @@ def save_loan():
                 version=1,
                 loan_type=loan_type,
                 currency=data.get('currency', 'GBP'),
-                amount_input_type=data.get('amountInputType', 'gross'),
+                amount_input_type=data.get('amountInputType') or data.get('amount_input_type', 'gross'),
                 gross_amount=fresh_calculation.get('grossAmount', 0),
                 net_amount=fresh_calculation.get('netAmount', 0),
                 property_value=fresh_calculation.get('propertyValue', 0),

--- a/test_save_loan_amount_input_type.py
+++ b/test_save_loan_amount_input_type.py
@@ -1,0 +1,43 @@
+import os
+import json
+
+# Use a separate SQLite database for testing
+os.environ['DATABASE_URL'] = 'sqlite:///test_save_loan.db'
+
+from app import app, db
+from models import LoanSummary
+
+
+def test_save_loan_preserves_amount_input_type():
+    """Ensure /save-loan stores provided amount_input_type"""
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+    client = app.test_client()
+
+    payload = {
+        "loanName": "Test Loan",
+        "loan_type": "bridge",
+        "currency": "GBP",
+        "amount_input_type": "net",
+        "net_amount": 100000,
+        "property_value": 200000,
+        "annual_rate": 5.0,
+        "loan_term": 12,
+        "repayment_option": "none",
+        "arrangement_fee_percentage": 2.0,
+        "legal_fees": 1500,
+        "site_visit_fee": 500,
+        "title_insurance_rate": 0.1,
+        "payment_timing": "advance",
+        "payment_frequency": "monthly"
+    }
+
+    response = client.post('/save-loan', json=payload)
+    assert response.status_code == 200, response.get_data(as_text=True)
+
+    with app.app_context():
+        loan = LoanSummary.query.filter_by(loan_name="Test Loan").first()
+        assert loan is not None
+        assert loan.amount_input_type == 'net'


### PR DESCRIPTION
## Summary
- Ensure `/save-loan` endpoint stores `amount_input_type` from either camelCase or snake_case field
- Add regression test confirming saved loans preserve `amount_input_type`

## Testing
- `pytest test_save_loan_amount_input_type.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask flask_sqlalchemy flask_login flask_jwt_extended flask_cors python-dotenv` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68aeced2b7a08320b4a340b90b33a0b9