### PR TITLE
Ensure constant capital payments for net Service+Capital loans

### DIFF
--- a/report_utils.py
+++ b/report_utils.py
@@ -136,6 +136,19 @@ def generate_report_schedule(params: Dict[str, Any]) -> Tuple[List[Dict[str, Any
 
     summary: Dict[str, float] = {}
 
+    if is_service_and_capital_net and schedule:
+        currency_symbol = schedule[0].get('opening_balance', '£')[0]
+        capital_repayment = Decimal(str(params.get('capital_repayment', 0)))
+        for row in schedule:
+            interest_amt = _to_decimal(row.get('interest_amount', 0), currency_symbol)
+            row['principal_payment'] = f"{currency_symbol}{capital_repayment:,.2f}"
+            scheduled = (interest_amt + capital_repayment).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+            row['total_payment'] = f"{currency_symbol}{scheduled:,.2f}"
+            row['scheduled_repayment'] = f"{currency_symbol}{scheduled:,.2f}"
+            row['interest_retained'] = f"{currency_symbol}0.00"
+            row['interest_refund'] = f"{currency_symbol}0.00"
+            row['interest_saving'] = f"{currency_symbol}0.00"
+
     # Remove any internal unrounded fields to keep report output stable
     for entry in schedule:
         for key in list(entry.keys()):

--- a/test_bridge_net_to_gross.py
+++ b/test_bridge_net_to_gross.py
@@ -515,8 +515,8 @@ def test_service_and_capital_net_matches_gross_schedule(payment_timing):
     else:
         gross_first = gross_result['detailed_payment_schedule'][0]
         net_first = net_result['detailed_payment_schedule'][0]
-        assert gross_first['interest_amount'] == net_first['interest_amount']
-        assert net_first['interest_retained'] != '£0.00'
+        assert net_first['interest_retained'] == '£0.00'
+        assert net_first['interest_amount'] == gross_first['interest_retained']
     assert net_result['totalInterest'] == pytest.approx(gross_result['totalInterest'])
 
 
@@ -616,7 +616,7 @@ def test_service_and_capital_net_to_gross_uses_day_interest():
     daily_rate = (params['annual_rate'] / Decimal('100')) / Decimal('365')
     expected = (gross * daily_rate * days_first).quantize(Decimal('0.01'))
 
-    assert retained_first == expected
-    assert interest_first == Decimal('0')
+    assert retained_first == Decimal('0')
+    assert interest_first == expected
     assert Decimal(second['interest_retained'].replace('£', '').replace(',', '')) == Decimal('0')
     assert Decimal(second['interest_refund'].replace('£', '').replace(',', '')) == Decimal('0')

--- a/test_service_and_capital_net_arrears_no_retained_interest.py
+++ b/test_service_and_capital_net_arrears_no_retained_interest.py
@@ -56,13 +56,16 @@ def test_net_arrears_has_no_retained_interest():
     for row in schedule:
         assert row['interest_retained'] == '£0.00'
         assert row['interest_refund'] == '£0.00'
+        assert row['principal_payment'] == '£5,000.00'
 
     total_interest = sum(_currency_to_decimal(r['interest_accrued']) for r in schedule)
     total_capital = sum(_currency_to_decimal(r['principal_payment']) for r in schedule)
 
     assert total_interest.quantize(Decimal('0.01')) == Decimal(str(result['totalInterest'])).quantize(Decimal('0.01'))
+    assert total_capital == Decimal('5000') * loan_term
     gross = Decimal(str(result.get('gross_amount', result.get('grossAmount'))))
-    assert total_capital.quantize(Decimal('0.01')) == gross.quantize(Decimal('0.01'))
+    expected_closing = gross - total_capital
+    assert _currency_to_decimal(schedule[-1]['closing_balance']) == expected_closing
     assert Decimal(str(result.get('retainedInterest', 0))) == Decimal('0')
     assert Decimal(str(result.get('interestRefund', 0))) == Decimal('0')
     assert Decimal(str(result['interestSavings'])) == Decimal('0')


### PR DESCRIPTION
## Summary
- Keep capital repayments constant for net-funded Service + Capital schedules instead of clearing the balance in the final period
- Remove retained interest from Service + Capital net-to-gross detailed reports and recompute repayments accordingly
- Update tests for new Service + Capital net behaviour

## Testing
- `pytest test_service_and_capital_net_arrears_no_retained_interest.py::test_net_arrears_has_no_retained_interest -q`
- `pytest test_report_service_and_capital_interest.py::test_report_schedule_net_input_has_no_retained_interest -q`
- `pytest test_service_and_flexible_schedule_match_capital.py::test_service_and_capital_matches_capital_payment_schedule -q`
- `pytest test_bridge_net_to_gross.py::test_service_and_capital_net_matches_gross_schedule -q`
- `pytest test_bridge_net_to_gross.py::test_service_and_capital_net_to_gross_uses_day_interest -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b0997d2c8320a5f115d3035b6bbf