### PR TITLE
Correct advance interest aggregation

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -4306,7 +4306,7 @@ class LoanCalculator:
 
         # Aggregate totals from the detailed schedule and update loan summary fields
         if detailed_schedule:
-            total_interest = Decimal('0')
+            total_interest_amt = Decimal('0')
             total_savings = Decimal('0')
             total_retained = Decimal('0')
             total_refund = Decimal('0')
@@ -4314,7 +4314,7 @@ class LoanCalculator:
             for entry in detailed_schedule:
                 try:
                     amt = entry.get('interest_amount', f"{currency_symbol}0").replace(currency_symbol, '').replace(',', '')
-                    total_interest += Decimal(amt)
+                    total_interest_amt += Decimal(amt)
                 except Exception:
                     pass
                 try:
@@ -4339,16 +4339,12 @@ class LoanCalculator:
                     pass
 
             rounding = Decimal('0.01')
-            if payment_timing == 'advance':
-                if total_interest:
-                    total_interest = total_interest.quantize(rounding, rounding=ROUND_HALF_UP)
-                    calculation['totalInterest'] = float(total_interest)
-                    calculation['total_interest'] = float(total_interest)
-            else:
-                if total_accrued:
-                    total_accrued = total_accrued.quantize(rounding, rounding=ROUND_HALF_UP)
-                    calculation['totalInterest'] = float(total_accrued)
-                    calculation['total_interest'] = float(total_accrued)
+            total_interest = total_accrued if total_accrued else total_interest_amt
+            if total_interest:
+                total_interest = total_interest.quantize(rounding, rounding=ROUND_HALF_UP)
+                calculation['totalInterest'] = float(total_interest)
+                calculation['total_interest'] = float(total_interest)
+
             if total_savings:
                 total_savings = total_savings.quantize(rounding, rounding=ROUND_HALF_UP)
                 calculation['interestSavings'] = float(total_savings)
@@ -4358,7 +4354,7 @@ class LoanCalculator:
             if total_refund:
                 total_refund = total_refund.quantize(rounding, rounding=ROUND_HALF_UP)
                 calculation['interestRefund'] = float(total_refund)
-            if payment_timing == 'advance' and total_accrued:
+            if total_accrued:
                 total_accrued = total_accrued.quantize(rounding, rounding=ROUND_HALF_UP)
                 calculation['total_interest_accrued'] = float(total_accrued)
 

--- a/test_capital_payment_schedule_values.py
+++ b/test_capital_payment_schedule_values.py
@@ -115,5 +115,9 @@ def test_capital_payment_only_advance_totals_match():
     }
     result = calc.calculate_bridge_loan(params)
     schedule = result['detailed_payment_schedule']
-    total_interest_schedule = sum(currency_to_decimal(r['interest_amount']) for r in schedule)
-    assert total_interest_schedule.quantize(Decimal('0.01')) == Decimal(str(result['totalInterest'])).quantize(Decimal('0.01'))
+    total_accrued = sum(currency_to_decimal(r['interest_accrued']) for r in schedule)
+    retained = Decimal(str(result['retainedInterest']))
+    refund = Decimal(str(result['interestRefund']))
+    summary_interest = Decimal(str(result['totalInterest']))
+    assert total_accrued.quantize(Decimal('0.01')) == summary_interest.quantize(Decimal('0.01'))
+    assert (retained - refund).quantize(Decimal('0.01')) == summary_interest.quantize(Decimal('0.01'))

--- a/test_service_and_capital_schedule_summary.py
+++ b/test_service_and_capital_schedule_summary.py
@@ -46,7 +46,7 @@ def test_service_and_capital_summary_matches_schedule():
     result = calc.calculate_bridge_loan(params)
     schedule = result['detailed_payment_schedule']
 
-    interest_total = sum(_currency_to_decimal(r['interest_amount']) for r in schedule)
+    interest_total = sum(_currency_to_decimal(r.get('interest_accrued', r['interest_amount'])) for r in schedule)
     capital_total = sum(_currency_to_decimal(r['principal_payment']) for r in schedule)
     closing_balance = _currency_to_decimal(schedule[-1]['closing_balance'])
 


### PR DESCRIPTION
## Summary
- compute total interest from accrued amounts instead of net payments
- ensure retained interest minus refunds aligns with summary totals
- test advance schedules against detailed interest accruals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b21441d4cc8320a995ab0aae422f33