### PR TITLE
Fix net-funded arrears retained interest schedule

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -4410,6 +4410,14 @@ class LoanCalculator:
                         interest_retained_raw_val = Decimal('0')
                         interest_refund_disp_val = Decimal('0.00')
                         interest_refund_raw_val = Decimal('0')
+                elif amount_input_type == 'net' and payment_timing == 'arrears':
+                    # Net-funded loans paid in arrears should show no retained interest
+                    interest_retained_disp_val = Decimal('0.00')
+                    interest_retained_raw_val = Decimal('0')
+                    interest_refund_disp_val = Decimal('0.00')
+                    interest_refund_raw_val = Decimal('0')
+                    interest_saving_disp = Decimal('0.00')
+                    interest_saving = Decimal('0')
 
                 balance_change = (
                     f"↓ -{currency_symbol}{principal_payment:,.2f}"

--- a/test_bridge_net_to_gross.py
+++ b/test_bridge_net_to_gross.py
@@ -556,9 +556,11 @@ def test_service_and_capital_net_matches_gross_schedule(payment_timing):
     net_result = calc.calculate_bridge_loan(net_params)
 
     if payment_timing == 'arrears':
-        assert gross_result['detailed_payment_schedule'] == net_result['detailed_payment_schedule']
-        assert net_result['retainedInterest'] == pytest.approx(gross_result['retainedInterest'])
-        assert net_result['interestRefund'] == pytest.approx(gross_result['interestRefund'])
+        for row in net_result['detailed_payment_schedule']:
+            assert row['interest_retained'] == '£0.00'
+            assert row['interest_refund'] == '£0.00'
+        assert net_result.get('retainedInterest', 0) == pytest.approx(0)
+        assert net_result.get('interestRefund', 0) == pytest.approx(0)
     else:
         gross_first = gross_result['detailed_payment_schedule'][0]
         net_first = net_result['detailed_payment_schedule'][0]

--- a/test_service_and_capital_net_arrears_no_retained_interest.py
+++ b/test_service_and_capital_net_arrears_no_retained_interest.py
@@ -1,0 +1,68 @@
+import sys, types
+from decimal import Decimal
+from datetime import datetime
+import pytest
+from calculations import LoanCalculator
+
+# Minimal stub for dateutil.relativedelta to avoid external dependency
+relativedelta_module = types.ModuleType('relativedelta')
+class relativedelta:
+    def __init__(self, months=0):
+        self.months = months
+    def __radd__(self, other):
+        from datetime import date
+        month = other.month - 1 + self.months
+        year = other.year + month // 12
+        month = month % 12 + 1
+        day = min(other.day, [31, 29 if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0) else 28,
+                              31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1])
+        return other.replace(year=year, month=month, day=day)
+relativedelta_module.relativedelta = relativedelta
+sys.modules['dateutil'] = types.ModuleType('dateutil')
+sys.modules['dateutil'].relativedelta = relativedelta_module
+sys.modules['dateutil.relativedelta'] = relativedelta_module
+
+
+def _currency_to_decimal(value: str) -> Decimal:
+    return Decimal(value.replace('£', '').replace(',', ''))
+
+
+def test_net_arrears_has_no_retained_interest():
+    calc = LoanCalculator()
+    start_date = datetime(2024, 1, 1)
+    loan_term = 12
+    loan_end = calc._add_months(start_date, loan_term)
+    loan_term_days = (loan_end - start_date).days
+    params = {
+        'loan_type': 'bridge',
+        'repayment_option': 'service_and_capital',
+        'amount_input_type': 'net',
+        'net_amount': 1000000,
+        'annual_rate': 12,
+        'loan_term': loan_term,
+        'capital_repayment': 5000,
+        'arrangement_fee_rate': 0,
+        'legal_fees': 0,
+        'site_visit_fee': 0,
+        'title_insurance_rate': 0,
+        'start_date': start_date.strftime('%Y-%m-%d'),
+        'loan_term_days': loan_term_days,
+        'payment_timing': 'arrears',
+        'payment_frequency': 'monthly',
+    }
+    result = calc.calculate_bridge_loan(params)
+    schedule = result['detailed_payment_schedule']
+
+    for row in schedule:
+        assert row['interest_retained'] == '£0.00'
+        assert row['interest_refund'] == '£0.00'
+
+    total_interest = sum(_currency_to_decimal(r['interest_accrued']) for r in schedule)
+    total_capital = sum(_currency_to_decimal(r['principal_payment']) for r in schedule)
+
+    assert total_interest.quantize(Decimal('0.01')) == Decimal(str(result['totalInterest'])).quantize(Decimal('0.01'))
+    gross = Decimal(str(result.get('gross_amount', result.get('grossAmount'))))
+    assert total_capital.quantize(Decimal('0.01')) == gross.quantize(Decimal('0.01'))
+    assert Decimal(str(result.get('retainedInterest', 0))) == Decimal('0')
+    assert Decimal(str(result.get('interestRefund', 0))) == Decimal('0')
+    assert Decimal(str(result['interestSavings'])) == Decimal('0')


### PR DESCRIPTION
## Summary
- zero retained and refunded interest in service+capital schedules when net-funded and paid in arrears
- add regression test to ensure net-funded arrears schedules show no retained interest
- update existing net-to-gross roundtrip test to check for zero retained interest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47d22d7a0832089e970d66f081174