### PR TITLE
Include periodic interest payments in loan summaries

### DIFF
--- a/report_utils.py
+++ b/report_utils.py
@@ -211,6 +211,38 @@ def generate_report_schedule(params: Dict[str, Any]) -> Tuple[List[Dict[str, Any
 
     summary = recalculate_summary(schedule)
 
+    # Always include reference monthly and quarterly interest payments
+    gross_amount = Decimal(
+        str(
+            calculation.get(
+                "grossAmount",
+                calculation.get(
+                    "gross_amount",
+                    params.get("gross_amount", params.get("grossAmount", 0)),
+                ),
+            )
+        )
+    )
+    annual_rate = Decimal(
+        str(
+            calculation.get(
+                "interestRate",
+                calculation.get(
+                    "annual_rate",
+                    params.get("annual_rate", params.get("annualRate", 0)),
+                ),
+            )
+        )
+    )
+    monthly_interest = calc._calculate_periodic_interest(
+        gross_amount, annual_rate / Decimal("100"), "monthly"
+    )
+    quarterly_interest = calc._calculate_periodic_interest(
+        gross_amount, annual_rate / Decimal("100"), "quarterly"
+    )
+    summary["monthlyInterestPayment"] = float(monthly_interest)
+    summary["quarterlyInterestPayment"] = float(quarterly_interest)
+
     if is_service_and_capital_net and summary:
         gross_amount = Decimal(
             str(

--- a/test_capital_payment_schedule_fields.py
+++ b/test_capital_payment_schedule_fields.py
@@ -1,17 +1,29 @@
 import sys, types
+import pytest
 
 # Minimal relativedelta stub
 relativedelta_module = types.ModuleType('relativedelta')
+
+
 class relativedelta:
     def __init__(self, months=0):
         self.months = months
+
     def __radd__(self, other):
         from datetime import date
+
         month = other.month - 1 + self.months
         year = other.year + month // 12
         month = month % 12 + 1
-        day = min(other.day, [31,29 if year %4==0 and (year%100!=0 or year%400==0) else 28,31,30,31,30,31,31,30,31,30,31][month-1])
+        day = min(
+            other.day,
+            [31, 29 if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0) else 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][
+                month - 1
+            ],
+        )
         return other.replace(year=year, month=month, day=day)
+
+
 relativedelta_module.relativedelta = relativedelta
 sys.modules['dateutil'] = types.ModuleType('dateutil')
 sys.modules['dateutil'].relativedelta = relativedelta_module
@@ -48,3 +60,5 @@ def test_capital_only_schedule_fields_present():
         for field in required_fields:
             assert field in entry, f"Missing field {field} in period {idx}"
     assert schedule[-1].get('interest_refund') not in (None, ''), 'Interest refund missing in last period'
+    assert result['monthlyInterestPayment'] == pytest.approx(2000000 * 0.12 / 12, abs=0.01)
+    assert result['quarterlyInterestPayment'] == pytest.approx(2000000 * 0.12 / 4, abs=0.01)

--- a/test_flexible_payment_schedule_fields.py
+++ b/test_flexible_payment_schedule_fields.py
@@ -1,4 +1,5 @@
 from calculations import LoanCalculator
+import pytest
 
 def test_flexible_payment_schedule_fields_present():
     calc = LoanCalculator()
@@ -29,3 +30,5 @@ def test_flexible_payment_schedule_fields_present():
     for idx, entry in enumerate(schedule, start=1):
         for field in required_fields:
             assert field in entry, f"Missing field {field} in period {idx}"
+    assert result['monthlyInterestPayment'] == pytest.approx(100000 * 0.12 / 12, abs=0.01)
+    assert result['quarterlyInterestPayment'] == pytest.approx(100000 * 0.12 / 4, abs=0.01)

--- a/test_report_interest_days_held.py
+++ b/test_report_interest_days_held.py
@@ -43,3 +43,5 @@ def test_interest_fields_use_days_held():
     assert summary['interestRefund'] == float(total_refund.quantize(rounding))
     assert summary['total_interest_accrued'] == float(total_accrued.quantize(rounding))
     assert summary['interestSavings'] == float(total_saving.quantize(rounding))
+    assert summary['monthlyInterestPayment'] == 1000.0
+    assert summary['quarterlyInterestPayment'] == 3000.0

--- a/test_service_only_summary_matches_schedule.py
+++ b/test_service_only_summary_matches_schedule.py
@@ -1,5 +1,6 @@
 import sys, types
 from decimal import Decimal
+import pytest
 
 # Provide minimal stub for dateutil.relativedelta to avoid external dependency
 relativedelta_module = types.ModuleType('relativedelta')
@@ -46,3 +47,5 @@ def test_service_only_summary_matches_schedule():
     assert diff < Decimal('0.02')
     diff_interest_only = (Decimal(str(result['interestOnlyTotal'])) - interest_total).copy_abs()
     assert diff_interest_only < Decimal('0.02')
+    assert result['monthlyInterestPayment'] == pytest.approx(100000 * 0.12 / 12, abs=0.01)
+    assert result['quarterlyInterestPayment'] == pytest.approx(100000 * 0.12 / 4, abs=0.01)

--- a/test_term_flexible_payment_schedule_details.py
+++ b/test_term_flexible_payment_schedule_details.py
@@ -15,7 +15,7 @@ def test_term_flexible_payment_schedule_includes_detail_fields():
         'arrangementFee': 0,
         'totalLegalFees': 0,
     }
-    schedule, _ = generate_report_schedule(params)
+    schedule, summary = generate_report_schedule(params)
     first = schedule[0]
     assert 'flexible_payment_calculation' in first
     assert 'amortisation_calculation' in first
@@ -24,3 +24,5 @@ def test_term_flexible_payment_schedule_includes_detail_fields():
     expected_flex = f"{first['principal_payment']} + {first['interest_amount']} = {first['total_payment']}"
     assert first['flexible_payment_calculation'] == expected_flex
     assert first['days_held'] > 0
+    assert summary['monthlyInterestPayment'] == 1000.0
+    assert summary['quarterlyInterestPayment'] == 3000.0


### PR DESCRIPTION
## Summary
- Add monthly and quarterly interest payment calculations to report summaries using gross amount and annual rate.
- Ensure bridge and term loan reports expose these periodic interest references.
- Extend tests to verify new summary fields for both loan types.
- Add coverage so service-only, capital payment, and flexible payment schedules also surface monthly and quarterly interest values.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b546c642bc8320a69ec164f001a429