### PR TITLE
Fix flexible payment interest allocation

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -3523,7 +3523,15 @@ class LoanCalculator:
         repayment_option = quote_data.get('repaymentOption', quote_data.get('repayment_option', 'none'))
         gross_amount = Decimal(str(quote_data.get('grossAmount', quote_data.get('gross_amount', 0))))
         loan_term = int(quote_data.get('loanTerm', quote_data.get('loan_term', 12)))
-        annual_rate = Decimal(str(quote_data.get('interestRate', quote_data.get('interest_rate', 0))))
+        # Accept both legacy and new field names for interest rate
+        annual_rate = Decimal(
+            str(
+                quote_data.get(
+                    'interestRate',
+                    quote_data.get('interest_rate', quote_data.get('annual_rate', 0))
+                )
+            )
+        )
         monthly_rate = annual_rate / 12
         
         # Get fees for first month display
@@ -3723,7 +3731,15 @@ class LoanCalculator:
 
             payment_timing = quote_data.get('payment_timing', 'advance')
             payment_frequency = quote_data.get('payment_frequency', 'monthly')
-            flexible_payment = Decimal(str(quote_data.get('flexible_payment', 0)))
+            # "Flexible Payment per Payment" may arrive in either snake or camel case
+            flexible_payment = Decimal(
+                str(
+                    quote_data.get(
+                        'flexible_payment',
+                        quote_data.get('flexiblePayment', 0)
+                    )
+                )
+            )
 
             start_date_str = quote_data.get('start_date', datetime.now().strftime('%Y-%m-%d'))
             if isinstance(start_date_str, str):

--- a/test_flexible_payment_interest_allocation.py
+++ b/test_flexible_payment_interest_allocation.py
@@ -1,0 +1,23 @@
+import math
+from calculations import LoanCalculator
+
+def test_flexible_payment_interest_split():
+    calc = LoanCalculator()
+    quote_data = {
+        'loan_type': 'bridge',
+        'repayment_option': 'flexible_payment',
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'flexiblePayment': 2000,
+        'payment_frequency': 'monthly',
+        'payment_timing': 'arrears',
+        'start_date': '2024-01-01',
+        'arrangementFee': 0,
+        'totalLegalFees': 0,
+    }
+    schedule = calc.generate_payment_schedule(quote_data)
+    first = schedule[0]
+    assert math.isclose(first['interest'], 1000.0, rel_tol=1e-9)
+    assert math.isclose(first['principal'], 1000.0, rel_tol=1e-9)
+    assert math.isclose(first['closing_balance'], 99000.0, rel_tol=1e-9)


### PR DESCRIPTION
## Summary
- handle legacy and new interest-rate field names when generating bridge schedules
- correctly parse Flexible Payment per Payment field in snake or camel case
- add regression test ensuring flexible payments split interest and principal

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b22367a2488320b6f56bcdb49b8dfa