### PR TITLE
Align certain net-to-gross paths with service-only logic

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -2678,9 +2678,21 @@ class LoanCalculator:
         else:
             # USER-SPECIFIED FORMULAS for Bridge Loan Net to Gross
             import logging
-            
-            logging.info(f"Bridge Net-to-Gross ({repayment_option}): target_net={net_amount}")
-            logging.info(f"Input fees: arrangement={arrangement_fee_rate}%, legal={legal_fees}, site_visit={site_visit_fee}, title_insurance={title_insurance_rate}%")
+
+            original_option = repayment_option
+            if repayment_option in (
+                'service_and_capital',
+                'capital_payment_only',
+                'flexible_payment',
+            ):
+                repayment_option = 'service_only'
+
+            logging.info(
+                f"Bridge Net-to-Gross ({original_option}): target_net={net_amount}"
+            )
+            logging.info(
+                f"Input fees: arrangement={arrangement_fee_rate}%, legal={legal_fees}, site_visit={site_visit_fee}, title_insurance={title_insurance_rate}%"
+            )
             
             # Convert percentages to decimals
             arrangement_fee_decimal = arrangement_fee_rate / Decimal('100')
@@ -2879,9 +2891,21 @@ class LoanCalculator:
         else:
             # USER-SPECIFIED FORMULAS for Term Loan Net to Gross (same as Bridge)
             import logging
-            
-            logging.info(f"Term Net-to-Gross ({repayment_option}): target_net={net_amount}")
-            logging.info(f"Input fees: arrangement={arrangement_fee_rate}%, legal={legal_fees}, site_visit={site_visit_fee}, title_insurance={title_insurance_rate}%")
+
+            original_option = repayment_option
+            if repayment_option in (
+                'service_and_capital',
+                'capital_payment_only',
+                'flexible_payment',
+            ):
+                repayment_option = 'service_only'
+
+            logging.info(
+                f"Term Net-to-Gross ({original_option}): target_net={net_amount}"
+            )
+            logging.info(
+                f"Input fees: arrangement={arrangement_fee_rate}%, legal={legal_fees}, site_visit={site_visit_fee}, title_insurance={title_insurance_rate}%"
+            )
             
             # Convert percentages to decimals
             arrangement_fee_decimal = arrangement_fee_rate / Decimal('100')

--- a/test_bridge_capital_only_net.py
+++ b/test_bridge_capital_only_net.py
@@ -3,7 +3,7 @@ import pytest
 from calculations import LoanCalculator
 
 
-def test_bridge_capital_only_net_matches_input():
+def test_bridge_capital_only_net_matches_service_only():
     calc = LoanCalculator()
     net_amount = Decimal('95000')
     annual_rate = Decimal('12')
@@ -13,7 +13,21 @@ def test_bridge_capital_only_net_matches_input():
     site_visit_fee = Decimal('500')
     title_insurance_rate = Decimal('1')
     loan_term_days = 365
-    capital_repayment = Decimal('1000')
+
+    gross_service = calc._calculate_gross_from_net_bridge(
+        net_amount,
+        annual_rate,
+        loan_term,
+        'service_only',
+        arrangement_fee_rate,
+        legal_fees,
+        site_visit_fee,
+        title_insurance_rate,
+        loan_term_days,
+        use_360_days=False,
+        payment_frequency='monthly',
+        payment_timing='advance',
+    )
 
     gross = calc._calculate_gross_from_net_bridge(
         net_amount,
@@ -30,23 +44,4 @@ def test_bridge_capital_only_net_matches_input():
         payment_timing='advance',
     )
 
-    fees = calc._calculate_fees(
-        gross,
-        arrangement_fee_rate,
-        legal_fees,
-        site_visit_fee,
-        title_insurance_rate,
-        Decimal('0'),
-    )
-
-    res = calc._calculate_bridge_capital_payment_only(
-        gross,
-        annual_rate,
-        loan_term,
-        capital_repayment,
-        fees,
-        payment_frequency='monthly',
-        payment_timing='advance'
-    )
-
-    assert res['netAdvance'] == pytest.approx(float(net_amount))
+    assert float(gross) == pytest.approx(float(gross_service))

--- a/test_capital_and_flexible_net_to_gross_roundtrip.py
+++ b/test_capital_and_flexible_net_to_gross_roundtrip.py
@@ -1,51 +1,34 @@
 from decimal import Decimal
