### PR TITLE
Use first-period day count for summary interest

### DIFF
--- a/test_capital_payment_summary_monthly_interest.py
+++ b/test_capital_payment_summary_monthly_interest.py
@@ -37,9 +37,11 @@ def test_capital_only_summary_includes_monthly_interest():
         'site_visit_fee': 0,
         'title_insurance_rate': 0,
         'property_value': 3000000,
+        'start_date': '2024-01-01',
     }
     result = calc.calculate_bridge_loan(params)
 
-    expected_monthly_interest = 2000000 * 0.12 / 12
+    days_first_month = 31  # January has 31 days
+    expected_monthly_interest = 2000000 * 0.12 / 365 * days_first_month
     assert result['periodicInterest'] == pytest.approx(expected_monthly_interest, abs=0.01)
     assert result['monthlyPayment'] == pytest.approx(10000, abs=0.01)

--- a/test_gross_net_roundtrip_fields.py
+++ b/test_gross_net_roundtrip_fields.py
@@ -35,7 +35,8 @@ def test_gross_to_net_and_back_fields():
     assert gross_result['titleInsurance'] == pytest.approx(3360.0)
     assert gross_result['totalInterest'] == pytest.approx(233447.68)
     assert gross_result['interestOnlyTotal'] == pytest.approx(240000.0)
-    assert gross_result['periodicInterest'] == pytest.approx(20000.0)
+    expected_first_interest = 2000000 * 0.12 / 365 * 31
+    assert gross_result['periodicInterest'] == pytest.approx(expected_first_interest, abs=0.01)
 
     net_params = dict(params, amount_input_type='net', net_amount=Decimal('1934640'))
     net_result = calc.calculate_bridge_loan(net_params)
@@ -52,4 +53,4 @@ def test_gross_to_net_and_back_fields():
     assert net_result['titleInsurance'] == pytest.approx(3360.0)
     assert net_result['totalInterest'] == pytest.approx(233447.68)
     assert net_result['interestOnlyTotal'] == pytest.approx(240000.0)
-    assert net_result['periodicInterest'] == pytest.approx(20000.0)
+    assert net_result['periodicInterest'] == pytest.approx(expected_first_interest, abs=0.01)


### PR DESCRIPTION
## Summary
- compute monthly interest payments using actual days held in first period
- derive interest-only totals via daily rates for net-to-gross calculations
- update tests for days-held monthly interest calculations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b38e3b2d948320b1552435c6fc915b