### PR TITLE
Use cumulative interest in balance charts

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -2939,14 +2939,18 @@ class LoanCalculator {
             return 0;
         });
 
+        // Convert interest values to a running cumulative sum
+        let cumulativeInterest = 0;
         const interestData = schedule.map(entry => {
             const interestRaw = entry.interest_amount || entry.interest || 0;
+            let interestValue = 0;
             if (typeof interestRaw === 'number') {
-                return interestRaw;
+                interestValue = interestRaw;
             } else if (typeof interestRaw === 'string') {
-                return parseFloat(interestRaw.replace(/[£€,]/g, '')) || 0;
+                interestValue = parseFloat(interestRaw.replace(/[£€,]/g, '')) || 0;
             }
-            return 0;
+            cumulativeInterest += interestValue;
+            return cumulativeInterest;
         });
 
         const data = {

--- a/static/js/charts.js
+++ b/static/js/charts.js
@@ -194,7 +194,13 @@ class ChartManager {
 
         const labels = schedule.map(payment => `Month ${payment.month}`);
         const balanceData = schedule.map(payment => payment.balance || 0);
-        const interestData = schedule.map(payment => payment.interest || payment.interest_amount || 0);
+        // Use a running sum for interest payments rather than period values
+        let cumulativeInterest = 0;
+        const interestData = schedule.map(payment => {
+            const interestValue = payment.interest || payment.interest_amount || 0;
+            cumulativeInterest += interestValue;
+            return cumulativeInterest;
+        });
 
         const config = {
             type: 'line',


### PR DESCRIPTION
## Summary
- display interest payments as cumulative totals for balance-over-time charts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3077e849c832089edaaaf4af9e134