### PR TITLE
Align interest refund with retained minus accrued

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -4373,6 +4373,16 @@ class LoanCalculator:
                 )
                 last['interest_accrued'] = f"{currency_symbol}{(last_acc + diff):,.2f}"
 
+        # Ensure interest refund equals retained minus accrued for capital repayments
+        if params.get('repayment_option') == 'capital_payment_only':
+            for entry in detailed_schedule:
+                try:
+                    retained_val = Decimal(entry.get('interest_retained', f"{currency_symbol}0").replace(currency_symbol, '').replace(',', ''))
+                    accrued_val = Decimal(entry.get('interest_accrued', f"{currency_symbol}0").replace(currency_symbol, '').replace(',', ''))
+                    entry['interest_refund'] = f"{currency_symbol}{(retained_val - accrued_val):,.2f}"
+                except Exception:
+                    continue
+
         # Attach period info to all entries
         for i, entry in enumerate(detailed_schedule):
             if i < len(period_ranges):

--- a/test_capital_payment_schedule_values.py
+++ b/test_capital_payment_schedule_values.py
@@ -66,3 +66,28 @@ def test_capital_payment_only_refund_totals_match():
     schedule = result['detailed_payment_schedule']
     refund_total = sum(abs(currency_to_decimal(r['interest_refund'])) for r in schedule)
     assert refund_total.quantize(Decimal('0.01')) == Decimal(str(result['interestRefund'])).quantize(Decimal('0.01'))
+
+
+def test_capital_payment_only_refund_equals_retained_minus_accrued():
+    calc = LoanCalculator()
+    params = {
+        'loan_type': 'bridge',
+        'repayment_option': 'capital_payment_only',
+        'gross_amount': 2000000,
+        'loan_term': 12,
+        'annual_rate': 12,
+        'capital_repayment': 200000,
+        'arrangement_fee_rate': 0,
+        'legal_fees': 0,
+        'site_visit_fee': 0,
+        'title_insurance_rate': 0,
+        'start_date': '2025-08-01',
+        'property_value': 3000000,
+    }
+    result = calc.calculate_bridge_loan(params)
+    schedule = result['detailed_payment_schedule']
+    for entry in schedule:
+        retained = currency_to_decimal(entry['interest_retained'])
+        accrued = currency_to_decimal(entry['interest_accrued'])
+        refund = currency_to_decimal(entry['interest_refund'])
+        assert refund.quantize(Decimal('0.01')) == (retained - accrued).quantize(Decimal('0.01'))


### PR DESCRIPTION
## Summary
- Ensure detailed payment schedule interest refund equals retained interest minus accrued interest for capital repayment only loans
- Add regression test validating refund equals retained minus accrued

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b188b38dd483208cd85044a12a6931