### PR TITLE
Show interest savings in schedule and honor development loan dates

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -1311,11 +1311,11 @@ class LoanCalculator:
             fees = self._calculate_fees(gross_amount, arrangement_fee_rate, legal_fees,
                                       site_visit_fee, title_insurance_rate, 0)
             
-            # Calculate interest for development loan
-            term_years = Decimal(loan_term) / Decimal('12')
+            # Calculate interest for development loan using actual day count
             annual_rate_decimal = annual_rate / Decimal('100')
-            interest_rate = annual_rate_decimal * term_years
-            total_interest = gross_amount * interest_rate
+            days_in_year = Decimal('360') if use_360_days else Decimal('365')
+            term_years = Decimal(loan_term_days) / days_in_year
+            total_interest = gross_amount * annual_rate_decimal * term_years
             
             # Calculate Day 1 advance properly
             total_day1_advance = day1_advance + fees['arrangementFee'] + legal_fees
@@ -1323,10 +1323,15 @@ class LoanCalculator:
             # Get user's tranche input - DO NOT calculate our own
             user_tranches = params.get('tranches', [])
             
+            # Update params with derived values for downstream calculations
+            params['end_date'] = end_date_str
+            params['loan_term_days'] = loan_term_days
+            params['loan_term'] = loan_term
+
             # Return proper calculation result using calculated gross amount
             return self._build_development_loan_result(
-                params, gross_amount, fees, total_interest, 
-                net_amount, property_value, loan_term, annual_rate, 
+                params, gross_amount, fees, total_interest,
+                net_amount, property_value, loan_term, annual_rate,
                 repayment_option, currency, total_day1_advance
             )
         

--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -949,6 +949,7 @@ class LoanCalculator {
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Opening Balance</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Calculation</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Serviced</th>
+                    <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Saving</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Principal Payment</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Total Payment</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Closing Balance</th>
@@ -962,6 +963,7 @@ class LoanCalculator {
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Opening Balance</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Calculation</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Amount</th>
+                    <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Saving</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Principal Payment</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Total Payment</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Closing Balance</th>
@@ -1018,6 +1020,7 @@ class LoanCalculator {
 
         if (isServicedCapital || isCapitalPaymentOnly || isFlexiblePayment) {
             let totalInterest = 0;
+            let totalInterestSaving = 0;
             let totalPrincipal = 0;
             let totalPayment = 0;
 
@@ -1033,6 +1036,7 @@ class LoanCalculator {
                     opening_balance: String(row.opening_balance || '').replace(/[£€]/g, currentSymbol),
                     interest_calculation: String(row.interest_calculation || '').replace(/[£€]/g, currentSymbol).replace(/\s*\+?\s*fees/gi, '').trim(),
                     interest_amount: String(row.interest_amount || '').replace(/[£€]/g, currentSymbol),
+                    interest_saving: String(row.interest_saving || '').replace(/[£€]/g, currentSymbol),
                     principal_payment: String(row.principal_payment || '').replace(/[£€]/g, currentSymbol),
                     total_payment: String(row.total_payment || '').replace(/[£€]/g, currentSymbol),
                     closing_balance: String(row.closing_balance || '').replace(/[£€]/g, currentSymbol),
@@ -1040,10 +1044,12 @@ class LoanCalculator {
                 };
 
                 const interestNumeric = parseFloat(fixedRow.interest_amount.replace(/[^0-9.-]/g, '')) || 0;
+                const interestSavingNumeric = parseFloat(fixedRow.interest_saving.replace(/[^0-9.-]/g, '')) || 0;
                 const principalNumeric = parseFloat(fixedRow.principal_payment.replace(/[^0-9.-]/g, '')) || 0;
                 const totalNumeric = parseFloat(fixedRow.total_payment.replace(/[^0-9.-]/g, '')) || 0;
 
                 totalInterest += interestNumeric;
+                totalInterestSaving += interestSavingNumeric;
                 totalPrincipal += principalNumeric;
                 totalPayment += totalNumeric;
 
@@ -1054,6 +1060,7 @@ class LoanCalculator {
                     <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.opening_balance}</td>
                     <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.interest_calculation}</td>
                     <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.interest_amount}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.interest_saving}</td>
                     <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.principal_payment}</td>
                     <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.total_payment}</td>
                     <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.closing_balance}</td>
@@ -1069,6 +1076,7 @@ class LoanCalculator {
             totalRow.innerHTML = `
                 <td colspan="5" class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">Total</td>
                 <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalInterest.toLocaleString(undefined, {minimumFractionDigits:2, maximumFractionDigits:2})}</td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalInterestSaving.toLocaleString(undefined, {minimumFractionDigits:2, maximumFractionDigits:2})}</td>
                 <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalPrincipal.toLocaleString(undefined, {minimumFractionDigits:2, maximumFractionDigits:2})}</td>
                 <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalPayment.toLocaleString(undefined, {minimumFractionDigits:2, maximumFractionDigits:2})}</td>
                 <td class="py-1 px-2" style="border-right: 1px solid #000;"></td>
@@ -1093,6 +1101,7 @@ class LoanCalculator {
                 tranche_release: String(row.tranche_release || '').replace(/[£€]/g, currentSymbol),
                 interest_calculation: String(row.interest_calculation || '').replace(/[£€]/g, currentSymbol),
                 interest_amount: String(row.interest_amount || '').replace(/[£€]/g, currentSymbol),
+                interest_saving: String(row.interest_saving || '').replace(/[£€]/g, currentSymbol),
                 principal_payment: String(row.principal_payment || '').replace(/[£€]/g, currentSymbol),
                 total_payment: String(row.total_payment || '').replace(/[£€]/g, currentSymbol),
                 closing_balance: String(row.closing_balance || '').replace(/[£€]/g, currentSymbol),
@@ -1116,6 +1125,7 @@ class LoanCalculator {
                 <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.tranche_release}</td>
                 <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.interest_calculation}</td>
                 <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.interest_amount}</td>
+                <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.interest_saving}</td>
                 <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.principal_payment}</td>
                 <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.total_payment}</td>
                 <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.closing_balance}</td>

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -970,7 +970,7 @@
 
 <!-- Visualization Modals -->
 <div class="modal fade" id="paymentScheduleModal" tabindex="-1" aria-labelledby="paymentScheduleLabel" aria-hidden="true">
-  <div class="modal-dialog modal-xl modal-dialog-scrollable">
+  <div class="modal-dialog modal-fullscreen modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header bg-novellus-navy text-white">
         <h5 class="modal-title" id="paymentScheduleLabel">Detailed Payment Schedule</h5>
@@ -987,6 +987,7 @@
                   <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Tranche Release</th>
                   <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Calculation</th>
                   <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Amount</th>
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Saving</th>
                   <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Principal Payment</th>
                   <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Total Payment</th>
                   <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Closing Balance</th>


### PR DESCRIPTION
## Summary
- display an Interest Saving column in the detailed payment schedule and show the modal fullscreen
- use actual day counts when calculating development loan interest and propagate updated dates

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `pip install --break-system-packages pytest` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b01c0d4d0c83209d74c05b4e0987c1