### PR TITLE
Align service + capital interest refund with retained and accrued

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -4143,10 +4143,12 @@ class LoanCalculator:
 
                 remaining_balance -= principal_payment
 
-                total_payment = interest_amount + principal_payment
+                interest_amount_disp = interest_amount.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+                interest_only_disp = interest_only.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+                interest_refund_disp = max(interest_only_disp - interest_amount_disp, Decimal('0.00'))
+                interest_saving_disp = interest_refund_disp
 
-                interest_refund = max(interest_only - interest_amount, Decimal('0'))
-                interest_saving = interest_refund
+                total_payment = interest_amount_disp + principal_payment
 
                 is_final = remaining_balance == 0
                 interest_calc = interest_calc_base
@@ -4169,11 +4171,11 @@ class LoanCalculator:
                     'opening_balance': f"{currency_symbol}{opening_balance:,.2f}",
                     'tranche_release': f"{currency_symbol}0.00",
                     'interest_calculation': interest_calc,
-                    'interest_amount': f"{currency_symbol}{interest_amount:,.2f}",
-                    'interest_saving': f"{currency_symbol}{interest_saving:,.2f}",
-                    'interest_accrued': f"{currency_symbol}{interest_amount:,.2f}",
-                    'interest_retained': f"{currency_symbol}{interest_only:,.2f}",
-                    'interest_refund': f"{currency_symbol}{interest_refund:,.2f}",
+                    'interest_amount': f"{currency_symbol}{interest_amount_disp:,.2f}",
+                    'interest_saving': f"{currency_symbol}{interest_saving_disp:,.2f}",
+                    'interest_accrued': f"{currency_symbol}{interest_amount_disp:,.2f}",
+                    'interest_retained': f"{currency_symbol}{interest_only_disp:,.2f}",
+                    'interest_refund': f"{currency_symbol}{interest_refund_disp:,.2f}",
                     'principal_payment': f"{currency_symbol}{principal_payment:,.2f}",
                     'total_payment': f"{currency_symbol}{total_payment:,.2f}",
                     'closing_balance': f"{currency_symbol}{closing_balance:,.2f}",

--- a/test_report_service_and_capital_interest.py
+++ b/test_report_service_and_capital_interest.py
@@ -1,0 +1,38 @@
+from decimal import Decimal
+from report_utils import generate_report_schedule
+
+
+def currency_to_decimal(val: str) -> Decimal:
+    return Decimal(val.replace('£', '').replace(',', ''))
+
+
+def _run_schedule(payment_timing: str):
+    params = {
+        'loan_type': 'bridge',
+        'repayment_option': 'service_and_capital',
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'capital_repayment': 10000,
+        'payment_frequency': 'monthly',
+        'payment_timing': payment_timing,
+        'start_date': '2024-01-01',
+    }
+    return generate_report_schedule(params)
+
+
+def test_report_schedule_interest_fields_match_formulas():
+    for timing in ['arrears', 'advance']:
+        schedule = _run_schedule(timing)
+        first = schedule[0]
+        gross = Decimal('100000')
+        daily_rate = Decimal('12') / Decimal('100') / Decimal('365')
+        days = Decimal(str(first['days_held']))
+        capital = currency_to_decimal(first.get('capital_outstanding', first['opening_balance']))
+        expected_retained = (gross * daily_rate * days).quantize(Decimal('0.01'))
+        expected_accrued = (capital * daily_rate * days).quantize(Decimal('0.01'))
+        expected_refund = (expected_retained - expected_accrued).quantize(Decimal('0.01'))
+        assert currency_to_decimal(first['interest_retained']) == expected_retained
+        assert currency_to_decimal(first['interest_accrued']) == expected_accrued
+        assert currency_to_decimal(first['interest_refund']) == expected_refund
+        assert currency_to_decimal(first['interest_saving']) == expected_refund

--- a/test_service_and_capital_schedule_summary.py
+++ b/test_service_and_capital_schedule_summary.py
@@ -53,6 +53,7 @@ def _assert_summary_matches_schedule(result):
     interest_total = sum(_currency_to_decimal(r.get('interest_accrued', r['interest_amount'])) for r in schedule)
     capital_total = sum(_currency_to_decimal(r['principal_payment']) for r in schedule)
     savings_total = sum(_currency_to_decimal(r.get('interest_saving', '£0.00')) for r in schedule)
+    refund_total = sum(_currency_to_decimal(r.get('interest_refund', '£0.00')) for r in schedule)
     interest_only_total = interest_total + savings_total
     closing_balance = _currency_to_decimal(schedule[-1]['closing_balance'])
 
@@ -65,6 +66,17 @@ def _assert_summary_matches_schedule(result):
     assert summary_interest.quantize(Decimal('0.01')) == (summary_interest_only - summary_savings).quantize(Decimal('0.01'))
     assert capital_total.quantize(Decimal('0.01')) == Decimal(str(result['gross_amount'])).quantize(Decimal('0.01'))
     assert closing_balance == Decimal('0')
+
+    for row in schedule:
+        retained = _currency_to_decimal(row['interest_retained'])
+        accrued = _currency_to_decimal(row['interest_accrued'])
+        refund = _currency_to_decimal(row['interest_refund'])
+        saving = _currency_to_decimal(row.get('interest_saving', '£0.00'))
+        assert refund == retained - accrued
+        assert saving == refund
+
+    assert refund_total.quantize(Decimal('0.01')) == savings_total.quantize(Decimal('0.01'))
+    assert refund_total.quantize(Decimal('0.01')) == Decimal(str(result['interestSavings'])).quantize(Decimal('0.01'))
 
 
 def test_service_and_capital_summary_matches_schedule_advance():


### PR DESCRIPTION
## Summary
- Recalculate report schedule interest fields using gross amount and capital outstanding to derive interest retained, accrued and refund
- Quantize service + capital payment calculations so interest refund equals retained minus accrued
- Add regression tests to validate schedule vs summary and report formulas for arrears and advance payments

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2f35bbc3483209491ec759ced52d2