-from datetime import datetime
 import pytest
 from calculations import LoanCalculator
 
+@pytest.mark.parametrize("repayment_option", [
+    "service_and_capital",
+    "capital_payment_only",
+    "flexible_payment",
+])
 @pytest.mark.parametrize("payment_frequency,payment_timing", [
     ("monthly", "advance"),
     ("monthly", "arrears"),
     ("quarterly", "advance"),
     ("quarterly", "arrears"),
 ])
-def test_capital_payment_only_net_to_gross_roundtrip(payment_frequency, payment_timing):
+def test_net_to_gross_matches_service_only(repayment_option, payment_frequency, payment_timing):
     calc = LoanCalculator()
-    gross_amount = Decimal('100000')
+    net_amount = Decimal('100000')
     annual_rate = Decimal('12')
     loan_term = 12
-    capital_repayment = Decimal('1000')
     arrangement_fee_rate = Decimal('2')
     legal_fees = Decimal('1000')
     site_visit_fee = Decimal('500')
     title_insurance_rate = Decimal('1')
     loan_term_days = 365
 
-    fees = calc._calculate_fees(
-        gross_amount,
-        arrangement_fee_rate,
-        legal_fees,
-        site_visit_fee,
-        title_insurance_rate,
-        Decimal('0'),
-    )
-
-    net = calc._calculate_bridge_capital_payment_only(
-        gross_amount,
-        annual_rate,
-        loan_term,
-        capital_repayment,
-        fees,
-        payment_frequency=payment_frequency,
-        payment_timing=payment_timing,
-    )
-    net_amount = Decimal(str(net['netAdvance']))
-
-    gross_calculated = calc._calculate_gross_from_net_bridge(
+    gross_service = calc._calculate_gross_from_net_bridge(
         net_amount,
         annual_rate,
         loan_term,
-        'capital_payment_only',
+        'service_only',
         arrangement_fee_rate,
         legal_fees,
         site_visit_fee,
@@ -56,53 +39,11 @@ def test_capital_payment_only_net_to_gross_roundtrip(payment_frequency, payment_
         payment_timing=payment_timing,
     )
 
-    assert float(gross_calculated) == pytest.approx(float(gross_amount))
-
-
-@pytest.mark.parametrize("payment_frequency,payment_timing", [
-    ("monthly", "advance"),
-    ("monthly", "arrears"),
-    ("quarterly", "advance"),
-    ("quarterly", "arrears"),
-])
-def test_flexible_payment_net_to_gross_roundtrip(payment_frequency, payment_timing):
-    calc = LoanCalculator()
-    gross_amount = Decimal('100000')
-    annual_rate = Decimal('12')
-    loan_term = 12
-    flexible_payment = Decimal('2000')
-    arrangement_fee_rate = Decimal('2')
-    legal_fees = Decimal('1000')
-    site_visit_fee = Decimal('500')
-    title_insurance_rate = Decimal('1')
-    loan_term_days = 365
-
-    fees = calc._calculate_fees(
-        gross_amount,
-        arrangement_fee_rate,
-        legal_fees,
-        site_visit_fee,
-        title_insurance_rate,
-        Decimal('0'),
-    )
-
-    res = calc._calculate_bridge_flexible(
-        gross_amount,
-        annual_rate,
-        loan_term,
-        flexible_payment,
-        fees,
-        start_date=datetime(2024, 1, 1),
-        payment_frequency=payment_frequency,
-        payment_timing=payment_timing,
-    )
-    net_amount = Decimal(str(res['netAdvance']))
-
     gross_calculated = calc._calculate_gross_from_net_bridge(
         net_amount,
         annual_rate,
         loan_term,
-        'flexible_payment',
+        repayment_option,
         arrangement_fee_rate,
         legal_fees,
         site_visit_fee,
@@ -113,4 +54,4 @@ def test_flexible_payment_net_to_gross_roundtrip(payment_frequency, payment_timi
         payment_timing=payment_timing,
     )
 
-    assert float(gross_calculated) == pytest.approx(float(gross_amount))
+    assert float(gross_calculated) == pytest.approx(float(gross_service))


### PR DESCRIPTION
## Summary
- Map Service+Capital, Capital Only, and Flexible Payment net-to-gross calculations to Service Only logic
- Add tests ensuring these repayment options yield the same gross as Service Only
- Update existing tests to reflect new net-to-gross behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b316a8b0688320a09879789d0c9b67