### PR TITLE
Add detailed fields to flexible payment schedules

### DIFF
--- a/test_flexible_payment_schedule_fields.py
+++ b/test_flexible_payment_schedule_fields.py
@@ -1,0 +1,31 @@
+from calculations import LoanCalculator
+
+def test_flexible_payment_schedule_fields_present():
+    calc = LoanCalculator()
+    params = {
+        'loan_type': 'bridge',
+        'repayment_option': 'flexible_payment',
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'flexible_payment': 2000,
+        'payment_frequency': 'monthly',
+        'payment_timing': 'arrears',
+        'arrangement_fee_rate': 0,
+        'legal_fees': 0,
+        'site_visit_fee': 0,
+        'title_insurance_rate': 0,
+        'property_value': 150000,
+    }
+    result = calc.calculate_bridge_loan(params)
+    schedule = result.get('detailed_payment_schedule')
+    assert schedule, 'No schedule generated'
+    required_fields = [
+        'start_period', 'end_period', 'days_held',
+        'capital_outstanding', 'annual_interest_rate', 'interest_pa',
+        'scheduled_repayment', 'interest_accrued', 'interest_retained',
+        'interest_refund', 'running_ltv'
+    ]
+    for idx, entry in enumerate(schedule, start=1):
+        for field in required_fields:
+            assert field in entry, f"Missing field {field} in period {idx}"

--- a/test_service_and_flexible_schedule_match_capital.py
+++ b/test_service_and_flexible_schedule_match_capital.py
@@ -73,7 +73,10 @@ def test_schedule_field_sets_match_capital_format():
         'opening_balance', 'tranche_release', 'interest_calculation',
         'interest_amount', 'interest_saving', 'principal_payment',
         'total_payment', 'closing_balance', 'balance_change',
-        'flexible_payment_calculation', 'amortisation_calculation'
+        'flexible_payment_calculation', 'amortisation_calculation',
+        'capital_outstanding', 'annual_interest_rate', 'interest_pa',
+        'scheduled_repayment', 'interest_accrued', 'interest_retained',
+        'interest_refund', 'running_ltv'
     }
     assert set(flex[0].keys()) == expected_flex_fields
 


### PR DESCRIPTION
## Summary
- populate capital outstanding, interest details and LTV for flexible payment schedules
- update existing schedule field expectations and add dedicated test for flexible payment reports

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b250cc18b08320a0fd56e915403719