### PR TITLE
Sync loan term with date fields

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -254,13 +254,26 @@ class LoanCalculator {
             day1AdvanceField.addEventListener('input', () => this.updateAutoTotalAmount());
         }
 
-        // Start or end date changes - update loan term and day count
-        document.getElementById('startDate').addEventListener('change', () => {
-            calculateEndDate(); // Global function defined in calculator.html
-        });
-        document.getElementById('endDate').addEventListener('change', () => {
-            calculateEndDate(); // Global function defined in calculator.html
-        });
+        // Start, end date or term changes - update related fields and day count
+        const startDateField = document.getElementById('startDate');
+        const endDateField = document.getElementById('endDate');
+        const loanTermField = document.getElementById('loanTerm');
+
+        if (startDateField) {
+            startDateField.addEventListener('change', () => {
+                calculateEndDate('start'); // Global function defined in calculator.html
+            });
+        }
+        if (endDateField) {
+            endDateField.addEventListener('change', () => {
+                calculateEndDate('end');
+            });
+        }
+        if (loanTermField) {
+            loanTermField.addEventListener('input', () => {
+                calculateEndDate('term');
+            });
+        }
 
         // 360-day checkbox changes - trigger automatic recalculation
         const use360DaysCheckbox = document.getElementById('use360Days');

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1122,32 +1122,50 @@
 <script src="{{ url_for('static', filename='js/notifications.js') }}"></script>
 <script src="{{ url_for('static', filename='js/calculator.js') }}"></script>
 <script>
-// End date calculation functionality with automatic recalculation
-function calculateEndDate() {
-    const startDate = document.getElementById('startDate').value;
-    const endDate = document.getElementById('endDate').value;
+// Synchronise start date, end date and loan term fields
+function calculateEndDate(trigger) {
+    const startDateEl = document.getElementById('startDate');
+    const endDateEl = document.getElementById('endDate');
+    const loanTermEl = document.getElementById('loanTerm');
 
-    if (startDate && endDate) {
-        const start = new Date(startDate);
-        const end = new Date(endDate);
+    const startDate = startDateEl.value;
+    const endDate = endDateEl.value;
+    const termMonths = parseInt(loanTermEl.value);
 
-        // Calculate actual days difference
+    let start, end;
+
+    // If loan term changed (or start date changed with existing term), calculate end date
+    if ((trigger === 'term' || trigger === 'start') && startDate && termMonths) {
+        start = new Date(startDate);
+        end = new Date(startDate);
+        end.setMonth(end.getMonth() + termMonths);
+        // Set date to previous day to represent end of period
+        end.setDate(end.getDate() - 1);
+        endDateEl.value = end.toISOString().split('T')[0];
+    } else if (startDate && endDate) {
+        start = new Date(startDate);
+        end = new Date(endDate);
+    }
+
+    // When we have both start and end dates, update day count and loan term if needed
+    if (start && end) {
         const timeDiff = end.getTime() - start.getTime();
         const daysDiff = Math.ceil(timeDiff / (1000 * 3600 * 24));
-        console.log(`Date range: ${daysDiff} days between ${startDate} and ${endDate}`);
+        console.log(`Date range: ${daysDiff} days between ${start.toISOString().split('T')[0]} and ${end.toISOString().split('T')[0]}`);
 
-        // Update displayed day count if loan summary exists
         const loanTermDaysEl = document.getElementById('loanTermDaysResult');
         if (loanTermDaysEl) loanTermDaysEl.textContent = daysDiff;
 
-        // Determine loan term in months based on dates
-        let monthsDiff = (end.getFullYear() - start.getFullYear()) * 12 +
-                         (end.getMonth() - start.getMonth());
-        if (end.getDate() < start.getDate()) {
-            monthsDiff -= 1;
+        // Only overwrite loan term when not triggered by loan term field
+        if (trigger !== 'term') {
+            let monthsDiff = (end.getFullYear() - start.getFullYear()) * 12 +
+                             (end.getMonth() - start.getMonth());
+            if (end.getDate() < start.getDate()) {
+                monthsDiff -= 1;
+            }
+            const loanTerm = Math.max(1, monthsDiff);
+            loanTermEl.value = loanTerm;
         }
-        const loanTerm = Math.max(1, monthsDiff);
-        document.getElementById('loanTerm').value = loanTerm;
 
         // Trigger calculation update if calculator instance exists and form has data
         triggerCalculationUpdate();
@@ -1206,12 +1224,16 @@ document.addEventListener('DOMContentLoaded', function() {
         // Add event listeners with error handling
         const startDate = document.getElementById('startDate');
         const endDate = document.getElementById('endDate');
+        const loanTerm = document.getElementById('loanTerm');
 
         if (startDate) {
-            startDate.addEventListener('change', calculateEndDate);
+            startDate.addEventListener('change', () => calculateEndDate('start'));
         }
         if (endDate) {
-            endDate.addEventListener('change', calculateEndDate);
+            endDate.addEventListener('change', () => calculateEndDate('end'));
+        }
+        if (loanTerm) {
+            loanTerm.addEventListener('input', () => calculateEndDate('term'));
         }
         
         // Initialize the main loan calculator and store global reference


### PR DESCRIPTION
## Summary
- synchronize start date, end date, and loan term inputs so changes to term months compute a new end date and day count
- update event listeners for dates and term months to trigger recalculation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b03031e2708320a040b6ea24af4139