### PR TITLE
Use daily rate for service+capital net-to-gross

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -2840,9 +2840,10 @@ class LoanCalculator:
                             else Decimal(str(loan_term))
                         )
                         days_first_period = Decimal(str(loan_term_days)) / periods
-                    period_factor = annual_rate_decimal * (
-                        days_first_period / days_per_year
-                    )
+
+                    daily_rate = annual_rate_decimal / days_per_year
+                    period_factor = daily_rate * days_first_period
+
                     denominator = (
                         Decimal('1')
                         - arrangement_fee_decimal
@@ -2859,7 +2860,10 @@ class LoanCalculator:
                         f"Days in first period: {days_first_period}"
                     )
                     logging.info(
-                        f"Period interest factor: {annual_rate}% × {days_first_period}/{days_per_year} = {period_factor:.6f}"
+                        f"Daily rate: {annual_rate}% / {days_per_year} = {daily_rate:.6f}"
+                    )
+                    logging.info(
+                        f"Period interest factor: {days_first_period} × {daily_rate:.6f} = {period_factor:.6f}"
                     )
                 else:
                     denominator = Decimal('1') - arrangement_fee_decimal - title_insurance_decimal
@@ -2873,7 +2877,7 @@ class LoanCalculator:
                 logging.info(
                     f"Gross = (£{net_amount} + £{total_legal_fees}) / (1 - {arrangement_fee_decimal:.6f} - {title_insurance_decimal:.6f}"
                     + (
-                        f" - {period_factor:.6f} ({days_first_period}/{days_per_year} of {annual_rate}%)"
+                        f" - {period_factor:.6f} ({days_first_period}×{daily_rate:.6f})"
                         if payment_timing == 'advance'
                         else ""
                     )

--- a/test_bridge_net_to_gross.py
+++ b/test_bridge_net_to_gross.py
@@ -392,6 +392,54 @@ def test_flexible_payment_net_to_gross_matches_service_only(payment_frequency, p
     assert float(gross_calculated) == pytest.approx(float(gross_service))
 
 
+def test_service_and_capital_net_to_gross_uses_day_interest():
+    """Interest retained for service + capital uses Gross × Days × Daily Rate."""
+    calc = LoanCalculator()
+    params = {
+        'annual_rate': Decimal('12'),
+        'loan_term': 12,
+        'repayment_option': 'service_and_capital',
+        'arrangement_fee_rate': Decimal('2'),
+        'legal_fees': Decimal('1000'),
+        'site_visit_fee': Decimal('500'),
+        'title_insurance_rate': Decimal('1'),
+        'capital_repayment': Decimal('1000'),
+        'payment_frequency': 'monthly',
+        'payment_timing': 'advance',
+        'start_date': '2024-01-01',
+    }
+
+    start_dt = datetime.strptime(params['start_date'], '%Y-%m-%d')
+    loan_term_days = (calc._add_months(start_dt, params['loan_term']) - start_dt).days
+
+    net_amount = Decimal('95000')
+    gross = calc._calculate_gross_from_net_bridge(
+        net_amount,
+        params['annual_rate'],
+        params['loan_term'],
+        params['repayment_option'],
+        params['arrangement_fee_rate'],
+        params['legal_fees'],
+        params['site_visit_fee'],
+        params['title_insurance_rate'],
+        loan_term_days,
+        use_360_days=False,
+        payment_frequency=params['payment_frequency'],
+        payment_timing=params['payment_timing'],
+        start_date=start_dt,
+    )
+
+    result = calc.calculate_bridge_loan(dict(params, amount_input_type='net', net_amount=net_amount))
+
+    first = result['detailed_payment_schedule'][0]
+    interest_first = Decimal(first['interest_amount'].replace('£', '').replace(',', ''))
+    days_first = Decimal(str(first['days_held']))
+    daily_rate = (params['annual_rate'] / Decimal('100')) / Decimal('365')
+    expected = (gross * daily_rate * days_first).quantize(Decimal('0.01'))
+
+    assert interest_first == expected
+
+
 @pytest.mark.parametrize("payment_timing", ["advance", "arrears"])
 def test_service_and_capital_net_matches_gross_schedule(payment_timing):
     calc = LoanCalculator()
@@ -493,3 +541,51 @@ def test_capital_payment_only_net_to_gross_matches_service_only(payment_frequenc
     )
 
     assert float(gross_calculated) == pytest.approx(float(gross_service))
+
+
+def test_service_and_capital_net_to_gross_uses_day_interest():
+    """Interest retained for service + capital uses Gross × Days × Daily Rate."""
+    calc = LoanCalculator()
+    params = {
+        'annual_rate': Decimal('12'),
+        'loan_term': 12,
+        'repayment_option': 'service_and_capital',
+        'arrangement_fee_rate': Decimal('2'),
+        'legal_fees': Decimal('1000'),
+        'site_visit_fee': Decimal('500'),
+        'title_insurance_rate': Decimal('1'),
+        'capital_repayment': Decimal('1000'),
+        'payment_frequency': 'monthly',
+        'payment_timing': 'advance',
+        'start_date': '2024-01-01',
+    }
+
+    start_dt = datetime.strptime(params['start_date'], '%Y-%m-%d')
+    loan_term_days = (calc._add_months(start_dt, params['loan_term']) - start_dt).days
+
+    net_amount = Decimal('95000')
+    gross = calc._calculate_gross_from_net_bridge(
+        net_amount,
+        params['annual_rate'],
+        params['loan_term'],
+        params['repayment_option'],
+        params['arrangement_fee_rate'],
+        params['legal_fees'],
+        params['site_visit_fee'],
+        params['title_insurance_rate'],
+        loan_term_days,
+        use_360_days=False,
+        payment_frequency=params['payment_frequency'],
+        payment_timing=params['payment_timing'],
+        start_date=start_dt,
+    )
+
+    result = calc.calculate_bridge_loan(dict(params, amount_input_type='net', net_amount=net_amount))
+
+    first = result['detailed_payment_schedule'][0]
+    interest_first = Decimal(first['interest_amount'].replace('£', '').replace(',', ''))
+    days_first = Decimal(str(first['days_held']))
+    daily_rate = (params['annual_rate'] / Decimal('100')) / Decimal('365')
+    expected = (gross * daily_rate * days_first).quantize(Decimal('0.01'))
+
+    assert interest_first == expected


### PR DESCRIPTION
## Summary
- compute service+capital net-to-gross interest using Gross × Days × Daily Rate
- test that daily-rate interest retention is applied in net-to-gross conversion

## Testing
- `pytest test_bridge_net_to_gross.py::test_service_and_capital_net_to_gross_uses_day_interest -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b33519716c8320be9f4cb334b5a3cd