### PR TITLE
Avoid extra repayment period for advance schedules

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -3630,11 +3630,8 @@ class LoanCalculator:
                 if payment_date <= loan_end_date:
                     payment_dates.append(payment_date)
 
-            if timing == 'advance':
-                # Append maturity date for principal repayment
-                payment_dates.append(loan_end_date)
-            elif payment_dates and payment_dates[-1] < loan_end_date:
-                # Ensure arrears timing ends exactly on loan end date
+            if payment_dates and payment_dates[-1] < loan_end_date:
+                # Ensure schedule ends exactly on loan end date for arrears timing
                 payment_dates[-1] = loan_end_date
         else:
             # Monthly payments
@@ -3654,11 +3651,8 @@ class LoanCalculator:
                 if payment_date <= loan_end_date:
                     payment_dates.append(payment_date)
 
-            if timing == 'advance':
-                # Append maturity date for principal repayment
-                payment_dates.append(loan_end_date)
-            elif payment_dates and payment_dates[-1] < loan_end_date:
-                # Ensure arrears timing ends exactly on loan end date
+            if payment_dates and payment_dates[-1] < loan_end_date:
+                # Ensure schedule ends exactly on loan end date for arrears timing
                 payment_dates[-1] = loan_end_date
 
         return payment_dates
@@ -5279,14 +5273,16 @@ class LoanCalculator:
                 else:
                     capital_per_payment = capital_repayment
 
+                # Ensure the final period clears the remaining balance
+                if period == len(payment_dates):
+                    capital_per_payment = remaining_balance
+                elif capital_per_payment > remaining_balance:
+                    capital_per_payment = remaining_balance
+
                 # Interest charged on current balance
                 interest_amount = self.calculate_simple_interest_by_days(
                     remaining_balance, annual_rate, days_in_period, use_360_days
                 )
-
-                # Ensure we don't pay more capital than remaining
-                if capital_per_payment > remaining_balance:
-                    capital_per_payment = remaining_balance
 
                 interest_only = self.calculate_simple_interest_by_days(
                     gross_amount, annual_rate, days_in_period, use_360_days

--- a/test_advance_payment_schedule.py
+++ b/test_advance_payment_schedule.py
@@ -31,8 +31,8 @@ def test_service_and_capital_advance_has_final_interest():
         'totalInterest': 0
     }
     schedule = calc._generate_detailed_bridge_schedule(data, params, '£')
-    assert _parse_interest(schedule[-2]) > 0
-    assert _parse_interest(schedule[-1]) == pytest.approx(0, abs=0.01)
+    assert len(schedule) == params['loan_term']
+    assert _parse_interest(schedule[-1]) > 0
 
 def test_capital_payment_only_advance_has_zero_final_interest():
     calc = LoanCalculator()
@@ -52,6 +52,7 @@ def test_capital_payment_only_advance_has_zero_final_interest():
         'totalLegalFees': 0
     }
     schedule = calc._generate_detailed_term_schedule(data, params, '£')
+    assert len(schedule) == params['loan_term']
     assert _parse_interest(schedule[-1]) == pytest.approx(0, abs=0.01)
 
 

--- a/test_ltv_target.py
+++ b/test_ltv_target.py
@@ -34,7 +34,7 @@ def test_ltv_target_capital_payment_only():
     target_ltv = Decimal('40')
 
     target_balance = property_value * target_ltv / Decimal('100')
-    months = loan_term - 1
+    months = loan_term
     monthly_capital = (gross_amount - target_balance) / months
 
     params = {
@@ -53,5 +53,5 @@ def test_ltv_target_capital_payment_only():
     result = calc.calculate_bridge_loan(params)
 
     assert result['startLTV'] == pytest.approx(50.0)
-    expected_end_ltv = float((gross_amount - monthly_capital * loan_term) / property_value * 100)
+    expected_end_ltv = float((gross_amount - monthly_capital * (loan_term - 1)) / property_value * 100)
     assert result['endLTV'] == pytest.approx(expected_end_ltv)

--- a/test_quarterly_service_and_capital_schedule.py
+++ b/test_quarterly_service_and_capital_schedule.py
@@ -40,7 +40,7 @@ def test_quarterly_service_and_capital_schedule_groups_months():
     result = calc.calculate_bridge_loan(params)
     schedule = result['detailed_payment_schedule']
 
-    assert len(schedule) == 5
+    assert len(schedule) == 4
     first = schedule[0]
     assert first['start_period'] == '01/01/2024'
     assert first['end_period'] == '01/04/2024'


### PR DESCRIPTION
## Summary
- Stop appending a 13th payment date for advance schedules
- Pay remaining balance in the final scheduled period for capital-only term loans
- Update tests for new schedule lengths and end-LTV calculation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4b35d90848320b098e35ac2eddb43