### PR TITLE
Add bridge loan end date schedule tests

### DIFF
--- a/test_bridge_end_date_inclusive.py
+++ b/test_bridge_end_date_inclusive.py
@@ -14,3 +14,20 @@ def test_bridge_end_date_includes_final_day():
     result = calc.calculate_bridge_loan(params)
     assert result['loanTermDays'] == 273
 
+
+def test_bridge_end_date_full_year_schedule():
+    calc = LoanCalculator()
+    params = {
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'repayment_option': 'service_and_capital',
+        'start_date': '2025-09-01',
+        'end_date': '2026-08-31',
+    }
+    result = calc.calculate_bridge_loan(params)
+    assert result['loanTerm'] == 12
+    schedule = result['detailed_payment_schedule']
+    assert len(schedule) == 12
+    assert float(schedule[-1]['interest_amount_raw']) != 0
+

--- a/test_bridge_end_date_switch.py
+++ b/test_bridge_end_date_switch.py
@@ -1,0 +1,30 @@
+from calculations import LoanCalculator
+
+
+def test_end_date_overrides_loan_term_schedule_length():
+    calc = LoanCalculator()
+    params = {
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'repayment_option': 'service_and_capital',
+        'start_date': '2025-09-01',
+    }
+    term_result = calc.calculate_bridge_loan(params)
+    assert term_result['loanTerm'] == 12
+    assert len(term_result['detailed_payment_schedule']) == 12
+
+    end_params = {
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 9,
+        'repayment_option': 'service_and_capital',
+        'start_date': '2025-09-01',
+        'end_date': '2026-05-31',
+    }
+    end_result = calc.calculate_bridge_loan(end_params)
+    assert end_result['loanTerm'] == 9
+    schedule = end_result['detailed_payment_schedule']
+    assert len(schedule) == 9
+    assert float(schedule[-1]['interest_amount_raw']) > 0
+


### PR DESCRIPTION
## Summary
- expand end-date-inclusive bridge loan test with full-year scenario
- add test ensuring schedule updates when switching from term length to explicit end date

## Testing
- `pytest test_bridge_end_date_inclusive.py test_bridge_end_date_switch.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5ab57a5ec8320a26a730504120706