### PR TITLE
Split excess term days into extra periods

### DIFF
--- a/test_payment_schedule_day_counts.py
+++ b/test_payment_schedule_day_counts.py
@@ -63,3 +63,15 @@ def test_payment_schedule_handles_short_month_rollover():
     schedule = result['detailed_payment_schedule']
     assert schedule[0]['days_held'] == 31
     assert schedule[0]['end_period'] == '01/03/2026'
+
+
+def test_monthly_periods_never_exceed_31_days_with_extra_term_days():
+    from datetime import datetime
+
+    calc = LoanCalculator()
+    start = datetime(2024, 1, 30)
+    loan_term = 1
+    loan_term_days = 61
+    payment_dates = calc._generate_payment_dates(start, loan_term, 'monthly', 'arrears', loan_term_days)
+    ranges = calc._compute_period_ranges(start, payment_dates, loan_term, 'arrears', loan_term_days)
+    assert all(r['days_held'] <= 31 for r in ranges)


### PR DESCRIPTION
## Summary
- Append extra 31-day (max) periods when loan term days exceed calendar months, keeping monthly periods capped at 31 days
- Ensure negative day differences still shorten the final period
- Add regression test ensuring monthly day counts never exceed 31 even with extra term days

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c86b77308320b7e3a27fbe403d99