### PR TITLE
Use day-based period factor for advance service+capital

### DIFF
--- a/test_bridge_net_to_gross.py
+++ b/test_bridge_net_to_gross.py
@@ -307,8 +307,11 @@ def test_service_and_capital_advance_net_to_gross_roundtrip():
         title_insurance_rate,
         Decimal('0'),
     )
-    period_interest = calc._calculate_periodic_interest(
-        gross_amount, annual_rate / Decimal('100'), 'monthly'
+    days_per_year = Decimal('365')
+    periods = Decimal(str(loan_term))
+    days_first_period = Decimal(str(loan_term_days)) / periods
+    period_interest = gross_amount * (
+        annual_rate / Decimal('100') * (days_first_period / days_per_year)
     )
     net_advance = (
         gross_amount


### PR DESCRIPTION
## Summary
- compute first-period days for service+capital advance bridging loans and derive period interest from it
- log first-period day count and period factor for clarity
- adjust net-to-gross roundtrip test to use day-based period interest

## Testing
- `pytest -q test_bridge_*`

------
https://chatgpt.com/codex/tasks/task_e_68b32d3e650c83208c64fad47d0d5b5d