### PR TITLE
Show interest savings in schedule report and use fullscreen modal

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -811,9 +811,13 @@ class LoanCalculator {
         const savingsPercentageEl = document.getElementById('savingsPercentageResult');
         
         // Check if we should show interest savings comparison
+        // Support both camelCase and snake_case fields returned from backend
+        const interestOnlyTotalVal = parseFloat(results.interestOnlyTotal ?? results.interest_only_total ?? 0);
+        const interestSavingsVal = parseFloat(results.interestSavings ?? results.interest_savings ?? 0);
+
         const shouldShowInterestComparison = (
-            (results.interestSavings !== undefined && results.interestSavings > 0) ||
-            (results.interestOnlyTotal !== undefined && results.interestOnlyTotal > 0) ||
+            (interestSavingsVal > 0) ||
+            (interestOnlyTotalVal > 0) ||
             (repaymentOption === 'service_and_capital' || repaymentOption === 'capital_payment_only' || repaymentOption === 'flexible_payment')
         );
         
@@ -821,12 +825,11 @@ class LoanCalculator {
             // Show interest-only total row
             if (interestOnlyTotalRow) interestOnlyTotalRow.style.display = 'table-row';
             if (interestOnlyTotalEl) {
-                const interestOnlyTotal = results.interestOnlyTotal || 0;
-                interestOnlyTotalEl.textContent = interestOnlyTotal.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+                interestOnlyTotalEl.textContent = interestOnlyTotalVal.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
             }
             
             // Show interest savings row only if there are actual savings
-            const interestSavings = results.interestSavings || 0;
+            const interestSavings = interestSavingsVal;
             if (interestSavings > 0 && interestSavingsRow) {
                 interestSavingsRow.style.display = 'table-row';
                 if (interestSavingsEl) {
@@ -2264,9 +2267,10 @@ class LoanCalculator {
                 '</tbody></table>';
         }
 
+        const interestSavingsValue = parseFloat(r.interestSavings ?? r.interest_savings ?? 0);
         let interestSavingsHtml = '';
-        if (r.interestSavings && r.interestSavings > 0) {
-            interestSavingsHtml = `<p><strong>Interest Savings:</strong> ${formatMoney(r.interestSavings)} compared to an interest-only loan.</p>`;
+        if (interestSavingsValue > 0) {
+            interestSavingsHtml = `<p><strong>Interest Savings:</strong> ${formatMoney(interestSavingsValue)} compared to an interest-only loan.</p>`;
         }
 
         // Determine interest calculation description

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1043,7 +1043,7 @@
 
 <!-- Calculation Breakdown Modal -->
 <div class="modal fade" id="calculationBreakdownModal" tabindex="-1" aria-labelledby="calculationBreakdownLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-dialog modal-fullscreen modal-dialog-scrollable">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="calculationBreakdownLabel">Calculation Details</h5>


### PR DESCRIPTION
## Summary
- Display interest savings in the detailed report even when backend uses snake_case fields
- Support snake_case fields for interest-only comparisons
- Open the calculation breakdown modal in full screen for easier viewing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b0144764a483208ccbcfeff0ec9ef7