### PR TITLE
Add tranche schedule modal for development loans

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -924,12 +924,15 @@ class LoanCalculator {
         
         // Display detailed payment schedule if available (for all loan types)
         this.displayDetailedPaymentSchedule(results);
-        
+
         // Display tranche breakdown for development loans
         if (results.tranche_breakdown && results.tranche_breakdown.length > 0) {
             this.displayTrancheBreakdown(results.tranche_breakdown, currency);
         }
-        
+
+        // Display tranche schedule report in modal if available
+        this.displayTrancheSchedule(results);
+
         // Update percentage displays with actual user input values
         this.updatePercentageDisplays();
     }
@@ -2092,6 +2095,51 @@ class LoanCalculator {
         } catch (error) {
             console.log('Error in clearExistingCharts:', error);
         }
+    }
+
+    displayTrancheSchedule(results) {
+        const btn = document.getElementById('trancheScheduleBtn');
+        const body = document.getElementById('trancheScheduleBody');
+        if (!btn || !body) return;
+
+        const schedule = results.detailed_tranche_schedule;
+        if (!Array.isArray(schedule) || schedule.length === 0) {
+            btn.style.display = 'none';
+            body.innerHTML = '';
+            return;
+        }
+
+        btn.style.display = 'inline-block';
+        body.innerHTML = '';
+
+        const currency = document.getElementById('currency').value;
+        const symbol = this.getCurrencySymbol(currency);
+
+        const formatMoney = (val) => {
+            const num = typeof val === 'string' ? parseFloat(val) : val;
+            if (isNaN(num)) return val ?? '';
+            return symbol + num.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
+        };
+
+        schedule.forEach((row, index) => {
+            const tr = document.createElement('tr');
+            tr.style.border = '1px solid #000';
+            tr.style.background = index % 2 === 0 ? '#f8f9fa' : 'white';
+
+            tr.innerHTML = `
+                <td class="py-1 px-2 text-center" style="border-right:1px solid #000; color:#000; font-size:0.875rem;">${row.period}</td>
+                <td class="py-1 px-2 text-center" style="border-right:1px solid #000; color:#000; font-size:0.875rem;">${row.start_period || ''}</td>
+                <td class="py-1 px-2 text-center" style="border-right:1px solid #000; color:#000; font-size:0.875rem;">${row.end_period || ''}</td>
+                <td class="py-1 px-2 text-center" style="border-right:1px solid #000; color:#000; font-size:0.875rem;">${row.days_held ?? ''}</td>
+                <td class="py-1 px-2 text-end" style="border-right:1px solid #000; color:#000; font-size:0.875rem;">${formatMoney(row.opening_balance)}</td>
+                <td class="py-1 px-2 text-end" style="border-right:1px solid #000; color:#000; font-size:0.875rem;">${formatMoney(row.tranche_release)}</td>
+                <td class="py-1 px-2 text-end" style="border-right:1px solid #000; color:#000; font-size:0.875rem;">${formatMoney(row.interest)}</td>
+                <td class="py-1 px-2 text-end" style="border-right:1px solid #000; color:#000; font-size:0.875rem;">${formatMoney(row.principal)}</td>
+                <td class="py-1 px-2 text-end" style="border-right:1px solid #000; color:#000; font-size:0.875rem;">${formatMoney(row.total_payment)}</td>
+                <td class="py-1 px-2 text-end" style="color:#000; font-size:0.875rem;">${formatMoney(row.closing_balance)}</td>
+            `;
+            body.appendChild(tr);
+        });
     }
 
     displayTrancheBreakdown(trancheData, currency) {

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -968,6 +968,9 @@
     <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#paymentScheduleModal">
         <i class="fas fa-calendar-alt me-1"></i>Detailed Payment Schedule
     </button>
+    <button class="btn btn-outline-primary" id="trancheScheduleBtn" data-bs-toggle="modal" data-bs-target="#trancheScheduleModal" style="display: none;">
+        <i class="fas fa-layer-group me-1"></i>Tranche Schedule
+    </button>
     <button class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#loanBreakdownModal">
         <i class="fas fa-chart-pie me-1"></i>Loan Breakdown
     </button>
@@ -1018,6 +1021,43 @@
               </tbody>
             </table>
           </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+</div>
+</div>
+</div>
+</div>
+
+<div class="modal fade" id="trancheScheduleModal" tabindex="-1" aria-labelledby="trancheScheduleLabel" aria-hidden="true">
+  <div class="modal-dialog modal-fullscreen modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header bg-novellus-navy text-white">
+        <h5 class="modal-title" id="trancheScheduleLabel">Tranche Schedule</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="table-responsive">
+          <table class="table table-sm" style="border: 1px solid #000; border-collapse: collapse; font-size: 0.875rem;">
+            <thead>
+              <tr style="background: #f8f9fa; border: 1px solid #000;">
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Start of Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">End of Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Days Held</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Opening Balance</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Tranche Release</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Principal</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Total Payment</th>
+                <th class="px-2 text-center" style="color: #000; font-weight: bold; font-size: 0.875rem;">Closing Balance</th>
+              </tr>
+            </thead>
+            <tbody id="trancheScheduleBody">
+              <!-- Tranche schedule rows will be populated by JavaScript -->
+            </tbody>
+          </table>
         </div>
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
## Summary
- add Tranche Schedule button and modal to calculator
- populate modal with detailed tranche schedule results

## Testing
- `pytest test_tranche_generation.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5bc0f98d88320a484d2a8b688bda3