### PR TITLE
Fix interest accrued totals

### DIFF
--- a/test_interest_accrued_total.py
+++ b/test_interest_accrued_total.py
@@ -47,8 +47,16 @@ def test_interest_accrued_matches_summary():
         total_accrued += Decimal(amt)
     total_accrued = total_accrued.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
 
-    summary_accrued = Decimal(
-        str(result.get('retainedInterest', result.get('interestOnlyTotal', 0)))
-    ).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+    summary_accrued = Decimal(str(result.get('totalInterest', 0))).quantize(
+        Decimal('0.01'), rounding=ROUND_HALF_UP
+    )
+
+    retained = Decimal(str(result.get('retainedInterest'))).quantize(
+        Decimal('0.01'), rounding=ROUND_HALF_UP
+    )
+    interest_only_total = Decimal(str(result.get('interestOnlyTotal'))).quantize(
+        Decimal('0.01'), rounding=ROUND_HALF_UP
+    )
 
     assert total_accrued == summary_accrued
+    assert retained == interest_only_total


### PR DESCRIPTION
## Summary
- ensure detailed bridge schedule's interest accrued total equals net interest rather than retained interest
- verify interest retained equals interest-only total and interest accrued total aligns with net interest

## Testing
- `pytest test_interest_accrued_total.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b18295db98832098f593372b02cf0d