### PR TITLE
Synchronize loan summary with payment schedule totals

### DIFF
--- a/test_bridge_capital_only_savings_value.py
+++ b/test_bridge_capital_only_savings_value.py
@@ -20,5 +20,5 @@ def test_capital_payment_only_uses_actual_days_for_savings():
         'payment_timing': 'arrears',
     }
     result = calc.calculate_bridge_loan(params)
-    assert result['interestSavings'] == pytest.approx(19785.21, abs=0.01)
-    assert result['totalInterest'] == pytest.approx(220214.79, abs=0.01)
+    assert result['interestSavings'] == pytest.approx(19785.22, abs=0.01)
+    assert result['totalInterest'] == pytest.approx(220214.78, abs=0.01)


### PR DESCRIPTION
## Summary
- Recompute loan summary interest, savings, and retained interest from the detailed payment schedule
- Apply the same aggregation for term loan schedules
- Update test expectations for capital payment-only savings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1ddc205d48320896e0485e6dd40db