### PR TITLE
Compute retained interest for flexible payments

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -4105,10 +4105,8 @@ class LoanCalculator:
                     f"{currency_symbol}{opening_balance:,.2f} × {annual_rate:.3f}% × {int(days_in_period)}/{days_per_year} days"
                 )
 
-                interest_only = self.calculate_simple_interest_by_days(
-                    gross_amount, annual_rate, int(days_in_period), use_360_days
-                )
-                interest_saving = max(interest_only - interest_paid, Decimal('0'))
+                interest_retained_current = gross_amount * daily_rate * days_in_period
+                interest_saving = max(interest_retained_current - interest_paid, Decimal('0'))
 
                 fees_added = Decimal('0')
                 if period == 1:
@@ -4129,6 +4127,11 @@ class LoanCalculator:
                     f"{currency_symbol}{principal_payment:,.2f} = "
                     f"{currency_symbol}{remaining_balance:,.2f}"
                 )
+
+                interest_retained_disp = interest_retained_current.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+                interest_saving_disp = interest_saving.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+                interest_paid_disp = interest_paid.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+
                 detailed_schedule.append({
                     'payment_date': payment_date.strftime('%d/%m/%Y'),
                     'start_period': period_start.strftime('%d/%m/%Y'),
@@ -4137,20 +4140,20 @@ class LoanCalculator:
                     'opening_balance': f"{currency_symbol}{opening_balance:,.2f}",
                     'tranche_release': f"{currency_symbol}0.00",
                     'interest_calculation': interest_calc,
-                    'interest_amount': f"{currency_symbol}{interest_paid:,.2f}",
-                    'interest_saving': f"{currency_symbol}{interest_saving:,.2f}",
+                    'interest_amount': f"{currency_symbol}{interest_paid_disp:,.2f}",
+                    'interest_saving': f"{currency_symbol}{interest_saving_disp:,.2f}",
                     'principal_payment': f"{currency_symbol}{principal_payment:,.2f}",
                     'total_payment': f"{currency_symbol}{total_payment:,.2f}" + (f" + {currency_symbol}{fees_added:,.2f} fees" if period == 1 and fees_added > 0 and interest_paid > 0 else ""),
                     'closing_balance': f"{currency_symbol}{remaining_balance:,.2f}",
                     'balance_change': balance_change,
-                    'flexible_payment_calculation': f"{currency_symbol}{principal_payment:,.2f} + {currency_symbol}{interest_paid:,.2f} = {currency_symbol}{flexible_per_payment:,.2f}",
+                    'flexible_payment_calculation': f"{currency_symbol}{principal_payment:,.2f} + {currency_symbol}{interest_paid_disp:,.2f} = {currency_symbol}{flexible_per_payment:,.2f}",
                     'amortisation_calculation': amortisation_calc,
                     'capital_outstanding': f"{currency_symbol}{capital_outstanding:,.2f}",
                     'annual_interest_rate': f"{annual_rate:.2f}%",
                     'interest_pa': f"{daily_rate:.6f}",
                     'scheduled_repayment': f"{currency_symbol}{flexible_per_payment:,.2f}",
-                    'interest_accrued': f"{currency_symbol}{interest_paid:,.2f}",
-                    'interest_retained': f"{currency_symbol}0.00",
+                    'interest_accrued': f"{currency_symbol}{interest_paid_disp:,.2f}",
+                    'interest_retained': f"{currency_symbol}{interest_retained_disp:,.2f}",
                     'interest_refund': f"{currency_symbol}0.00",
                     'running_ltv': f"{running_ltv:.2f}"
                 })

--- a/test_flexible_payment_interest_retained.py
+++ b/test_flexible_payment_interest_retained.py
@@ -1,0 +1,39 @@
+from decimal import Decimal
+from calculations import LoanCalculator
+
+def test_flexible_payment_interest_retained_and_saving():
+    calc = LoanCalculator()
+    params = {
+        'loan_type': 'bridge',
+        'repayment_option': 'flexible_payment',
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'flexible_payment': 2000,
+        'payment_frequency': 'monthly',
+        'payment_timing': 'arrears',
+        'start_date': '2024-01-01',
+        'arrangement_fee': 0,
+        'totalLegalFees': 0,
+    }
+    result = calc.calculate_bridge_loan(params)
+    schedule = result['detailed_payment_schedule']
+    gross = Decimal('100000')
+    annual_rate = Decimal('12')
+    days_per_year = Decimal('365')
+    daily_rate = annual_rate / Decimal('100') / days_per_year
+
+    first = schedule[0]
+    days_first = Decimal(str(first['days_held']))
+    expected_first = (gross * daily_rate * days_first).quantize(Decimal('0.01'))
+    retained_first = Decimal(first['interest_retained'].replace('£', '').replace(',', ''))
+    assert retained_first == expected_first
+
+    second = schedule[1]
+    days_second = Decimal(str(second['days_held']))
+    expected_second = (gross * daily_rate * days_second).quantize(Decimal('0.01'))
+    retained_second = Decimal(second['interest_retained'].replace('£', '').replace(',', ''))
+    accrued_second = Decimal(second['interest_accrued'].replace('£', '').replace(',', ''))
+    saving_second = Decimal(second['interest_saving'].replace('£', '').replace(',', ''))
+    assert retained_second == expected_second
+    assert saving_second == (retained_second - accrued_second).quantize(Decimal('0.01'))


### PR DESCRIPTION
## Summary
- Derive retained interest each period for flexible payment schedules using gross amount and daily rate
- Report per-period interest savings and retained interest in payment schedule
- Add regression test validating retained interest and savings calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b254301bdc8320b24adaccbc6d138a