### PR TITLE
Add S+C only repayment option

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -878,7 +878,7 @@ class LoanCalculator {
         const periodicInterestEl = document.getElementById('periodicInterestResult');
         const periodicInterestLabel = document.getElementById('periodicInterestLabel');
 
-        const interestRepaymentTypes = ['service_only', 'service_and_capital', 'capital_payment_only', 'flexible_payment'];
+        const interestRepaymentTypes = ['service_only', 'service_and_capital', 'capital_payment_only', 'flexible_payment', 'sc_only'];
         if ((loanType === 'term' || loanType === 'bridge') && interestRepaymentTypes.includes(repaymentOption)) {
             let periodicInterest = results.periodicInterest || results.periodic_interest || 0;
 
@@ -951,7 +951,7 @@ class LoanCalculator {
         
         const repaymentOption = results.repayment_option || results.repaymentOption || '';
         const isServicedOnly = repaymentOption === 'service_only';
-        const isServicedCapital = repaymentOption === 'service_and_capital';
+        const isServicedCapital = repaymentOption === 'service_and_capital' || repaymentOption === 'sc_only';
         const isFlexiblePayment = repaymentOption === 'flexible_payment';
         const isCapitalPaymentOnly = repaymentOption === 'capital_payment_only';
 
@@ -1251,6 +1251,7 @@ class LoanCalculator {
                     { value: 'none', text: 'Retained Interest (Interest Only)' },
                     { value: 'service_only', text: 'Service Only (Interest Payments)' },
                     { value: 'service_and_capital', text: 'Service + Capital (Principal & Interest)' },
+                    { value: 'sc_only', text: 'S+C Only (Principal & Interest)' },
                     { value: 'capital_payment_only', text: 'Capital Payment Only (Interest Retained)' },
                     { value: 'flexible_payment', text: 'Flexible Payment Schedule' }
                 ];
@@ -1423,7 +1424,7 @@ class LoanCalculator {
             
             if (paymentTimingSection) {
                 // Show payment timing for service only, capital+interest, capital payment only, and flexible payment options
-                if (repaymentOption === 'service_only' || repaymentOption === 'service_and_capital' || repaymentOption === 'capital_payment_only' || repaymentOption === 'flexible_payment') {
+                if (repaymentOption === 'service_only' || repaymentOption === 'service_and_capital' || repaymentOption === 'capital_payment_only' || repaymentOption === 'flexible_payment' || repaymentOption === 'sc_only') {
                     paymentTimingSection.style.display = 'block';
                     showAdditionalParams = true;
                 } else {
@@ -1434,7 +1435,7 @@ class LoanCalculator {
             // Show capital repayment section for service + capital and capital payment only options
             const capitalRepaymentSection = document.getElementById('capitalRepaymentSection');
             if (capitalRepaymentSection) {
-                if (repaymentOption === 'service_and_capital' || repaymentOption === 'capital_payment_only') {
+                if (repaymentOption === 'service_and_capital' || repaymentOption === 'capital_payment_only' || repaymentOption === 'sc_only') {
                     capitalRepaymentSection.style.display = 'block';
                     showAdditionalParams = true;
                 } else {
@@ -1457,7 +1458,7 @@ class LoanCalculator {
             const ltvSection = document.getElementById('ltvSimulationSection');
             if (ltvSection) {
                 if ((loanType === 'bridge' || loanType === 'term') &&
-                    (repaymentOption === 'service_and_capital' || repaymentOption === 'capital_payment_only' || repaymentOption === 'flexible_payment')) {
+                    (repaymentOption === 'service_and_capital' || repaymentOption === 'capital_payment_only' || repaymentOption === 'flexible_payment' || repaymentOption === 'sc_only')) {
                     ltvSection.style.display = 'block';
                     showAdditionalParams = true;
                 } else {
@@ -2334,6 +2335,9 @@ class LoanCalculator {
             case 'service_and_capital':
                 repaymentDescription = 'Capital & interest  regular payments amortise the loan using <code>Payment = P × r / (1 - (1 + r)<sup>-n</sup>)</code>.';
                 break;
+            case 'sc_only':
+                repaymentDescription = 'S+C only  interest and capital are paid each period without interest-only comparison.';
+                break;
             case 'capital_payment_only':
                 repaymentDescription = 'Capital payments only  interest is retained upfront and scheduled capital payments reduce the balance.';
                 break;
@@ -2353,6 +2357,7 @@ class LoanCalculator {
                     netToGrossDescription = 'Gross = (Net + Legal + Site) / (1 - Arrangement - (Rate / 12) - Title)';
                     break;
                 case 'service_and_capital':
+                case 'sc_only':
                 case 'flexible_payment':
                     netToGrossDescription = 'Gross = (Net + Legal + Site) / (1 - Arrangement - Title)';
                     break;
@@ -2364,7 +2369,7 @@ class LoanCalculator {
 
         // Fee impact on net and gross amounts
         let feeImpactDescription = `Fees total ${totalFees} (arrangement ${arrangement}, legal ${legal}, site visit ${site}, title insurance ${title}).`;
-        if (['service_only', 'service_and_capital', 'flexible_payment'].includes(repaymentOption)) {
+        if (['service_only', 'service_and_capital', 'flexible_payment', 'sc_only'].includes(repaymentOption)) {
             feeImpactDescription += ' Net = Gross - Fees. Interest is calculated on the gross amount.';
         } else {
             feeImpactDescription += ' Net = Gross - Fees - Interest. Interest is calculated on the gross amount.';

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -479,6 +479,7 @@
 <option value="none">Retained Interest (Interest Only)</option>
 <option value="service_only">Service Only (Interest Payments)</option>
 <option value="service_and_capital">Service + Capital (Principal &amp; Interest)</option>
+<option value="sc_only">S+C Only (Principal &amp; Interest)</option>
 <option value="capital_payment_only">Capital Payment Only (Interest Retained)</option>
 <option value="flexible_payment">Flexible Payment Schedule</option>
 </select>

--- a/test_sc_only_summary.py
+++ b/test_sc_only_summary.py
@@ -1,0 +1,45 @@
+import sys, types
+from decimal import Decimal
+import pytest
+
+# Provide minimal stub for dateutil.relativedelta
+relativedelta_module = types.ModuleType('relativedelta')
+class relativedelta:
+    def __init__(self, months=0):
+        self.months = months
+    def __radd__(self, other):
+        from datetime import date
+        month = other.month - 1 + self.months
+        year = other.year + month // 12
+        month = month % 12 + 1
+        day = min(other.day, [31, 29 if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0) else 28,
+                              31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1])
+        return other.replace(year=year, month=month, day=day)
+relativedelta_module.relativedelta = relativedelta
+sys.modules['dateutil'] = types.ModuleType('dateutil')
+sys.modules['dateutil'].relativedelta = relativedelta_module
+sys.modules['dateutil.relativedelta'] = relativedelta_module
+
+from calculations import LoanCalculator
+
+
+def test_sc_only_uses_service_capital_logic_without_savings():
+    calc = LoanCalculator()
+    params = {
+        'loan_type': 'bridge',
+        'repayment_option': 'sc_only',
+        'gross_amount': 1000000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'capital_repayment': 5000,
+        'arrangement_fee_rate': 0,
+        'legal_fees': 0,
+        'site_visit_fee': 0,
+        'title_insurance_rate': 0,
+        'start_date': '2024-01-01',
+    }
+    result = calc.calculate_bridge_loan(params)
+    expected_interest = Decimal('1000000') * Decimal('0.12') / Decimal('12')
+    assert result['monthlyPayment'] == pytest.approx(float(expected_interest + Decimal('5000')), abs=0.01)
+    assert result.get('interestSavings', 0) == 0
+    assert result.get('interestOnlyTotal', 0) == 0


### PR DESCRIPTION
## Summary
- add new `sc_only` repayment option that reuses service + capital calculations without interest savings
- expose S+C Only choice in calculator UI and ensure JS treats it like service + capital
- cover S+C Only with a dedicated test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4a7ecaea08320aa32216f5a4852fd