### PR TITLE
Fix term day calculation to use calendar end date

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -119,8 +119,8 @@ class LoanCalculator:
     def _calculate_term_days(self, start_date: datetime, term_months: int) -> int:
         """Calculate exact number of days for a term based on calendar months."""
         start_date = self._normalize_date(start_date)
-        end_date = self._add_months(start_date, term_months)
-        return (end_date - start_date).days
+        end_date = self._add_months(start_date, term_months) - timedelta(days=1)
+        return (end_date - start_date).days + 1
 
     def calculate_simple_interest_by_days(self, principal: Decimal, annual_rate: Decimal,
                                           days: int, use_360_days: bool = False) -> Decimal:
@@ -391,12 +391,16 @@ class LoanCalculator:
             actual_days = (end_date - start_date).days
             loan_term = max(1, round(actual_days / float(avg_days_per_month)))
             loan_term_days = actual_days
-            logging.info(f"Bridge loan: Using end_date {end_date_str}, actual_days={actual_days}, loan_term_days={loan_term_days} (actual), loan_term={loan_term} months")
+            logging.info(
+                f"Bridge loan: Using end_date {end_date_str}, actual_days={actual_days}, loan_term_days={loan_term_days} (actual), loan_term={loan_term} months"
+            )
         else:
-            end_date = start_date + relativedelta(months=loan_term)
-            loan_term_days = (end_date - start_date).days
+            end_date = start_date + relativedelta(months=loan_term) - timedelta(days=1)
+            loan_term_days = (end_date - start_date).days + 1
             end_date_str = end_date.strftime('%Y-%m-%d')
-            logging.info(f"Bridge loan: Calculated end_date {end_date_str}, loan_term_days={loan_term_days} (calendar), loan_term={loan_term} months")
+            logging.info(
+                f"Bridge loan: Calculated end_date {end_date_str}, loan_term_days={loan_term_days} (calendar), loan_term={loan_term} months"
+            )
 
         params['loan_term_days'] = loan_term_days
 
@@ -787,8 +791,8 @@ class LoanCalculator:
             loan_term_days = actual_days
             logging.info(f"Term loan: Using end_date {end_date_str}, actual_days={actual_days}, loan_term_days={loan_term_days} (actual), loan_term={loan_term} months")
         else:
-            end_date = start_date + relativedelta(months=loan_term)
-            loan_term_days = (end_date - start_date).days
+            end_date = start_date + relativedelta(months=loan_term) - timedelta(days=1)
+            loan_term_days = (end_date - start_date).days + 1
             end_date_str = end_date.strftime('%Y-%m-%d')
             logging.info(f"Term loan: Calculated end_date {end_date_str}, loan_term_days={loan_term_days} (calendar), loan_term={loan_term} months")
 
@@ -1684,8 +1688,8 @@ class LoanCalculator:
         else:
             # Priority 2: Calculate end date from start date + loan term
             from dateutil.relativedelta import relativedelta
-            loan_end_date = start_date + relativedelta(months=loan_term)
-            loan_term_days = (loan_end_date - start_date).days
+            loan_end_date = start_date + relativedelta(months=loan_term) - timedelta(days=1)
+            loan_term_days = (loan_end_date - start_date).days + 1
             end_date_str = loan_end_date.strftime('%Y-%m-%d')
         
         for tranche in tranches:
@@ -1852,7 +1856,7 @@ class LoanCalculator:
             day1_net_advance = Decimal('0')
         
         # Calculate loan term in days (using actual calendar days)
-        loan_term_days = (loan_end_date - start_date).days
+        loan_term_days = (loan_end_date - start_date).days + 1
         
         result = {
             'grossAmount': float(total_gross_amount),
@@ -3626,7 +3630,7 @@ class LoanCalculator:
 
         start_date = self._normalize_date(start_date)
         payment_dates: List[datetime] = []
-        loan_end_date = self._add_months(start_date, loan_term)
+        loan_end_date = self._add_months(start_date, loan_term) - timedelta(days=1)
 
         if frequency == 'quarterly':
             # Quarterly payments (every 3 months)

--- a/test_gross_net_roundtrip_fields.py
+++ b/test_gross_net_roundtrip_fields.py
@@ -26,7 +26,7 @@ def test_gross_to_net_and_back_fields():
     assert gross_result['grossAmount'] == pytest.approx(2000000.0)
     assert gross_result['netAdvance'] == pytest.approx(1934640.0)
     assert gross_result['start_date'] == '2025-08-30'
-    assert gross_result['end_date'] == '2026-08-30'
+    assert gross_result['end_date'] == '2026-08-29'
     assert gross_result['loanTerm'] == 12
     assert gross_result['loanTermDays'] == 365
     assert gross_result['arrangementFee'] == pytest.approx(40000.0)
@@ -44,7 +44,7 @@ def test_gross_to_net_and_back_fields():
     assert net_result['grossAmount'] == pytest.approx(2000000.0)
     assert net_result['netAdvance'] == pytest.approx(1934640.0)
     assert net_result['start_date'] == '2025-08-30'
-    assert net_result['end_date'] == '2026-08-30'
+    assert net_result['end_date'] == '2026-08-29'
     assert net_result['loanTerm'] == 12
     assert net_result['loanTermDays'] == 365
     assert net_result['arrangementFee'] == pytest.approx(40000.0)


### PR DESCRIPTION
## Summary
- calculate end-of-term dates with calendar accuracy
- ensure loan term days include the final day of the term
- update tests for new calendar-based end date

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b57457bca48320b8be6cefdd14f62a