### PR TITLE
Use day-count basis for service-and-capital term schedule interest

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -4683,8 +4683,8 @@ class LoanCalculator:
                 principal_payment = remaining_balance if is_final_payment else Decimal('0')
                 total_payment = interest_paid + principal_payment
             elif repayment_option == 'service_and_capital':
-                interest_due = self._calculate_periodic_interest(
-                    remaining_balance, annual_rate / Decimal('100'), payment_frequency
+                interest_paid = self.calculate_simple_interest_by_days(
+                    remaining_balance, annual_rate, days_in_period, use_360_days
                 )
                 capital_repayment = Decimal(str(quote_data.get('capital_repayment', 1000)))
                 if payment_frequency == 'quarterly':
@@ -4695,7 +4695,6 @@ class LoanCalculator:
                 principal_payment = capital_per_payment
                 if principal_payment > remaining_balance:
                     principal_payment = remaining_balance
-                interest_paid = interest_due
                 total_payment = interest_paid + principal_payment
             elif repayment_option == 'flexible_payment':
                 interest_due = self._calculate_periodic_interest(


### PR DESCRIPTION
## Summary
- compute service-and-capital term schedule interest using `calculate_simple_interest_by_days`
- ensure principal and totals use day-count-based interest to align accrued and retained figures

## Testing
- `pytest test_service_and_capital_schedule_summary.py test_quarterly_service_and_capital_schedule.py test_bridge_frequency_timing_effects.py test_advance_payment_schedule.py test_bridge_net_to_gross.py test_capital_and_flexible_net_to_gross_roundtrip.py test_report_service_and_capital_interest.py test_period_fields.py test_bridge_day_count_non_retained.py test_monthly_interest_savings.py test_service_and_flexible_schedule_match_capital.py`


------
https://chatgpt.com/codex/tasks/task_e_68b323991ce48320981cec1832cadf5e