### PR TITLE
Correct interest refund calculation in report schedule

### DIFF
--- a/report_utils.py
+++ b/report_utils.py
@@ -96,11 +96,12 @@ def generate_report_schedule(params: Dict[str, Any]) -> List[Dict[str, Any]]:
 
             interest_retained = retained_raw.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
             interest_accrued = accrued_raw.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-            interest_refund = (retained_raw - accrued_raw).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+            interest_refund = (interest_retained - interest_accrued).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+            interest_saving = interest_refund
 
             row['interest_retained'] = f"{currency_symbol}{interest_retained:,.2f}"
             row['interest_accrued'] = f"{currency_symbol}{interest_accrued:,.2f}"
             row['interest_refund'] = f"{currency_symbol}{interest_refund:,.2f}"
-            row['interest_saving'] = f"{currency_symbol}{interest_refund:,.2f}"
+            row['interest_saving'] = f"{currency_symbol}{interest_saving:,.2f}"
 
     return schedule


### PR DESCRIPTION
## Summary
- Use quantized interest values to compute interest refund in `generate_report_schedule`
- Mirror `interest_saving` with `interest_refund`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2f5fd20bc8320be0943a5904239ce