### PR TITLE
Include periodic interest payments in loan summaries

### DIFF
--- a/report_utils.py
+++ b/report_utils.py
@@ -211,6 +211,38 @@ def generate_report_schedule(params: Dict[str, Any]) -> Tuple[List[Dict[str, Any
 
     summary = recalculate_summary(schedule)
 
+    # Always include reference monthly and quarterly interest payments
+    gross_amount = Decimal(
+        str(
+            calculation.get(
+                "grossAmount",
+                calculation.get(
+                    "gross_amount",
+                    params.get("gross_amount", params.get("grossAmount", 0)),
+                ),
+            )
+        )
+    )
+    annual_rate = Decimal(
+        str(
+            calculation.get(
+                "interestRate",
+                calculation.get(
+                    "annual_rate",
+                    params.get("annual_rate", params.get("annualRate", 0)),
+                ),
+            )
+        )
+    )
+    monthly_interest = calc._calculate_periodic_interest(
+        gross_amount, annual_rate / Decimal("100"), "monthly"
+    )
+    quarterly_interest = calc._calculate_periodic_interest(
+        gross_amount, annual_rate / Decimal("100"), "quarterly"
+    )
+    summary["monthlyInterestPayment"] = float(monthly_interest)
+    summary["quarterlyInterestPayment"] = float(quarterly_interest)
+
     if is_service_and_capital_net and summary:
         gross_amount = Decimal(
             str(

--- a/test_report_interest_days_held.py
+++ b/test_report_interest_days_held.py
@@ -43,3 +43,5 @@ def test_interest_fields_use_days_held():
     assert summary['interestRefund'] == float(total_refund.quantize(rounding))
     assert summary['total_interest_accrued'] == float(total_accrued.quantize(rounding))
     assert summary['interestSavings'] == float(total_saving.quantize(rounding))
+    assert summary['monthlyInterestPayment'] == 1000.0
+    assert summary['quarterlyInterestPayment'] == 3000.0

--- a/test_term_flexible_payment_schedule_details.py
+++ b/test_term_flexible_payment_schedule_details.py
@@ -15,7 +15,7 @@ def test_term_flexible_payment_schedule_includes_detail_fields():
         'arrangementFee': 0,
         'totalLegalFees': 0,
     }
-    schedule, _ = generate_report_schedule(params)
+    schedule, summary = generate_report_schedule(params)
     first = schedule[0]
     assert 'flexible_payment_calculation' in first
     assert 'amortisation_calculation' in first
@@ -24,3 +24,5 @@ def test_term_flexible_payment_schedule_includes_detail_fields():
     expected_flex = f"{first['principal_payment']} + {first['interest_amount']} = {first['total_payment']}"
     assert first['flexible_payment_calculation'] == expected_flex
     assert first['days_held'] > 0
+    assert summary['monthlyInterestPayment'] == 1000.0
+    assert summary['quarterlyInterestPayment'] == 3000.0


### PR DESCRIPTION
## Summary
- Add monthly and quarterly interest payment calculations to report summaries using gross amount and annual rate.
- Ensure bridge and term loan reports expose these periodic interest references.
- Extend tests to verify new summary fields for both loan types.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b546c642bc8320a69ec164f001a429