### PR TITLE
Fix month-end payment date calculation for short months

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -3423,7 +3423,11 @@ class LoanCalculator:
                     payment_date = self._add_months(start_date, month)
                 else:
                     # Payment at end of month
-                    payment_date = self._add_months(start_date, month + 1) - timedelta(days=1)
+                    next_date = self._add_months(start_date, month + 1)
+                    if next_date.day < start_date.day:
+                        payment_date = next_date
+                    else:
+                        payment_date = next_date - timedelta(days=1)
 
                 # Only include payments within loan period
                 if payment_date <= loan_end_date:

--- a/test_payment_schedule_day_counts.py
+++ b/test_payment_schedule_day_counts.py
@@ -42,3 +42,24 @@ def test_payment_schedule_uses_calendar_days():
     schedule = result['detailed_payment_schedule']
     assert schedule[0]['days_held'] == 31
     assert schedule[1]['days_held'] == 29
+
+
+def test_payment_schedule_handles_short_month_rollover():
+    calc = LoanCalculator()
+    params = {
+        'loan_type': 'bridge',
+        'repayment_option': 'service_only',
+        'gross_amount': 100000,
+        'loan_term': 2,
+        'annual_rate': 12,
+        'arrangement_fee_rate': 0,
+        'legal_fees': 0,
+        'site_visit_fee': 0,
+        'title_insurance_rate': 0,
+        'payment_timing': 'arrears',
+        'start_date': '2026-01-29',
+    }
+    result = calc.calculate_bridge_loan(params)
+    schedule = result['detailed_payment_schedule']
+    assert schedule[0]['days_held'] == 31
+    assert schedule[0]['end_period'] == '28/02/2026'


### PR DESCRIPTION
## Summary
- Correct monthly payment date generation so arrears schedules roll to the final day of shorter months
- Add regression test covering January to February rollover

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b19d28147883209c3ea22203138fbb