### PR TITLE
Fix service-only net-to-gross calculation

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -2698,19 +2698,15 @@ class LoanCalculator:
                 logging.info(f"Gross = £{net_amount + total_legal_fees} / {denominator:.6f} = £{gross_amount:.2f}")
                 
             elif repayment_option == 'service_only':
-                # Bridge Serviced: Gross = (Net + Legals + Site) / (1 - Arrangement Fee - (Interest rate/12) - Title insurance)
-                if use_360_days:
-                    # Apply 360-day rate adjustment (365/360 factor)
-                    monthly_interest_factor = annual_rate_decimal / Decimal('12') * Decimal('365') / Decimal('360')
-                else:
-                    monthly_interest_factor = annual_rate_decimal / Decimal('12')
-                denominator = Decimal('1') - arrangement_fee_decimal - monthly_interest_factor - title_insurance_decimal
+                # Bridge Serviced: Gross = (Net + Legals + Site) / (1 - Arrangement Fee - Title insurance)
+                denominator = Decimal('1') - arrangement_fee_decimal - title_insurance_decimal
                 gross_amount = (net_amount + total_legal_fees) / denominator
-                
+
                 logging.info(f"BRIDGE SERVICED NET-TO-GROSS:")
-                logging.info(f"Formula: Gross = (Net + Legals + Site) / (1 - Arrangement Fee - (Interest rate/12) - Title insurance)")
-                logging.info(f"Monthly interest factor: {annual_rate}%/12 = {monthly_interest_factor:.6f}")
-                logging.info(f"Gross = (£{net_amount} + £{total_legal_fees}) / (1 - {arrangement_fee_decimal:.6f} - {monthly_interest_factor:.6f} - {title_insurance_decimal:.6f})")
+                logging.info(f"Formula: Gross = (Net + Legals + Site) / (1 - Arrangement Fee - Title insurance)")
+                logging.info(
+                    f"Gross = (£{net_amount} + £{total_legal_fees}) / (1 - {arrangement_fee_decimal:.6f} - {title_insurance_decimal:.6f})"
+                )
                 logging.info(f"Gross = £{net_amount + total_legal_fees} / {denominator:.6f} = £{gross_amount:.2f}")
                 
             elif repayment_option == 'service_and_capital':

--- a/test_bridge_net_to_gross.py
+++ b/test_bridge_net_to_gross.py
@@ -136,3 +136,43 @@ def test_bridge_interest_only_net_matches_input():
     )
 
     assert res['netAdvance'] == pytest.approx(float(net_amount))
+
+
+def test_service_only_net_to_gross_roundtrip():
+    """Service-only net to gross should invert gross to net when no interest is deducted."""
+    calc = LoanCalculator()
+    gross_amount = Decimal('100000')
+    annual_rate = Decimal('12')
+    loan_term = 9
+    arrangement_fee_rate = Decimal('2')
+    legal_fees = Decimal('1000')
+    site_visit_fee = Decimal('500')
+    title_insurance_rate = Decimal('1')
+    loan_term_days = 274
+
+    # Gross to net (fees only, no interest retained)
+    fees = calc._calculate_fees(
+        gross_amount,
+        arrangement_fee_rate,
+        legal_fees,
+        site_visit_fee,
+        title_insurance_rate,
+        Decimal('0'),
+    )
+    net_amount = gross_amount - fees['arrangementFee'] - fees['totalLegalFees']
+
+    # Net to gross should return the original gross amount
+    gross_calculated = calc._calculate_gross_from_net_bridge(
+        net_amount,
+        annual_rate,
+        loan_term,
+        'service_only',
+        arrangement_fee_rate,
+        legal_fees,
+        site_visit_fee,
+        title_insurance_rate,
+        loan_term_days,
+        use_360_days=False,
+    )
+
+    assert float(gross_calculated) == pytest.approx(float(gross_amount))


### PR DESCRIPTION
## Summary
- correct service-only net-to-gross calculation by removing monthly interest factor for interest-only bridge loans
- add unit test ensuring service-only net-to-gross returns original gross when starting from gross-to-net calculation

## Testing
- `pytest test_bridge_net_to_gross.py::test_service_only_net_to_gross_roundtrip -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2da9b9ee88320ab0b7561c862c895