### PR TITLE
Show amortisation details in flexible payment schedules

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -4119,6 +4119,12 @@ class LoanCalculator:
                 balance_change = (
                     f"↓ -{currency_symbol}{principal_payment:,.2f}" if principal_payment > 0 else "↔ No Change"
                 )
+
+                amortisation_calc = (
+                    f"{currency_symbol}{opening_balance:,.2f} - "
+                    f"{currency_symbol}{principal_payment:,.2f} = "
+                    f"{currency_symbol}{remaining_balance:,.2f}"
+                )
                 detailed_schedule.append({
                     'payment_date': payment_date.strftime('%d/%m/%Y'),
                     'start_period': period_start.strftime('%d/%m/%Y'),
@@ -4133,7 +4139,8 @@ class LoanCalculator:
                     'total_payment': f"{currency_symbol}{total_payment:,.2f}" + (f" + {currency_symbol}{fees_added:,.2f} fees" if period == 1 and fees_added > 0 and interest_paid > 0 else ""),
                     'closing_balance': f"{currency_symbol}{remaining_balance:,.2f}",
                     'balance_change': balance_change,
-                    'flexible_payment_calculation': f"{currency_symbol}{principal_payment:,.2f} + {currency_symbol}{interest_paid:,.2f} = {currency_symbol}{flexible_per_payment:,.2f}"
+                    'flexible_payment_calculation': f"{currency_symbol}{principal_payment:,.2f} + {currency_symbol}{interest_paid:,.2f} = {currency_symbol}{flexible_per_payment:,.2f}",
+                    'amortisation_calculation': amortisation_calc
                 })
 
                 if remaining_balance <= 0:

--- a/report_utils.py
+++ b/report_utils.py
@@ -51,19 +51,17 @@ def generate_report_schedule(params: Dict[str, Any]) -> List[Dict[str, Any]]:
 
 
     Capital Payment Only already produces the desired report format. For
-    Service + Capital and Flexible Payment the underlying engine yields a
-    different schedule layout, so this helper re-runs the calculation using
-    the Capital Payment Only breakdown to ensure all three repayment options
-    share an identical structure in generated reports while leaving standard
-    calculations untouched.
+    Service + Capital the underlying engine yields a different schedule
+    layout, so this helper re-runs the calculation using the Capital Payment
+    Only breakdown to ensure all repayment options share an identical
+    structure in generated reports while leaving standard calculations
+    untouched.
 
     """
     calc = LoanCalculator()
     repayment_option = params.get('repayment_option')
-    if repayment_option in ('service_and_capital', 'flexible_payment'):
+    if repayment_option == 'service_and_capital':
         cap_params = params.copy()
         cap_params['repayment_option'] = 'capital_payment_only'
-        if repayment_option == 'flexible_payment':
-            cap_params['capital_repayment'] = params.get('flexible_payment', params.get('flexiblePayment', 0))
         return calc.calculate_bridge_loan(cap_params).get('detailed_payment_schedule', [])
     return calc.calculate_bridge_loan(params).get('detailed_payment_schedule', [])

--- a/test_flexible_payment_amortisation_detail.py
+++ b/test_flexible_payment_amortisation_detail.py
@@ -1,0 +1,22 @@
+from report_utils import generate_report_schedule
+
+
+def test_flexible_payment_schedule_shows_amortisation_details():
+    params = {
+        'loan_type': 'bridge',
+        'repayment_option': 'flexible_payment',
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'flexible_payment': 2000,
+        'payment_frequency': 'monthly',
+        'payment_timing': 'arrears',
+        'start_date': '2024-01-01',
+        'arrangementFee': 0,
+        'totalLegalFees': 0,
+    }
+    schedule = generate_report_schedule(params)
+    first = schedule[0]
+    assert 'amortisation_calculation' in first
+    expected = f"{first['opening_balance']} - {first['principal_payment']} = {first['closing_balance']}"
+    assert first['amortisation_calculation'] == expected

--- a/test_service_and_flexible_schedule_match_capital.py
+++ b/test_service_and_flexible_schedule_match_capital.py
@@ -30,7 +30,8 @@ def test_flexible_payment_matches_capital_payment_schedule():
     params_flex = dict(base, repayment_option='flexible_payment', flexible_payment=2000)
     capital_schedule = generate_report_schedule(params_capital)
     flex_schedule = generate_report_schedule(params_flex)
-    assert flex_schedule == capital_schedule
+    assert flex_schedule != capital_schedule
+    assert 'amortisation_calculation' in flex_schedule[0]
 
 
 def test_flexible_payment_camel_case_matches_capital_payment_schedule():
@@ -46,7 +47,8 @@ def test_flexible_payment_camel_case_matches_capital_payment_schedule():
     params_flex = dict(base, repayment_option='flexible_payment', flexiblePayment=2000)
     capital_schedule = generate_report_schedule(params_capital)
     flex_schedule = generate_report_schedule(params_flex)
-    assert flex_schedule == capital_schedule
+    assert flex_schedule != capital_schedule
+    assert 'amortisation_calculation' in flex_schedule[0]
 
 
 def test_schedule_field_sets_match_capital_format():
@@ -66,5 +68,12 @@ def test_schedule_field_sets_match_capital_format():
     flex = generate_report_schedule(params_flex)
     cap_fields = set(cap[0].keys())
     assert set(svc[0].keys()) == cap_fields
-    assert set(flex[0].keys()) == cap_fields
+    expected_flex_fields = {
+        'payment_date', 'start_period', 'end_period', 'days_held',
+        'opening_balance', 'tranche_release', 'interest_calculation',
+        'interest_amount', 'interest_saving', 'principal_payment',
+        'total_payment', 'closing_balance', 'balance_change',
+        'flexible_payment_calculation', 'amortisation_calculation'
+    }
+    assert set(flex[0].keys()) == expected_flex_fields
 


### PR DESCRIPTION
## Summary
- Include explicit amortisation calculation lines for flexible payment report schedules
- Generate flexible payment report schedules without converting to capital-payment format
- Test flexible payment schedules for amortisation detail and update existing schedule tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b24c9fe7b48320aeda7bd123f75f44