### PR TITLE
feat: display retained and refund interest

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -795,7 +795,38 @@ class LoanCalculator {
         const loanType = document.getElementById('loanType').value;
         const repaymentOption = document.getElementById('repaymentOption').value;
         const paymentFrequency = document.querySelector('input[name="payment_frequency"]:checked')?.value || 'monthly';
-        
+
+        // Retained interest and refund
+        const retainedInterestRow = document.getElementById('retainedInterestRow');
+        const retainedInterestEl = document.getElementById('retainedInterestResult');
+        const interestRefundRow = document.getElementById('interestRefundRow');
+        const interestRefundEl = document.getElementById('interestRefundResult');
+
+        const retainedInterestVal = parseFloat(results.retainedInterest ?? results.retained_interest ?? 0);
+        const interestRefundVal = parseFloat(results.interestRefund ?? results.interest_refund ?? 0);
+
+        if (retainedInterestRow) {
+            if (retainedInterestVal > 0) {
+                retainedInterestRow.style.display = 'table-row';
+                if (retainedInterestEl) {
+                    retainedInterestEl.textContent = retainedInterestVal.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+                }
+            } else {
+                retainedInterestRow.style.display = 'none';
+            }
+        }
+
+        if (interestRefundRow) {
+            if (interestRefundVal > 0) {
+                interestRefundRow.style.display = 'table-row';
+                if (interestRefundEl) {
+                    interestRefundEl.textContent = interestRefundVal.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+                }
+            } else {
+                interestRefundRow.style.display = 'none';
+            }
+        }
+
         // Show interest-only total and savings if available (for flexible payment options)
         const interestOnlyTotalRow = document.getElementById('interestOnlyTotalRow');
         const interestOnlyTotalEl = document.getElementById('interestOnlyTotalResult');

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -905,6 +905,16 @@
 <td class="text-end px-3" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;"><span id="interestRatePercentageDisplay">12.00%</span> <span class="currency-symbol">£</span></td>
 <td class="fw-bold px-3 text-end" id="totalInterestResult" style="color: #000 !important; background: #f8f9fa;">-</td>
 </tr>
+<tr id="retainedInterestRow" style="border: 1px solid #000; display: none;">
+  <td class="px-3" style="color: #000 !important; border-right: 1px solid #000; background: white;">Retained Interest</td>
+  <td class="text-end px-3 currency-symbol" style="color: #000 !important; border-right: 1px solid #000; background: white;">£</td>
+  <td class="fw-bold px-3 text-end" id="retainedInterestResult" style="color: #000 !important; background: white;">-</td>
+</tr>
+<tr id="interestRefundRow" style="border: 1px solid #000; display: none;">
+  <td class="px-3" style="color: #28a745 !important; border-right: 1px solid #000; background: #f8f9fa;">Interest Refund</td>
+  <td class="text-end px-3 currency-symbol" style="color: #28a745 !important; border-right: 1px solid #000; background: #f8f9fa;">£</td>
+  <td class="fw-bold px-3 text-end" id="interestRefundResult" style="color: #28a745 !important; background: #f8f9fa;">-</td>
+</tr>
 <tr id="interestOnlyTotalRow" style="border: 1px solid #000; display: none;">
 <td class="px-3" style="color: #6c757d !important; border-right: 1px solid #000; background: white;">Interest-Only Total</td>
 <td class="text-end px-3 currency-symbol" style="color: #6c757d !important; border-right: 1px solid #000; background: white;">£</td>


### PR DESCRIPTION
## Summary
- show retained interest and interest refund rows in loan summary
- populate retained/refund values in calculator results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37c1a619c8320b76fa2762eb75d38