### PR TITLE
Handle capital payment interest refunds

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -4241,8 +4241,10 @@ class LoanCalculator:
                 elif period < len(payment_dates):
                     if capital_per_payment > remaining_balance:
                         capital_per_payment = remaining_balance
+                    interest_only = (opening_balance - capital_per_payment) * baseline_rate
+                    interest_refund_current = max(interest_retained_current - interest_only, Decimal('0'))
                     interest_amount = Decimal('0')
-                    interest_saving = max(interest_only - interest_amount, Decimal('0'))
+                    interest_saving = interest_refund_current
                     balance_change = f"↓ -{currency_symbol}{capital_per_payment:,.2f}" if capital_per_payment > 0 else "↔ No Change"
                     closing_balance = remaining_balance - capital_per_payment
                     detailed_schedule.append({
@@ -4253,7 +4255,7 @@ class LoanCalculator:
                         'interest_amount': f"{currency_symbol}{interest_amount:,.2f}",
                         'interest_saving': f"{currency_symbol}{interest_saving:,.2f}",
                         'principal_payment': f"{currency_symbol}{capital_per_payment:,.2f}",
-                        'total_payment': f"{currency_symbol}{capital_per_payment:,.2f}",
+                        'total_payment': f"{currency_symbol}{(capital_per_payment - interest_refund_current):,.2f}",
                         'closing_balance': f"{currency_symbol}{closing_balance:,.2f}",
                         'balance_change': balance_change,
                         'capital_outstanding': f"{currency_symbol}{opening_balance:,.2f}",
@@ -4262,7 +4264,7 @@ class LoanCalculator:
                         'scheduled_repayment': f"{currency_symbol}{capital_per_payment:,.2f}",
                         'interest_accrued': f"{currency_symbol}{interest_only:,.2f}",
                         'interest_retained': f"{currency_symbol}{interest_retained_current:,.2f}",
-                        'interest_refund': f"{currency_symbol}0.00",
+                        'interest_refund': f"{currency_symbol}{interest_refund_current:,.2f}",
                         'running_ltv': f"{running_ltv:.2f}"
                     })
                     remaining_balance = closing_balance

--- a/test_capital_payment_schedule_values.py
+++ b/test_capital_payment_schedule_values.py
@@ -1,0 +1,46 @@
+import sys, types
+
+relativedelta_module = types.ModuleType('relativedelta')
+class relativedelta:
+    def __init__(self, months=0):
+        self.months = months
+    def __radd__(self, other):
+        from datetime import date
+        month = other.month - 1 + self.months
+        year = other.year + month // 12
+        month = month % 12 + 1
+        day = min(other.day, [31,29 if year %4==0 and (year%100!=0 or year%400==0) else 28,31,30,31,30,31,31,30,31,30,31][month-1])
+        return other.replace(year=year, month=month, day=day)
+relativedelta_module.relativedelta = relativedelta
+sys.modules['dateutil'] = types.ModuleType('dateutil')
+sys.modules['dateutil'].relativedelta = relativedelta_module
+sys.modules['dateutil.relativedelta'] = relativedelta_module
+
+from decimal import Decimal
+from calculations import LoanCalculator
+
+def currency_to_decimal(value):
+    return Decimal(value.replace('£','').replace(',',''))
+
+def test_capital_payment_only_interest_refund():
+    calc = LoanCalculator()
+    params = {
+        'loan_type': 'bridge',
+        'repayment_option': 'capital_payment_only',
+        'gross_amount': 2000000,
+        'loan_term': 12,
+        'annual_rate': 12,
+        'capital_repayment': 200000,
+        'arrangement_fee_rate': 0,
+        'legal_fees': 0,
+        'site_visit_fee': 0,
+        'title_insurance_rate': 0,
+        'start_date': '2025-08-01',
+        'property_value': 3000000,
+    }
+    result = calc.calculate_bridge_loan(params)
+    schedule = result['detailed_payment_schedule']
+    first_interest = currency_to_decimal(schedule[0]['interest_accrued'])
+    second_refund = currency_to_decimal(schedule[1]['interest_refund'])
+    assert first_interest == Decimal('20000.00')
+    assert second_refund == Decimal('2000.00')


### PR DESCRIPTION
## Summary
- compute interest refund for each capital-payment-only schedule period
- test capital payment schedule refund calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1759587ec8320b2e9c42d8b4854e3