### PR TITLE
Revert short-month day count change and compute report days held

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -3485,12 +3485,8 @@ class LoanCalculator:
         current = start_date
 
         while current < loan_end:
-            # Determine the end of the period by adding one calendar month
-            # rather than a fixed number of days.  This ensures that periods
-            # respect varying month lengths (e.g. February) and prevents
-            # rollover into the following month when the starting day does not
-            # exist in the next month.
-            period_end = self._add_months(current, 1)
+            days_in_month = calendar.monthrange(current.year, current.month)[1]
+            period_end = current + timedelta(days=days_in_month)
             if period_end > loan_end:
                 period_end = loan_end
             ranges.append({'start': current, 'end': period_end, 'days_held': (period_end - current).days})
@@ -3510,12 +3506,8 @@ class LoanCalculator:
         for entry in schedule:
             if current >= loan_end:
                 break
-            # Use calendar month arithmetic to find the next period end rather
-            # than adding the nominal number of days in the current month.  The
-            # latter can skip over shorter months and yield 31‑day periods for
-            # February.  Using ``_add_months`` keeps the dates aligned with the
-            # calendar and produces the correct day counts.
-            period_end = self._add_months(current, 1)
+            days_in_month = calendar.monthrange(current.year, current.month)[1]
+            period_end = current + timedelta(days=days_in_month)
             if period_end > loan_end:
                 period_end = loan_end
             entry['start_period'] = current.strftime('%d/%m/%Y')
@@ -3874,10 +3866,11 @@ class LoanCalculator:
         # Generate payment dates
         payment_dates = self._generate_payment_dates(start_date, loan_term, payment_frequency, payment_timing)
 
-        # Recompute period ranges so that each period end is based on adding
-        # whole calendar months.  This keeps the schedule aligned with actual
-        # month lengths and avoids carrying extra days from shorter months like
-        # February into the following period.
+        # Recompute period ranges so that each period end is based on the number
+        # of days in the month of its start date. This ensures the detailed
+        # payment schedule uses calendar‑accurate month lengths regardless of
+        # payment timing or frequency.
+        import calendar
 
         periods = len(payment_dates)
         period_ranges = []
@@ -3894,9 +3887,9 @@ class LoanCalculator:
                 total_days = 0
 
                 for _ in range(period_months):
-                    next_start = self._add_months(current_start, 1)
-                    total_days += (next_start - current_start).days
-                    current_start = next_start
+                    days_in_month = calendar.monthrange(current_start.year, current_start.month)[1]
+                    total_days += days_in_month
+                    current_start += timedelta(days=days_in_month)
 
                 period_end = current_start  # exclusive end date
                 period_ranges.append(

--- a/report_utils.py
+++ b/report_utils.py
@@ -3,6 +3,7 @@
 from typing import Any, Dict, List
 
 from decimal import Decimal, ROUND_HALF_UP
+from datetime import datetime
 
 from calculations import LoanCalculator
 
@@ -78,7 +79,15 @@ def generate_report_schedule(params: Dict[str, Any]) -> List[Dict[str, Any]]:
         daily_rate = annual_rate / Decimal('100') / days_per_year
 
         for row in schedule:
-            days = Decimal(str(row.get('days_held', 0)))
+            start = row.get('start_period')
+            end = row.get('end_period')
+            if start and end:
+                day_count = (datetime.strptime(end, '%d/%m/%Y') - datetime.strptime(start, '%d/%m/%Y')).days
+                row['days_held'] = day_count
+            else:
+                day_count = int(row.get('days_held', 0))
+
+            days = Decimal(str(day_count))
             opening_balance = Decimal(row.get('opening_balance', f"{currency_symbol}0").replace(currency_symbol, '').replace(',', ''))
             interest_retained = (gross_amount * daily_rate * days).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
             interest_accrued = (opening_balance * daily_rate * days).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)

--- a/test_payment_schedule_day_counts.py
+++ b/test_payment_schedule_day_counts.py
@@ -61,5 +61,5 @@ def test_payment_schedule_handles_short_month_rollover():
     }
     result = calc.calculate_bridge_loan(params)
     schedule = result['detailed_payment_schedule']
-    assert schedule[0]['days_held'] == 30
-    assert schedule[0]['end_period'] == '28/02/2026'
+    assert schedule[0]['days_held'] == 31
+    assert schedule[0]['end_period'] == '01/03/2026'


### PR DESCRIPTION
## Summary
- revert previous commit adjusting day count for short months
- compute report schedule days held from period boundaries for accurate interest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2bb6d571c8320a92a4116a863b041