### PR TITLE
Decouple loan date fields

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -254,19 +254,12 @@ class LoanCalculator {
             day1AdvanceField.addEventListener('input', () => this.updateAutoTotalAmount());
         }
 
-        // Start date changes - trigger automatic end date calculation
+        // Start or end date changes - update loan term and day count
         document.getElementById('startDate').addEventListener('change', () => {
             calculateEndDate(); // Global function defined in calculator.html
         });
-
-        // Loan term changes - trigger automatic end date calculation
-        document.getElementById('loanTerm').addEventListener('change', () => {
-            calculateEndDate(); // Global function defined in calculator.html
-        });
-
-        // End date changes - trigger automatic loan term recalculation
         document.getElementById('endDate').addEventListener('change', () => {
-            recalculateLoanTerm(); // Global function defined in calculator.html
+            calculateEndDate(); // Global function defined in calculator.html
         });
 
         // 360-day checkbox changes - trigger automatic recalculation

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -604,7 +604,7 @@
 <div class="">
 <label class="form-label" for="endDate">End Date</label>
 <input class="form-control" id="endDate" name="end_date" style="min-height: 38px; font-size: 1rem;" type="date"/>
-<small class="form-text text-muted">Automatically calculated based on start date and loan term. You can edit manually to override.</small>
+<small class="form-text text-muted">Select start and end dates to calculate the loan term in days.</small>
 </div>
 <!-- Fees Section -->
 <div class="">
@@ -1125,61 +1125,6 @@
 // End date calculation functionality with automatic recalculation
 function calculateEndDate() {
     const startDate = document.getElementById('startDate').value;
-    const loanTerm = parseInt(document.getElementById('loanTerm').value);
-    
-    if (startDate && loanTerm && loanTerm > 0) {
-        const start = new Date(startDate);
-        
-        // Calculate exact days for consistent loan terms
-        let daysToAdd;
-        switch (loanTerm) {
-            case 6:
-                daysToAdd = 181; // 6 months = 181 days (approximately)
-                break;
-            case 12:
-                daysToAdd = 365; // 12 months = exactly 365 days
-                break;
-            case 18:
-                daysToAdd = 548; // 18 months = 548 days (365 + 183)
-                break;
-            case 24:
-                daysToAdd = 730; // 24 months = exactly 730 days (2 years)
-                break;
-            default:
-                // For other terms, use month-based calculation
-                const end = new Date(start);
-                end.setMonth(end.getMonth() + loanTerm);
-                end.setDate(end.getDate() - 1);
-                const endDateInput = document.getElementById('endDate');
-                endDateInput.value = end.toISOString().split('T')[0];
-                triggerCalculationUpdate();
-                return;
-        }
-        
-        // Add the exact number of days
-        const end = new Date(start);
-        end.setDate(end.getDate() + daysToAdd);
-        
-        const endDateInput = document.getElementById('endDate');
-        endDateInput.value = end.toISOString().split('T')[0];
-        
-        console.log(`Calculated end date for ${loanTerm}-month loan: ${daysToAdd} days from ${startDate} = ${end.toISOString().split('T')[0]}`);
-        
-        // Trigger calculation update if calculator instance exists and form has data
-        triggerCalculationUpdate();
-    }
-}
-
-// Make end date editable on click
-function makeEndDateEditable() {
-    const endDateInput = document.getElementById('endDate');
-    endDateInput.removeAttribute('readonly');
-    endDateInput.focus();
-}
-
-// Recalculate loan term when end date is manually changed
-function recalculateLoanTerm() {
-    const startDate = document.getElementById('startDate').value;
     const endDate = document.getElementById('endDate').value;
 
     if (startDate && endDate) {
@@ -1189,40 +1134,23 @@ function recalculateLoanTerm() {
         // Calculate actual days difference
         const timeDiff = end.getTime() - start.getTime();
         const daysDiff = Math.ceil(timeDiff / (1000 * 3600 * 24));
+        console.log(`Date range: ${daysDiff} days between ${startDate} and ${endDate}`);
 
-        console.log(`Manual date change: ${daysDiff} days between ${startDate} and ${endDate}`);
-
-        // Immediately update displayed day count if loan summary exists
+        // Update displayed day count if loan summary exists
         const loanTermDaysEl = document.getElementById('loanTermDaysResult');
         if (loanTermDaysEl) loanTermDaysEl.textContent = daysDiff;
 
-        // Determine loan term based on actual days
-        let loanTerm;
-        if (daysDiff >= 350 && daysDiff <= 380) {
-            loanTerm = 12; // 12-month loan (around 365 days)
-        } else if (daysDiff >= 170 && daysDiff <= 190) {
-            loanTerm = 6; // 6-month loan (around 181 days)
-        } else if (daysDiff >= 530 && daysDiff <= 560) {
-            loanTerm = 18; // 18-month loan (around 548 days)
-        } else if (daysDiff >= 720 && daysDiff <= 740) {
-            loanTerm = 24; // 24-month loan (around 730 days)
-        } else {
-            // For other ranges, calculate exact month difference
-            let monthsDiff = (end.getFullYear() - start.getFullYear()) * 12 +
-                             (end.getMonth() - start.getMonth());
-            if (end.getDate() < start.getDate()) {
-                monthsDiff -= 1;
-            }
-            loanTerm = Math.max(1, monthsDiff);
+        // Determine loan term in months based on dates
+        let monthsDiff = (end.getFullYear() - start.getFullYear()) * 12 +
+                         (end.getMonth() - start.getMonth());
+        if (end.getDate() < start.getDate()) {
+            monthsDiff -= 1;
         }
+        const loanTerm = Math.max(1, monthsDiff);
+        document.getElementById('loanTerm').value = loanTerm;
 
-        if (loanTerm > 0) {
-            document.getElementById('loanTerm').value = loanTerm;
-            console.log(`Set loan term to ${loanTerm} months based on ${daysDiff} days`);
-
-            // Trigger calculation update if calculator instance exists and form has data
-            triggerCalculationUpdate();
-        }
+        // Trigger calculation update if calculator instance exists and form has data
+        triggerCalculationUpdate();
     }
 }
 
@@ -1277,18 +1205,13 @@ document.addEventListener('DOMContentLoaded', function() {
         
         // Add event listeners with error handling
         const startDate = document.getElementById('startDate');
-        const loanTerm = document.getElementById('loanTerm');
         const endDate = document.getElementById('endDate');
-        
+
         if (startDate) {
             startDate.addEventListener('change', calculateEndDate);
         }
-        if (loanTerm) {
-            loanTerm.addEventListener('input', calculateEndDate);
-        }
         if (endDate) {
-            endDate.addEventListener('click', makeEndDateEditable);
-            endDate.addEventListener('change', recalculateLoanTerm);
+            endDate.addEventListener('change', calculateEndDate);
         }
         
         // Initialize the main loan calculator and store global reference


### PR DESCRIPTION
## Summary
- stop auto-adjusting end date when start date or term changes
- recompute loan term and day count based on user-selected dates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b025cd5f60832098139b80089a9b39