### PR TITLE
Expose reference interest payments in service-only bridge summaries

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -646,12 +646,9 @@ class LoanCalculator:
         })
 
         # Always provide reference monthly and quarterly interest payments
-        monthly_interest = self._calculate_periodic_interest(
-            gross_amount, annual_rate / Decimal('100'), 'monthly'
-        )
-        quarterly_interest = self._calculate_periodic_interest(
-            gross_amount, annual_rate / Decimal('100'), 'quarterly'
-        )
+        annual_rate_decimal = annual_rate / Decimal('100')
+        monthly_interest = gross_amount * annual_rate_decimal / Decimal('12')
+        quarterly_interest = gross_amount * annual_rate_decimal / Decimal('4')
         calculation['monthlyInterestPayment'] = float(monthly_interest)
         calculation['quarterlyInterestPayment'] = float(quarterly_interest)
 

--- a/report_utils.py
+++ b/report_utils.py
@@ -234,12 +234,9 @@ def generate_report_schedule(params: Dict[str, Any]) -> Tuple[List[Dict[str, Any
             )
         )
     )
-    monthly_interest = calc._calculate_periodic_interest(
-        gross_amount, annual_rate / Decimal("100"), "monthly"
-    )
-    quarterly_interest = calc._calculate_periodic_interest(
-        gross_amount, annual_rate / Decimal("100"), "quarterly"
-    )
+    annual_rate_decimal = annual_rate / Decimal("100")
+    monthly_interest = gross_amount * annual_rate_decimal / Decimal("12")
+    quarterly_interest = gross_amount * annual_rate_decimal / Decimal("4")
     summary["monthlyInterestPayment"] = float(monthly_interest)
     summary["quarterlyInterestPayment"] = float(quarterly_interest)
 

--- a/test_report_service_only_interest_payments.py
+++ b/test_report_service_only_interest_payments.py
@@ -1,0 +1,65 @@
+import sys
+import types
+import pytest
+
+# Provide minimal stub for dateutil.relativedelta to avoid external dependency
+relativedelta_module = types.ModuleType('relativedelta')
+
+
+class relativedelta:
+    def __init__(self, months=0):
+        self.months = months
+
+    def __radd__(self, other):
+        from datetime import date
+
+        month = other.month - 1 + self.months
+        year = other.year + month // 12
+        month = month % 12 + 1
+        day = min(
+            other.day,
+            [
+                31,
+                29 if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0) else 28,
+                31,
+                30,
+                31,
+                30,
+                31,
+                31,
+                30,
+                31,
+                30,
+                31,
+            ][month - 1],
+        )
+        return other.replace(year=year, month=month, day=day)
+
+
+relativedelta_module.relativedelta = relativedelta
+sys.modules['dateutil'] = types.ModuleType('dateutil')
+sys.modules['dateutil'].relativedelta = relativedelta_module
+sys.modules['dateutil.relativedelta'] = relativedelta_module
+
+from report_utils import generate_report_schedule
+
+
+def test_report_service_only_includes_reference_interest_payments():
+    params = {
+        'loan_type': 'bridge',
+        'repayment_option': 'service_only',
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'payment_frequency': 'monthly',
+        'payment_timing': 'arrears',
+        'arrangement_fee_rate': 0,
+        'legal_fees': 0,
+        'site_visit_fee': 0,
+        'title_insurance_rate': 0,
+        'start_date': '2024-01-01',
+    }
+    _, summary = generate_report_schedule(params)
+    assert summary['monthlyInterestPayment'] == pytest.approx(100000 * 0.12 / 12, abs=0.01)
+    assert summary['quarterlyInterestPayment'] == pytest.approx(100000 * 0.12 / 4, abs=0.01)
+


### PR DESCRIPTION
## Summary
- compute monthly and quarterly reference interest payments directly from gross amount and rate
- include these reference payments in generated summaries
- add regression test verifying service-only reports show the correct reference amounts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5515c75688320b2b797914240c6ea