### PR TITLE
Add detailed fields for term flexible payment schedule

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -4961,11 +4961,19 @@ class LoanCalculator:
                     total_payment += fees_added
 
                 balance_change = f"↓ -{currency_symbol}{principal_payment:,.2f}" if principal_payment > 0 else "↔ No Change"
-                closing_balance = remaining_balance - principal_payment
+                opening_balance = remaining_balance
+                closing_balance = opening_balance - principal_payment
+
+                flexible_calc = (
+                    f"{currency_symbol}{principal_payment:,.2f} + {currency_symbol}{actual_interest_paid:,.2f} = {currency_symbol}{flexible_per_payment:,.2f}"
+                )
+                amortisation_calc = (
+                    f"{currency_symbol}{opening_balance:,.2f} - {currency_symbol}{principal_payment:,.2f} = {currency_symbol}{closing_balance:,.2f}"
+                )
 
                 detailed_schedule.append({
                     'payment_date': payment_date.strftime('%d/%m/%Y'),
-                    'opening_balance': f"{currency_symbol}{remaining_balance:,.2f}",
+                    'opening_balance': f"{currency_symbol}{opening_balance:,.2f}",
                     'tranche_release': f"{currency_symbol}0.00",
                     'interest_calculation': interest_calc,
                     'interest_amount': f"{currency_symbol}{actual_interest_paid:,.2f}",
@@ -4973,9 +4981,11 @@ class LoanCalculator:
                     'principal_payment': f"{currency_symbol}{principal_payment:,.2f}",
                     'total_payment': f"{currency_symbol}{total_payment:,.2f}" + (f" + {currency_symbol}{fees_added:,.2f} fees" if period == 1 and fees_added > 0 and not is_final else ""),
                     'closing_balance': f"{currency_symbol}{closing_balance:,.2f}",
-                    'balance_change': balance_change
+                    'balance_change': balance_change,
+                    'flexible_payment_calculation': flexible_calc,
+                    'amortisation_calculation': amortisation_calc
                 })
-                
+
                 remaining_balance = closing_balance
                 
                 if remaining_balance <= 0:

--- a/test_term_flexible_payment_schedule_details.py
+++ b/test_term_flexible_payment_schedule_details.py
@@ -1,0 +1,26 @@
+from report_utils import generate_report_schedule
+
+
+def test_term_flexible_payment_schedule_includes_detail_fields():
+    params = {
+        'loan_type': 'term',
+        'repayment_option': 'flexible_payment',
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'flexible_payment': 2000,
+        'payment_frequency': 'monthly',
+        'payment_timing': 'arrears',
+        'start_date': '2024-01-01',
+        'arrangementFee': 0,
+        'totalLegalFees': 0,
+    }
+    schedule = generate_report_schedule(params)
+    first = schedule[0]
+    assert 'flexible_payment_calculation' in first
+    assert 'amortisation_calculation' in first
+    expected_amortisation = f"{first['opening_balance']} - {first['principal_payment']} = {first['closing_balance']}"
+    assert first['amortisation_calculation'] == expected_amortisation
+    expected_flex = f"{first['principal_payment']} + {first['interest_amount']} = {first['total_payment']}"
+    assert first['flexible_payment_calculation'] == expected_flex
+    assert first['days_held'] > 0


### PR DESCRIPTION
## Summary
- include flexible-payment and amortisation details when generating term-loan schedules
- add regression test for term flexible payment report schedule

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b24ee577148320a538c024efee3da1