### PR TITLE
Recalculate report schedule summaries after interest adjustments

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -465,7 +465,9 @@ def api_calculate():
         # Ensure detailed schedule structure for serviced + capital and flexible payments
         if loan_type == 'bridge' and repayment_option in ('service_and_capital', 'flexible_payment'):
             try:
-                result['detailed_payment_schedule'] = generate_report_schedule(calc_params)
+                schedule, summary = generate_report_schedule(calc_params)
+                result['detailed_payment_schedule'] = schedule
+                result.update(summary)
             except Exception as e:
                 app.logger.warning(f"Report schedule generation failed: {str(e)}")
 

--- a/test_flexible_payment_amortisation_detail.py
+++ b/test_flexible_payment_amortisation_detail.py
@@ -15,7 +15,7 @@ def test_flexible_payment_schedule_shows_amortisation_details():
         'arrangementFee': 0,
         'totalLegalFees': 0,
     }
-    schedule = generate_report_schedule(params)
+    schedule, _ = generate_report_schedule(params)
     first = schedule[0]
     assert 'amortisation_calculation' in first
     expected = f"{first['opening_balance']} - {first['principal_payment']} = {first['closing_balance']}"

--- a/test_report_interest_days_held.py
+++ b/test_report_interest_days_held.py
@@ -18,7 +18,7 @@ def test_interest_fields_use_days_held():
         'payment_timing': 'arrears',
         'start_date': '2024-01-01',
     }
-    schedule = generate_report_schedule(params)
+    schedule, summary = generate_report_schedule(params)
     first = schedule[0]
     gross = Decimal('100000')
     annual_rate = Decimal('12')
@@ -30,3 +30,16 @@ def test_interest_fields_use_days_held():
     accrued = currency_to_decimal(first['interest_accrued'])
     assert retained == expected_retained
     assert accrued == expected_accrued
+
+    total_retained = sum(currency_to_decimal(r['interest_retained']) for r in schedule)
+    total_refund = sum(currency_to_decimal(r['interest_refund']) for r in schedule)
+    total_accrued = sum(currency_to_decimal(r['interest_accrued']) for r in schedule)
+    total_saving = sum(currency_to_decimal(r['interest_saving']) for r in schedule)
+
+    rounding = Decimal('0.01')
+    expected_total_interest = (total_retained - total_refund).quantize(rounding)
+    assert summary['totalInterest'] == float(expected_total_interest)
+    assert summary['retainedInterest'] == float(total_retained.quantize(rounding))
+    assert summary['interestRefund'] == float(total_refund.quantize(rounding))
+    assert summary['total_interest_accrued'] == float(total_accrued.quantize(rounding))
+    assert summary['interestSavings'] == float(total_saving.quantize(rounding))

--- a/test_report_service_and_capital_interest.py
+++ b/test_report_service_and_capital_interest.py
@@ -23,7 +23,7 @@ def _run_schedule(payment_timing: str):
 
 def test_report_schedule_interest_fields_match_formulas():
     for timing in ['arrears', 'advance']:
-        schedule = _run_schedule(timing)
+        schedule, _ = _run_schedule(timing)
         first = schedule[0]
         gross = Decimal('100000')
         daily_rate = Decimal('12') / Decimal('100') / Decimal('365')

--- a/test_service_and_flexible_schedule_match_capital.py
+++ b/test_service_and_flexible_schedule_match_capital.py
@@ -12,8 +12,8 @@ def test_service_and_capital_matches_capital_payment_schedule():
     }
     params_capital = dict(base, repayment_option='capital_payment_only', capital_repayment=2000)
     params_service = dict(base, repayment_option='service_and_capital', capital_repayment=2000)
-    capital_schedule = generate_report_schedule(params_capital)
-    service_schedule = generate_report_schedule(params_service)
+    capital_schedule, _ = generate_report_schedule(params_capital)
+    service_schedule, _ = generate_report_schedule(params_service)
     assert service_schedule == capital_schedule
 
 
@@ -28,8 +28,8 @@ def test_flexible_payment_matches_capital_payment_schedule():
     }
     params_capital = dict(base, repayment_option='capital_payment_only', capital_repayment=2000)
     params_flex = dict(base, repayment_option='flexible_payment', flexible_payment=2000)
-    capital_schedule = generate_report_schedule(params_capital)
-    flex_schedule = generate_report_schedule(params_flex)
+    capital_schedule, _ = generate_report_schedule(params_capital)
+    flex_schedule, _ = generate_report_schedule(params_flex)
     assert flex_schedule != capital_schedule
     assert 'amortisation_calculation' in flex_schedule[0]
 
@@ -45,8 +45,8 @@ def test_flexible_payment_camel_case_matches_capital_payment_schedule():
     }
     params_capital = dict(base, repayment_option='capital_payment_only', capital_repayment=2000)
     params_flex = dict(base, repayment_option='flexible_payment', flexiblePayment=2000)
-    capital_schedule = generate_report_schedule(params_capital)
-    flex_schedule = generate_report_schedule(params_flex)
+    capital_schedule, _ = generate_report_schedule(params_capital)
+    flex_schedule, _ = generate_report_schedule(params_flex)
     assert flex_schedule != capital_schedule
     assert 'amortisation_calculation' in flex_schedule[0]
 
@@ -63,9 +63,9 @@ def test_schedule_field_sets_match_capital_format():
     params_capital = dict(base, repayment_option='capital_payment_only', capital_repayment=2000)
     params_service = dict(base, repayment_option='service_and_capital', capital_repayment=2000)
     params_flex = dict(base, repayment_option='flexible_payment', flexible_payment=2000)
-    cap = generate_report_schedule(params_capital)
-    svc = generate_report_schedule(params_service)
-    flex = generate_report_schedule(params_flex)
+    cap, _ = generate_report_schedule(params_capital)
+    svc, _ = generate_report_schedule(params_service)
+    flex, _ = generate_report_schedule(params_flex)
     cap_fields = set(cap[0].keys())
     assert set(svc[0].keys()) == cap_fields
     expected_flex_fields = {

--- a/test_term_flexible_payment_schedule_details.py
+++ b/test_term_flexible_payment_schedule_details.py
@@ -15,7 +15,7 @@ def test_term_flexible_payment_schedule_includes_detail_fields():
         'arrangementFee': 0,
         'totalLegalFees': 0,
     }
-    schedule = generate_report_schedule(params)
+    schedule, _ = generate_report_schedule(params)
     first = schedule[0]
     assert 'flexible_payment_calculation' in first
     assert 'amortisation_calculation' in first


### PR DESCRIPTION
## Summary
- aggregate interest fields via new `recalculate_summary`
- return schedule and summary from `generate_report_schedule`
- update routes and tests to use the recalculated summary

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2f9cf887483208ab5c942d7abcc4f