### PR TITLE
Ensure interest accrued schedule total matches summary

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -4368,10 +4368,15 @@ class LoanCalculator:
                     total_accrued += Decimal(acc_str)
                 except Exception:
                     continue
-            diff = expected_accrued - total_accrued
-            if abs(diff) > Decimal('0.01'):
+            # Adjust final period so that interest accrued column matches
+            # the loan summary interest to the penny. Round the difference to
+            # 2 decimal places and apply it to the last entry if needed.
+            diff = (expected_accrued - total_accrued).quantize(Decimal('0.01'))
+            if diff != 0:
                 last = detailed_schedule[-1]
-                last_acc = Decimal(last.get('interest_accrued', f"{currency_symbol}0").replace(currency_symbol, '').replace(',', ''))
+                last_acc = Decimal(
+                    last.get('interest_accrued', f"{currency_symbol}0").replace(currency_symbol, '').replace(',', '')
+                )
                 last['interest_accrued'] = f"{currency_symbol}{(last_acc + diff):,.2f}"
 
         # Attach period info to all entries

--- a/test_interest_accrued_total.py
+++ b/test_interest_accrued_total.py
@@ -17,7 +17,7 @@ sys.modules['dateutil'] = types.ModuleType('dateutil')
 sys.modules['dateutil'].relativedelta = relativedelta_module
 sys.modules['dateutil.relativedelta'] = relativedelta_module
 
-from decimal import Decimal
+from decimal import Decimal, ROUND_HALF_UP
 import pytest
 from calculations import LoanCalculator
 
@@ -45,6 +45,10 @@ def test_interest_accrued_matches_summary():
     for entry in schedule:
         amt = entry['interest_accrued'].replace('£', '').replace(',', '')
         total_accrued += Decimal(amt)
+    total_accrued = total_accrued.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
 
-    summary_accrued = Decimal(str(result.get('retainedInterest', result.get('interestOnlyTotal', 0))))
-    assert float(total_accrued) == pytest.approx(float(summary_accrued))
+    summary_accrued = Decimal(
+        str(result.get('retainedInterest', result.get('interestOnlyTotal', 0)))
+    ).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+
+    assert total_accrued == summary_accrued


### PR DESCRIPTION
## Summary
- Correct detailed payment schedule to round final interest accrued amount so total equals loan summary interest to the penny.
- Add regression test enforcing exact equality between schedule interest accrued column and loan summary.

## Testing
- `pytest test_interest_accrued_total.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b17ea698588320a3ea37e78d5671f4