### PR TITLE
Add monthly interest savings to detailed payment schedules

### DIFF
--- a/test_monthly_interest_savings.py
+++ b/test_monthly_interest_savings.py
@@ -1,0 +1,34 @@
+from decimal import Decimal
+import pytest
+from calculations import LoanCalculator
+
+@pytest.mark.parametrize(
+    "repayment_option, extra",
+    [
+        ("service_and_capital", {"capital_repayment": 5000}),
+        ("flexible_payment", {"flexible_payment": 5000}),
+        ("capital_payment_only", {"capital_repayment": 5000}),
+    ],
+)
+def test_interest_saving_in_schedule(repayment_option, extra):
+    calc = LoanCalculator()
+    params = {
+        "loan_type": "bridge",
+        "gross_amount": 100000,
+        "annual_rate": 12,
+        "loan_term": 12,
+        "currency": "GBP",
+        "repayment_option": repayment_option,
+        "start_date": "2025-01-01",
+    }
+    params.update(extra)
+    result = calc.calculate_bridge_loan(params)
+    schedule = result.get("detailed_payment_schedule")
+    assert schedule, "Schedule should not be empty"
+    values = []
+    for entry in schedule:
+        assert "interest_saving" in entry
+        val = Decimal(entry["interest_saving"].replace("£", "").replace(",", ""))
+        assert val >= 0
+        values.append(val)
+    assert any(v > 0 for v in values)


### PR DESCRIPTION
## Summary
- compute interest-only baseline for service+capital, flexible, and capital-payment-only options
- expose per-period `interest_saving` in bridge and term detailed schedules
- test that detailed schedules include non-negative monthly interest savings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b00f69476483208f1e180097f375e3