### PR TITLE
Refactor service+capital net-to-gross calculation

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -2892,57 +2892,23 @@ class LoanCalculator:
                 )
                 
             elif repayment_option == 'service_and_capital':
-                # Bridge Service + Capital: deduct first period interest only when paid in advance
+                # Bridge Service + Capital net-to-gross uses explicit formula
+                arrangement_decimal = arrangement_fee_rate / Decimal('100')
+                title_decimal = title_insurance_rate / Decimal('100')
+                fixed_fees = legal_fees + site_visit_fee
+
+                period_factor = Decimal('0')
                 if payment_timing == 'advance':
                     days_per_year = Decimal('360') if use_360_days else Decimal('365')
                     periods = (
-                        Decimal('4')
-                        if payment_frequency == 'quarterly'
-                        else Decimal(str(loan_term))
+                        Decimal('4') if payment_frequency == 'quarterly' else Decimal(str(loan_term))
                     )
                     days_first_period = Decimal(str(loan_term_days)) / periods
-                    daily_rate = annual_rate_decimal / days_per_year
+                    daily_rate = (annual_rate / Decimal('100')) / days_per_year
                     period_factor = daily_rate * days_first_period
 
-                    denominator = (
-                        Decimal('1')
-                        - arrangement_fee_decimal
-                        - title_insurance_decimal
-                        - period_factor
-                    )
-                    logging.info(
-                        "BRIDGE SERVICE + CAPITAL NET-TO-GROSS (advance):"
-                    )
-                    logging.info(
-                        "Formula: Gross = (Net + Legals + Site) / (1 - Arrangement Fee - Period Interest - Title insurance)"
-                    )
-                    logging.info(
-                        f"Days in first period (avg): {days_first_period}"
-                    )
-                    logging.info(
-                        f"Daily rate: {annual_rate}% / {days_per_year} = {daily_rate:.6f}"
-                    )
-                    logging.info(
-                        f"Period interest factor: {days_first_period} × {daily_rate:.6f} = {period_factor:.6f}"
-                    )
-                else:
-                    denominator = Decimal('1') - arrangement_fee_decimal - title_insurance_decimal
-                    logging.info("BRIDGE SERVICE + CAPITAL NET-TO-GROSS (arrears):")
-                    logging.info(
-                        "Formula: Gross = (Net + Legals + Site) / (1 - Arrangement Fee - Title insurance)"
-                    )
-
-                gross_amount = (net_amount + total_legal_fees) / denominator
-
-                logging.info(
-                    f"Gross = (£{net_amount} + £{total_legal_fees}) / (1 - {arrangement_fee_decimal:.6f} - {title_insurance_decimal:.6f}"
-                    + (
-                        f" - {period_factor:.6f} ({days_first_period}×{daily_rate:.6f})"
-                        if payment_timing == 'advance'
-                        else ""
-                    )
-                    + f") = £{gross_amount:.2f}"
-                )
+                denominator = Decimal('1') - arrangement_decimal - title_decimal - period_factor
+                gross_amount = (net_amount + fixed_fees) / denominator
                 
             elif repayment_option == 'flexible_payment':
                 # Flexible Payment: borrower receives the full gross amount


### PR DESCRIPTION
## Summary
- Simplify service + capital net-to-gross to explicit fee-based formula with first-period interest only for advance payments

## Testing
- `pytest test_bridge_net_to_gross.py::test_service_and_capital_net_to_gross_uses_first_period_interest test_bridge_net_to_gross.py::test_service_and_capital_net_matches_gross_schedule test_bridge_net_to_gross.py::test_service_and_capital_net_to_gross_uses_day_interest test_capital_and_flexible_net_to_gross_roundtrip.py::test_net_to_gross_matches_service_only test_capital_and_flexible_net_to_gross_roundtrip.py::test_interest_only_total_uses_gross_amount test_capital_and_flexible_net_to_gross_roundtrip.py::test_zero_capital_repayment_matches_interest_only -q`

------
https://chatgpt.com/codex/tasks/task_e_68b48e69151c8320b6cdaff93466b4d6