### PR TITLE
Align service+capital net advance with service-only

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -2069,11 +2069,15 @@ class LoanCalculator:
         monthly_payment = capital_repayment + (gross_amount * monthly_rate / 100)
 
         if net_amount is not None:
-            net_advance = net_amount
+            # User provided net amount represents the net advance after any first period interest deduction
+            net_advance_after_first_interest = net_amount
+            net_advance_before_interest = net_amount + (first_period_interest if payment_timing == 'advance' else Decimal('0'))
         else:
-            net_advance = gross_amount - fees.get('arrangementFee', Decimal('0')) - fees.get('totalLegalFees', Decimal('0'))
+            net_advance_before_interest = gross_amount - fees.get('arrangementFee', Decimal('0')) - fees.get('totalLegalFees', Decimal('0'))
             if payment_timing == 'advance':
-                net_advance -= first_period_interest
+                net_advance_after_first_interest = net_advance_before_interest - first_period_interest
+            else:
+                net_advance_after_first_interest = net_advance_before_interest
 
         return {
             'gross_amount': float(gross_amount),
@@ -2081,7 +2085,9 @@ class LoanCalculator:
             'totalInterest': self._two_dp(total_interest),
             'total_interest': self._two_dp(total_interest),
             'totalAmount': self._two_dp(gross_amount + total_interest),
-            'netAdvance': self._two_dp(net_advance),
+            'netAdvance': self._two_dp(net_advance_after_first_interest),
+            'firstPeriodInterest': self._two_dp(first_period_interest),
+            'netAdvanceBeforeInterest': self._two_dp(net_advance_before_interest),
             'interestOnlyTotal': self._two_dp(interest_only_total),
             'interestSavings': self._two_dp(interest_savings),
             'savingsPercentage': float(savings_percentage)

--- a/test_bridge_net_to_gross.py
+++ b/test_bridge_net_to_gross.py
@@ -277,12 +277,14 @@ def test_service_and_capital_advance_net_deducts_interest():
     first_period_interest = (
         gross_amount * (annual_rate / Decimal('100')) * (days_per_period / days_per_year)
     )
-    expected_net = (
+    expected_before_interest = (
         gross_amount
         - fees['arrangementFee']
         - fees['totalLegalFees']
-        - first_period_interest
     )
+    expected_net = expected_before_interest - first_period_interest
+    assert float(result['netAdvanceBeforeInterest']) == pytest.approx(float(expected_before_interest), abs=0.01)
+    assert float(result['firstPeriodInterest']) == pytest.approx(float(first_period_interest), abs=0.01)
     assert float(result['netAdvance']) == pytest.approx(float(expected_net), abs=0.01)
 
 


### PR DESCRIPTION
## Summary
- include first-period interest and before-interest net advance in service+capital calculations
- verify service+capital first period interest and net advance values

## Testing
- `pytest test_bridge_net_to_gross.py::test_service_and_capital_advance_net_deducts_interest -q`
- `pytest test_bridge_net_to_gross.py::test_service_and_capital_net_to_gross_matches_service_only -q`
- `pytest test_service_and_capital_schedule_summary.py::test_service_and_capital_summary_matches_schedule_advance -q`
- `pytest test_service_and_capital_schedule_summary.py::test_service_and_capital_summary_matches_schedule_arrears -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3401e04088320b741aeb58f9e7c48