### PR TITLE
Fix retained interest calculation to use gross amount

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -4622,16 +4622,17 @@ class LoanCalculator:
                 else:
                     final_principal = remaining_balance
                     interest_accrued = opening_balance * daily_rate * days_in_period
-                    interest_refund_current = interest_retained_current - interest_accrued
                     interest_accrued_disp = interest_accrued.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
                     interest_retained_disp = interest_retained_current.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-                    interest_refund_disp = interest_refund_current.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-                    interest_amount = -interest_refund_current
-                    interest_amount_disp = interest_amount.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
-                    total_final_payment = final_principal + interest_amount
+                    # Derive refund from the difference to avoid rounding drift
+                    interest_refund_disp = (interest_retained_disp - interest_accrued_disp).quantize(
+                        Decimal('0.01'), rounding=ROUND_HALF_UP
+                    )
+                    interest_amount_disp = -interest_refund_disp
+                    total_final_payment = final_principal + interest_amount_disp
                     total_final_payment_disp = total_final_payment.quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
                     interest_display = f"-{currency_symbol}{interest_refund_disp:,.2f}"
-                    cumulative_refund += interest_refund_current
+                    cumulative_refund += interest_refund_disp
                     capital_outstanding = Decimal('0') if payment_timing == 'advance' else opening_balance
                     detailed_schedule.append({
                         'payment_date': payment_date.strftime('%d/%m/%Y'),


### PR DESCRIPTION
## Summary
- Derive report schedule gross amount from calculation results, ensuring retained interest uses the correct base for net-to-gross and service+capital loans
- Align final capital-payment-only period calculations to prevent rounding drift in retained/accrued interest

## Testing
- `pytest test_report_service_and_capital_interest.py test_report_interest_days_held.py test_service_and_flexible_schedule_match_capital.py -q`
- `pytest test_interest_accrued_total.py::test_interest_accrued_matches_summary -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3968315a88320bf3842b8e407961b