### PR TITLE
Handle service and flexible payment schedules without dateutil

### DIFF
--- a/report_utils.py
+++ b/report_utils.py
@@ -1,5 +1,49 @@
+"""Utility helpers for payment schedule generation used in reports."""
+
 from typing import Any, Dict, List
+
 from calculations import LoanCalculator
+
+
+# Provide a minimal fallback for ``dateutil.relativedelta`` so that schedule
+# generation can run in environments where the optional dependency is missing
+# (such as the execution sandbox used for the tests).  Only the behaviour
+# needed by the loan calculator is implemented – addition of whole months.
+try:  # pragma: no cover - prefer the real library when available
+    from dateutil.relativedelta import relativedelta as _relativedelta  # type: ignore
+except Exception:  # pragma: no cover
+    import sys
+    import types
+    from datetime import datetime
+
+    class _relativedelta:  # minimal replacement
+        def __init__(self, months: int = 0):
+            self.months = months
+
+        # ``datetime + relativedelta(months=n)`` is used in the calculator.  We
+        # implement the right-hand addition protocol so this class behaves the
+        # same for that use case.
+        def __radd__(self, other: datetime) -> datetime:
+            month = other.month - 1 + self.months
+            year = other.year + month // 12
+            month = month % 12 + 1
+            # Clamp the day to the last valid day of the target month.
+            month_lengths = [31, 29 if (year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)) else 28,
+                             31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+            day = min(other.day, month_lengths[month - 1])
+            return other.replace(year=year, month=month, day=day)
+
+    # Register the stub so ``from dateutil.relativedelta import relativedelta``
+    # works inside the calculator.
+    stub_module = types.ModuleType("relativedelta")
+    stub_module.relativedelta = _relativedelta
+    dateutil_module = sys.modules.setdefault("dateutil", types.ModuleType("dateutil"))
+    dateutil_module.relativedelta = stub_module
+    sys.modules["dateutil.relativedelta"] = stub_module
+
+    relativedelta = _relativedelta
+else:  # pragma: no cover
+    relativedelta = _relativedelta
 
 
 def generate_report_schedule(params: Dict[str, Any]) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- add minimal `relativedelta` stub to avoid mandatory dateutil dependency
- normalize service+capital and flexible payment schedules by reusing capital payment-only logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ed66d44c83208b0109fb3e305409