### PR TITLE
Fix period range handling and recompute bridge totals

### DIFF
--- a/report_utils.py
+++ b/report_utils.py
@@ -130,6 +130,12 @@ def generate_report_schedule(params: Dict[str, Any]) -> Tuple[List[Dict[str, Any
 
     summary: Dict[str, float] = {}
 
+    # Remove any internal unrounded fields to keep report output stable
+    for entry in schedule:
+        for key in list(entry.keys()):
+            if key.endswith('_raw'):
+                del entry[key]
+
     # Recalculate interest fields using days_held to ensure consistency in reports
     if schedule:
         currency_symbol = schedule[0].get('opening_balance', '£')[0]


### PR DESCRIPTION
## Summary
- ensure period ranges respect provided loan term days
- recalculate bridge loan summary totals from unrounded schedule values
- strip internal raw fields from generated report schedules

## Testing
- `pytest -q` *(fails: test_capital_payment_only_uses_actual_days_for_savings, test_service_capital_uses_actual_days, test_capital_payment_schedule_values, test_interest_accrued_total, test_service_and_flexible_schedule_match_capital, test_service_only_summary_matches_schedule)*

------
https://chatgpt.com/codex/tasks/task_e_68b45b02657883208adb48e2cd4a9461