### PR TITLE
Add tranche schedule generation for development loans

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -23,7 +23,7 @@ from utils import (
     validate_quote_data, generate_payment_schedule_csv, format_currency,
     parse_currency_amount, generate_application_reference, validate_email
 )
-from report_utils import generate_report_schedule
+from report_utils import generate_report_schedule, generate_tranche_schedule
 from snowflake_utils import (
     set_snowflake_config,
     get_snowflake_config,
@@ -474,6 +474,12 @@ def api_calculate():
                 result.update(summary)
             except Exception as e:
                 app.logger.warning(f"Report schedule generation failed: {str(e)}")
+
+        if loan_type in ('development', 'development2'):
+            try:
+                result['detailed_tranche_schedule'] = generate_tranche_schedule(calc_params)
+            except Exception as e:
+                app.logger.warning(f"Tranche schedule generation failed: {str(e)}")
 
         # Generate payment schedule
         try:


### PR DESCRIPTION
## Summary
- provide generate_tranche_schedule helper reusing LoanCalculator logic
- return detailed tranche schedules for development loans through API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5b98535408320bd17c7e8a2f08cd5