### PR TITLE
Handle camelCase flexible payment in report schedule

### DIFF
--- a/report_utils.py
+++ b/report_utils.py
@@ -64,6 +64,6 @@ def generate_report_schedule(params: Dict[str, Any]) -> List[Dict[str, Any]]:
         cap_params = params.copy()
         cap_params['repayment_option'] = 'capital_payment_only'
         if repayment_option == 'flexible_payment' and 'capital_repayment' not in cap_params:
-            cap_params['capital_repayment'] = params.get('flexible_payment', 0)
+            cap_params['capital_repayment'] = params.get('flexible_payment', params.get('flexiblePayment', 0))
         return calc.calculate_bridge_loan(cap_params).get('detailed_payment_schedule', [])
     return calc.calculate_bridge_loan(params).get('detailed_payment_schedule', [])

--- a/test_service_and_flexible_schedule_match_capital.py
+++ b/test_service_and_flexible_schedule_match_capital.py
@@ -33,6 +33,22 @@ def test_flexible_payment_matches_capital_payment_schedule():
     assert flex_schedule == capital_schedule
 
 
+def test_flexible_payment_camel_case_matches_capital_payment_schedule():
+    base = {
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'payment_frequency': 'monthly',
+        'payment_timing': 'arrears',
+        'start_date': '2024-01-01',
+    }
+    params_capital = dict(base, repayment_option='capital_payment_only', capital_repayment=2000)
+    params_flex = dict(base, repayment_option='flexible_payment', flexiblePayment=2000)
+    capital_schedule = generate_report_schedule(params_capital)
+    flex_schedule = generate_report_schedule(params_flex)
+    assert flex_schedule == capital_schedule
+
+
 def test_schedule_field_sets_match_capital_format():
     base = {
         'gross_amount': 100000,


### PR DESCRIPTION
## Summary
- treat `flexiblePayment` and `flexible_payment` keys interchangeably when generating report schedules
- add regression test ensuring camelCase `flexiblePayment` matches capital-payment schedule

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b230625ba88320a11f796b9c5bd007