### PR TITLE
Use daily interest for capital payment only loans

### DIFF
--- a/test_capital_payment_schedule_values.py
+++ b/test_capital_payment_schedule_values.py
@@ -42,8 +42,8 @@ def test_capital_payment_only_interest_refund():
     schedule = result['detailed_payment_schedule']
     first_interest = currency_to_decimal(schedule[0]['interest_accrued'])
     second_refund = currency_to_decimal(schedule[1]['interest_refund'])
-    assert first_interest == Decimal('20000.00')
-    assert second_refund == Decimal('2000.00')
+    assert first_interest == Decimal('20383.56')
+    assert second_refund == Decimal('1972.60')
 
 
 def test_capital_payment_only_refund_totals_match():

--- a/test_interest_retained_split.py
+++ b/test_interest_retained_split.py
@@ -43,14 +43,16 @@ def test_interest_retained_split_monthly():
         'site_visit_fee': 0,
         'title_insurance_rate': 0,
         'property_value': 3000000,
+        'start_date': '2025-01-01',
     }
     result = calc.calculate_bridge_loan(params)
     schedule = result['detailed_payment_schedule']
     retained_total = Decimal(str(result['retainedInterest']))
     periods = len(schedule)
     first_period_retained = Decimal(schedule[0]['interest_retained'].replace('£', '').replace(',', ''))
-    # Expect first period retained to be roughly total/periods
-    expected = retained_total / periods
+    expected = calc.calculate_simple_interest_by_days(
+        Decimal('2000000'), Decimal('7'), 31, False
+    )
     assert abs(first_period_retained - expected) < Decimal('0.01')
     # Ensure total retained across schedule equals retainedInterest
     total_split = sum(Decimal(entry['interest_retained'].replace('£', '').replace(',', '')) for entry in schedule)


### PR DESCRIPTION
## Summary
- compute retained interest using daily rate and actual day counts
- apply day-based interest in capital-payment-only bridge schedules
- update tests for daily interest expectations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1917973b88320b969254dbb921357