### PR TITLE
Revert start date-based bridge calculation changes

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -505,7 +505,6 @@ class LoanCalculator:
                 use_360_days,
                 payment_frequency,
                 payment_timing,
-                start_date,
             )
             # Generate detailed payment schedule
             currency_symbol = params.get('currencySymbol', params.get('currency_symbol', '£'))
@@ -2019,21 +2018,8 @@ class LoanCalculator:
             'netAdvanceBeforeInterest': self._two_dp(net_advance_before_interest)
         }
     
-    def _calculate_bridge_service_capital(
-        self,
-        gross_amount: Decimal,
-        monthly_rate: Decimal,
-        loan_term: int,
-        capital_repayment: Decimal,
-        fees: Dict,
-        interest_type: str = 'simple',
-        net_amount: Decimal = None,
-        loan_term_days: int = None,
-        use_360_days: bool = False,
-        payment_frequency: str = 'monthly',
-        payment_timing: str = 'arrears',
-        start_date: Optional[datetime] = None,
-    ) -> Dict:
+    def _calculate_bridge_service_capital(self, gross_amount: Decimal, monthly_rate: Decimal,
+                                        loan_term: int, capital_repayment: Decimal, fees: Dict, interest_type: str = 'simple', net_amount: Decimal = None, loan_term_days: int = None, use_360_days: bool = False, payment_frequency: str = 'monthly', payment_timing: str = 'arrears') -> Dict:
         """Calculate bridge loan with service + capital payments.
 
         This version supports monthly or quarterly payments and timing in advance
@@ -2057,38 +2043,15 @@ class LoanCalculator:
 
         annual_rate = monthly_rate * 12
 
-        # Determine period day counts when using exact dates
-        day_counts: List[Decimal] = []
-        if start_date is not None and interest_type == 'simple':
-            payment_dates = self._generate_payment_dates(
-                start_date, loan_term, payment_frequency, payment_timing
-            )
-            period_ranges = self._compute_period_ranges(
-                start_date, payment_dates, loan_term, payment_timing
-            )
-
-            group_size = 3 if payment_frequency == 'quarterly' else 1
-            running = 0
-            for idx, pr in enumerate(period_ranges, 1):
-                running += pr['days_held']
-                if idx % group_size == 0 or idx == len(period_ranges):
-                    day_counts.append(Decimal(str(running)))
-                    running = 0
-
-            days_per_year = Decimal('360') if use_360_days else Decimal('365')
-            first_period_interest = gross_amount * (annual_rate / Decimal('100')) * (
-                day_counts[0] / days_per_year
-            )
-        elif loan_term_days is not None and interest_type == 'simple':
+        # Pre-compute first period interest for potential advance payments
+        if loan_term_days is not None and interest_type == 'simple':
             days_per_year = Decimal('360') if use_360_days else Decimal('365')
             days_per_period = Decimal(str(loan_term_days)) / Decimal(str(periods))
             first_period_interest = gross_amount * (annual_rate / Decimal('100')) * (
                 days_per_period / days_per_year
             )
-            day_counts = [Decimal(str(days_per_period)) for _ in range(periods)]
         else:
             first_period_interest = gross_amount * rate_per_period
-            day_counts = [None] * periods  # type: ignore[list-item]
 
         for i in range(periods):
             if remaining_balance <= 0:
@@ -2096,18 +2059,10 @@ class LoanCalculator:
 
             opening_balance = remaining_balance
 
-            if day_counts and day_counts[0] is not None and interest_type == 'simple':
-                days_per_year = Decimal('360') if use_360_days else Decimal('365')
-                days_in_period = day_counts[i]
-                interest_payment = opening_balance * (annual_rate / Decimal('100')) * (
-                    days_in_period / days_per_year
-                )
-            elif loan_term_days is not None and interest_type == 'simple':
+            if loan_term_days is not None and interest_type == 'simple':
                 days_per_year = Decimal('360') if use_360_days else Decimal('365')
                 days_per_period = Decimal(str(loan_term_days)) / Decimal(str(periods))
-                interest_payment = opening_balance * (annual_rate / Decimal('100')) * (
-                    days_per_period / days_per_year
-                )
+                interest_payment = opening_balance * (annual_rate / Decimal('100')) * (days_per_period / days_per_year)
             else:
                 # Only simple interest is fully supported with frequency/timing.
                 if interest_type == 'simple':
@@ -2122,14 +2077,7 @@ class LoanCalculator:
             remaining_balance -= pay
 
         # Interest-only comparison assumes no capital repayments
-        if day_counts and day_counts[0] is not None and interest_type == 'simple':
-            days_per_year = Decimal('360') if use_360_days else Decimal('365')
-            interest_only_total = sum(
-                gross_amount * (annual_rate / Decimal('100')) * (dc / days_per_year)
-                for dc in day_counts
-            )
-        else:
-            interest_only_total = gross_amount * rate_per_period * periods
+        interest_only_total = gross_amount * rate_per_period * periods
         interest_savings = interest_only_total - total_interest
         savings_percentage = (interest_savings / interest_only_total * 100) if interest_only_total > 0 else 0
 

--- a/test_bridge_net_to_gross.py
+++ b/test_bridge_net_to_gross.py
@@ -301,8 +301,7 @@ def test_service_only_advance_net_to_gross_roundtrip():
     assert float(gross_calculated) == pytest.approx(float(gross_amount))
 
 
-@pytest.mark.parametrize("start_date", [None, datetime.strptime("2024-01-01", "%Y-%m-%d")])
-def test_service_and_capital_advance_net_deducts_interest(start_date):
+def test_service_and_capital_advance_net_deducts_interest():
     """Service + capital gross-to-net should deduct first period interest when in advance."""
     calc = LoanCalculator()
     gross_amount = Decimal('100000')
@@ -313,13 +312,7 @@ def test_service_and_capital_advance_net_deducts_interest(start_date):
     site_visit_fee = Decimal('500')
     title_insurance_rate = Decimal('1')
     capital_repayment = Decimal('1000')
-
-    if start_date is None:
-        loan_term_days = 274
-        days_first_period = Decimal(loan_term_days) / Decimal(loan_term)
-    else:
-        loan_term_days = (calc._add_months(start_date, loan_term) - start_date).days
-        days_first_period = (calc._add_months(start_date, 1) - start_date).days
+    loan_term_days = 274
 
     fees = calc._calculate_fees(
         gross_amount,
@@ -342,11 +335,11 @@ def test_service_and_capital_advance_net_deducts_interest(start_date):
         use_360_days=False,
         payment_frequency='monthly',
         payment_timing='advance',
-        start_date=start_date,
     )
     days_per_year = Decimal('365')
+    days_per_period = Decimal(str(loan_term_days)) / Decimal(str(loan_term))
     first_period_interest = (
-        gross_amount * (annual_rate / Decimal('100')) * (Decimal(days_first_period) / days_per_year)
+        gross_amount * (annual_rate / Decimal('100')) * (days_per_period / days_per_year)
     )
     expected_before_interest = (
         gross_amount
@@ -563,10 +556,6 @@ def test_service_and_capital_net_matches_gross_schedule(payment_timing):
     assert net_result['totalInterest'] == pytest.approx(gross_result['totalInterest'])
     assert net_result['retainedInterest'] == pytest.approx(gross_result['retainedInterest'])
     assert net_result['interestRefund'] == pytest.approx(gross_result['interestRefund'])
-    assert net_result['netAdvance'] == pytest.approx(float(net_amount))
-    if payment_timing == 'advance':
-        expected_before = float(net_amount) + net_result['firstPeriodInterest']
-        assert net_result['netAdvanceBeforeInterest'] == pytest.approx(expected_before)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- revert merge that introduced start-date precise day count for service + capital bridge loans
- adjust corresponding test to reflect fixed day-based calculation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3533351b483208972fb79d6a7a97c