### PR TITLE
Ensure service+capital summary interest matches schedule

### DIFF
--- a/test_service_and_capital_schedule_summary.py
+++ b/test_service_and_capital_schedule_summary.py
@@ -21,12 +21,14 @@ sys.modules['dateutil.relativedelta'] = relativedelta_module
 
 from calculations import LoanCalculator
 
+
 def _currency_to_decimal(value: str) -> Decimal:
     """Convert currency formatted string like '£1,234.56' to Decimal."""
     return Decimal(value.replace('£', '').replace(',', ''))
 
-def test_service_and_capital_summary_matches_schedule():
-    """Ensure loan summary totals match aggregated payment schedule values."""
+
+def _run_sac_scenario(payment_timing: str):
+    """Helper to run a service-and-capital scenario for the given timing."""
     calc = LoanCalculator()
     params = {
         'loan_type': 'bridge',
@@ -41,25 +43,33 @@ def test_service_and_capital_summary_matches_schedule():
         'title_insurance_rate': 0,
         'start_date': '2025-08-01',
         'property_value': 3000000,
-        'payment_timing': 'advance',
+        'payment_timing': payment_timing,
     }
-    result = calc.calculate_bridge_loan(params)
-    schedule = result['detailed_payment_schedule']
+    return calc.calculate_bridge_loan(params)
 
+
+def _assert_summary_matches_schedule(result):
+    schedule = result['detailed_payment_schedule']
     interest_total = sum(_currency_to_decimal(r.get('interest_accrued', r['interest_amount'])) for r in schedule)
     capital_total = sum(_currency_to_decimal(r['principal_payment']) for r in schedule)
     savings_total = sum(_currency_to_decimal(r.get('interest_saving', '£0.00')) for r in schedule)
     interest_only_total = interest_total + savings_total
     closing_balance = _currency_to_decimal(schedule[-1]['closing_balance'])
 
-    # Summary comparisons
     assert interest_total.quantize(Decimal('0.01')) == Decimal(str(result['totalInterest'])).quantize(Decimal('0.01'))
     assert savings_total.quantize(Decimal('0.01')) == Decimal(str(result['interestSavings'])).quantize(Decimal('0.01'))
     assert interest_only_total.quantize(Decimal('0.01')) == Decimal(str(result['interestOnlyTotal'])).quantize(Decimal('0.01'))
-    # Derived summary check
     summary_interest_only = Decimal(str(result['interestOnlyTotal']))
     summary_savings = Decimal(str(result['interestSavings']))
     summary_interest = Decimal(str(result['totalInterest']))
     assert summary_interest.quantize(Decimal('0.01')) == (summary_interest_only - summary_savings).quantize(Decimal('0.01'))
     assert capital_total.quantize(Decimal('0.01')) == Decimal(str(result['gross_amount'])).quantize(Decimal('0.01'))
     assert closing_balance == Decimal('0')
+
+
+def test_service_and_capital_summary_matches_schedule_advance():
+    _assert_summary_matches_schedule(_run_sac_scenario('advance'))
+
+
+def test_service_and_capital_summary_matches_schedule_arrears():
+    _assert_summary_matches_schedule(_run_sac_scenario('arrears'))


### PR DESCRIPTION
## Summary
- derive loan summary interest from interest paid instead of accrued totals
- compute interest-only total and savings from schedule to keep summary consistent
- test service+capital schedules for both advance and arrears timings

## Testing
- `python -m pytest test_service_and_capital_schedule_summary.py -q`
- `python -m pytest test_quarterly_service_and_capital_schedule.py test_service_only_summary_matches_schedule.py test_service_only_last_period_interest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2e9427e708320b061cc405e4e1c42