### PR TITLE
Fix service-only advance timing summary totals

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -433,15 +433,17 @@ class LoanCalculator:
             # Update total interest to match detailed schedule
             detailed_schedule = calculation.get('detailed_payment_schedule', [])
             if detailed_schedule:
-                total_interest_from_schedule = 0
+                total_interest_from_schedule = Decimal('0')
                 for payment in detailed_schedule:
-                    interest_str = payment.get('interest_amount', '£0.00')
-                    interest_numeric = interest_str.replace("£", "").replace("€", "").replace(",", "")
-                    total_interest_from_schedule += float(interest_numeric) if interest_numeric else 0
+                    interest_str = payment.get('interest_accrued', payment.get('interest_amount', '£0.00'))
+                    interest_numeric = interest_str.replace('£', '').replace('€', '').replace(',', '')
+                    total_interest_from_schedule += Decimal(interest_numeric) if interest_numeric else Decimal('0')
 
                 total_interest_from_schedule = self._two_dp(total_interest_from_schedule)
-                calculation['totalInterest'] = total_interest_from_schedule
-                calculation['total_interest'] = total_interest_from_schedule
+                calculation['totalInterest'] = float(total_interest_from_schedule)
+                calculation['total_interest'] = float(total_interest_from_schedule)
+                # For service-only loans, total interest equals the interest-only total
+                calculation['interestOnlyTotal'] = float(total_interest_from_schedule)
         elif repayment_option == 'service_and_capital':
             # Service + Capital - pass net_amount if this is a net-to-gross conversion
             net_for_calculation = net_amount if amount_input_type == 'net' else None

--- a/test_service_only_summary_matches_schedule.py
+++ b/test_service_only_summary_matches_schedule.py
@@ -1,0 +1,46 @@
+import sys, types
+from decimal import Decimal
+
+# Provide minimal stub for dateutil.relativedelta to avoid external dependency
+relativedelta_module = types.ModuleType('relativedelta')
+class relativedelta:
+    def __init__(self, months=0):
+        self.months = months
+    def __radd__(self, other):
+        from datetime import date
+        month = other.month - 1 + self.months
+        year = other.year + month // 12
+        month = month % 12 + 1
+        day = min(other.day, [31, 29 if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0) else 28,
+                              31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1])
+        return other.replace(year=year, month=month, day=day)
+relativedelta_module.relativedelta = relativedelta
+sys.modules['dateutil'] = types.ModuleType('dateutil')
+sys.modules['dateutil'].relativedelta = relativedelta_module
+sys.modules['dateutil.relativedelta'] = relativedelta_module
+
+from calculations import LoanCalculator
+
+def _currency_to_decimal(value: str) -> Decimal:
+    return Decimal(value.replace('£', '').replace(',', ''))
+
+def test_service_only_summary_matches_schedule():
+    calc = LoanCalculator()
+    params = {
+        'loan_type': 'bridge',
+        'repayment_option': 'service_only',
+        'gross_amount': 100000,
+        'loan_term': 12,
+        'annual_rate': 12,
+        'arrangement_fee_rate': 0,
+        'legal_fees': 0,
+        'site_visit_fee': 0,
+        'title_insurance_rate': 0,
+        'start_date': '2025-08-01',
+        'payment_timing': 'advance',
+    }
+    result = calc.calculate_bridge_loan(params)
+    schedule = result['detailed_payment_schedule']
+    interest_total = sum(_currency_to_decimal(r.get('interest_accrued', r['interest_amount'])) for r in schedule)
+    assert interest_total.quantize(Decimal('0.01')) == Decimal(str(result['totalInterest'])).quantize(Decimal('0.01'))
+    assert Decimal(str(result['interestOnlyTotal'])).quantize(Decimal('0.01')) == interest_total.quantize(Decimal('0.01'))


### PR DESCRIPTION
## Summary
- ensure service-only loan summaries include total interest and interest-only total derived from detailed schedule
- add regression test verifying service-only advance timing schedule aligns with summary

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2d5715e448320a571e0ee1e1cb5c5