### PR TITLE
Fix net-to-gross interest calculations for non-service-only options

### DIFF
--- a/test_capital_and_flexible_net_to_gross_roundtrip.py
+++ b/test_capital_and_flexible_net_to_gross_roundtrip.py
@@ -55,3 +55,34 @@ def test_net_to_gross_matches_service_only(repayment_option, payment_frequency, 
     )
 
     assert float(gross_calculated) == pytest.approx(float(gross_service))
+
+
+@pytest.mark.parametrize("repayment_option", [
+    "service_and_capital",
+    "capital_payment_only",
+    "flexible_payment",
+])
+def test_interest_only_total_uses_gross_amount(repayment_option):
+    calc = LoanCalculator()
+    params = {
+        'amount_input_type': 'net',
+        'net_amount': Decimal('100000'),
+        'annual_rate': Decimal('12'),
+        'loan_term': 12,
+        'repayment_option': repayment_option,
+        'capital_repayment': Decimal('1000'),
+        'flexible_payment': Decimal('2000'),
+        'arrangement_fee_rate': Decimal('2'),
+        'legal_fees': Decimal('1000'),
+        'site_visit_fee': Decimal('500'),
+        'title_insurance_rate': Decimal('1'),
+        'payment_frequency': 'monthly',
+        'payment_timing': 'arrears',
+    }
+
+    result = calc.calculate_bridge_loan(params)
+    gross = Decimal(str(result['grossAmount']))
+    expected = gross * Decimal('12') / Decimal('100') * Decimal('1')
+
+    assert abs(float(result['interestOnlyTotal']) - float(expected)) < 0.01
+    assert Decimal(str(result['netAdvance'])) == Decimal('100000')


### PR DESCRIPTION
## Summary
- compute service+capital, flexible payment, and capital-only loans from net inputs using calculated gross amount
- ensure interest-only totals recalc from gross after schedule generation
- test interest-only totals for net-to-gross scenarios across repayment options

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b31d373edc8320a34e16ca143564e7