### PR TITLE
Fix service+capital advance summary totals

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -455,7 +455,6 @@ class LoanCalculator:
             # Align summary totals with detailed schedule
             detailed_schedule = calculation.get('detailed_payment_schedule', [])
             if detailed_schedule:
-                total_interest_from_schedule = Decimal('0')
                 total_savings_from_schedule = Decimal('0')
                 total_interest_only_from_schedule = Decimal('0')
                 for payment in detailed_schedule:
@@ -465,10 +464,10 @@ class LoanCalculator:
                     saving_numeric = saving_str.replace('£', '').replace('€', '').replace(',', '')
                     interest_val = Decimal(interest_numeric) if interest_numeric else Decimal('0')
                     saving_val = Decimal(saving_numeric) if saving_numeric else Decimal('0')
-                    total_interest_from_schedule += interest_val
                     total_savings_from_schedule += saving_val
                     total_interest_only_from_schedule += interest_val + saving_val
 
+                total_interest_from_schedule = total_interest_only_from_schedule - total_savings_from_schedule
                 calculation['totalInterest'] = self._two_dp(total_interest_from_schedule)
                 calculation['total_interest'] = calculation['totalInterest']
                 calculation['interestSavings'] = self._two_dp(total_savings_from_schedule)

--- a/test_service_and_capital_schedule_summary.py
+++ b/test_service_and_capital_schedule_summary.py
@@ -56,5 +56,10 @@ def test_service_and_capital_summary_matches_schedule():
     assert interest_total.quantize(Decimal('0.01')) == Decimal(str(result['totalInterest'])).quantize(Decimal('0.01'))
     assert savings_total.quantize(Decimal('0.01')) == Decimal(str(result['interestSavings'])).quantize(Decimal('0.01'))
     assert interest_only_total.quantize(Decimal('0.01')) == Decimal(str(result['interestOnlyTotal'])).quantize(Decimal('0.01'))
+    # Derived summary check
+    summary_interest_only = Decimal(str(result['interestOnlyTotal']))
+    summary_savings = Decimal(str(result['interestSavings']))
+    summary_interest = Decimal(str(result['totalInterest']))
+    assert summary_interest.quantize(Decimal('0.01')) == (summary_interest_only - summary_savings).quantize(Decimal('0.01'))
     assert capital_total.quantize(Decimal('0.01')) == Decimal(str(result['gross_amount'])).quantize(Decimal('0.01'))
     assert closing_balance == Decimal('0')


### PR DESCRIPTION
## Summary
- derive service+capital interest summary from detailed schedule to ensure totals align when payments are made in advance
- add regression test asserting summary totals reconcile with payment schedule

## Testing
- `pytest test_service_and_capital_schedule_summary.py -q`
- `pytest -q` *(fails: test_ltv_target_capital_payment_only)*

------
https://chatgpt.com/codex/tasks/task_e_68b240d338688320b715c6233fc89cde