### PR TITLE
Align service-and-capital net-to-gross with service-only logic

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -2748,6 +2748,7 @@ class LoanCalculator:
             if repayment_option in (
                 'capital_payment_only',
                 'flexible_payment',
+                'service_and_capital',
             ):
                 repayment_option = 'service_only'
 


### PR DESCRIPTION
## Summary
- Treat `service_and_capital` payments like `service_only` during net-to-gross conversions
- Expand test coverage ensuring service + capital uses service-only formula
- Update roundtrip test to reflect simplified first-period interest

## Testing
- `pytest test_bridge_net_to_gross.py test_capital_and_flexible_net_to_gross_roundtrip.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b33bf82b5c8320a751b82f7d95d019