### PR TITLE
Ensure flexible payment sets capital repayment

### DIFF
--- a/report_utils.py
+++ b/report_utils.py
@@ -63,7 +63,7 @@ def generate_report_schedule(params: Dict[str, Any]) -> List[Dict[str, Any]]:
     if repayment_option in ('service_and_capital', 'flexible_payment'):
         cap_params = params.copy()
         cap_params['repayment_option'] = 'capital_payment_only'
-        if repayment_option == 'flexible_payment' and 'capital_repayment' not in cap_params:
+        if repayment_option == 'flexible_payment':
             cap_params['capital_repayment'] = params.get('flexible_payment', params.get('flexiblePayment', 0))
         return calc.calculate_bridge_loan(cap_params).get('detailed_payment_schedule', [])
     return calc.calculate_bridge_loan(params).get('detailed_payment_schedule', [])


### PR DESCRIPTION
## Summary
- Always set `capital_repayment` when generating report schedules for `flexible_payment`
- Support both `flexible_payment` and `flexiblePayment` keys when deriving the value

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b232b3635883209386d020e116e84e