### PR TITLE
Always report advance schedule for capital repayments

### DIFF
--- a/test_advance_payment_schedule.py
+++ b/test_advance_payment_schedule.py
@@ -16,7 +16,8 @@ def test_service_and_capital_advance_has_zero_final_interest():
         'capital_repayment': 1000,
         'payment_timing': 'advance',
         'payment_frequency': 'monthly',
-        'start_date': '2024-01-01'
+        'start_date': '2024-01-01',
+        'loan_term_days': 366
     }
     data = {
         'gross_amount': 100000,
@@ -36,7 +37,8 @@ def test_capital_payment_only_advance_has_zero_final_interest():
         'capital_repayment': 1000,
         'payment_timing': 'advance',
         'payment_frequency': 'monthly',
-        'start_date': '2024-01-01'
+        'start_date': '2024-01-01',
+        'loan_term_days': 366
     }
     data = {
         'gross_amount': 100000,
@@ -44,4 +46,69 @@ def test_capital_payment_only_advance_has_zero_final_interest():
         'totalLegalFees': 0
     }
     schedule = calc._generate_detailed_term_schedule(data, params, '£')
+    assert _parse_interest(schedule[-1]) == pytest.approx(0, abs=0.01)
+
+
+def test_service_and_capital_arrears_still_zero_final_interest():
+    calc = LoanCalculator()
+    params = {
+        'repayment_option': 'service_and_capital',
+        'loan_term': 12,
+        'annual_rate': 12,
+        'capital_repayment': 1000,
+        'payment_timing': 'arrears',
+        'payment_frequency': 'monthly',
+        'start_date': '2024-01-01',
+        'loan_term_days': 366
+    }
+    data = {
+        'gross_amount': 100000,
+        'arrangementFee': 0,
+        'totalLegalFees': 0,
+        'totalInterest': 0
+    }
+    schedule = calc._generate_detailed_bridge_schedule(data, params, '£')
+    assert _parse_interest(schedule[-1]) == pytest.approx(0, abs=0.01)
+
+
+def test_capital_payment_only_arrears_still_zero_final_interest():
+    calc = LoanCalculator()
+    params = {
+        'repayment_option': 'capital_payment_only',
+        'loan_term': 12,
+        'annual_rate': 12,
+        'capital_repayment': 1000,
+        'payment_timing': 'arrears',
+        'payment_frequency': 'monthly',
+        'start_date': '2024-01-01',
+        'loan_term_days': 366
+    }
+    data = {
+        'gross_amount': 100000,
+        'arrangementFee': 0,
+        'totalLegalFees': 0
+    }
+    schedule = calc._generate_detailed_term_schedule(data, params, '£')
+    assert _parse_interest(schedule[-1]) == pytest.approx(0, abs=0.01)
+
+
+def test_flexible_payment_has_zero_final_interest():
+    calc = LoanCalculator()
+    params = {
+        'repayment_option': 'flexible_payment',
+        'loan_term': 12,
+        'annual_rate': 12,
+        'payment_timing': 'arrears',
+        'payment_frequency': 'monthly',
+        'flexible_payment': 10000,
+        'start_date': '2024-01-01',
+        'loan_term_days': 366
+    }
+    data = {
+        'gross_amount': 100000,
+        'arrangementFee': 0,
+        'totalLegalFees': 0,
+        'totalInterest': 0
+    }
+    schedule = calc._generate_detailed_bridge_schedule(data, params, '£')
     assert _parse_interest(schedule[-1]) == pytest.approx(0, abs=0.01)


### PR DESCRIPTION
## Summary
- Force detailed schedules for service+capital, capital-only, and flexible payment options to use advance timing
- Zero out final interest for these repayment types and handle flexible-payment edge cases
- Add coverage ensuring final interest remains zero even when `payment_timing` is arrears

## Testing
- `pytest test_advance_payment_schedule.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af2ac001c483209c95a792f277614d