### PR TITLE
Use inclusive period end dates and days-held counts

### DIFF
--- a/test_payment_schedule_day_counts.py
+++ b/test_payment_schedule_day_counts.py
@@ -62,7 +62,9 @@ def test_payment_schedule_handles_short_month_rollover():
     result = calc.calculate_bridge_loan(params)
     schedule = result['detailed_payment_schedule']
     assert schedule[0]['days_held'] == 31
-    assert schedule[0]['end_period'] == '01/03/2026'
+    # The end period now reflects the final day within the range rather than the
+    # first day following it.
+    assert schedule[0]['end_period'] == '28/02/2026'
 
 
 def test_monthly_periods_never_exceed_31_days_with_extra_term_days():

--- a/test_quarterly_service_and_capital_schedule.py
+++ b/test_quarterly_service_and_capital_schedule.py
@@ -43,5 +43,6 @@ def test_quarterly_service_and_capital_schedule_groups_months():
     assert len(schedule) == 4
     first = schedule[0]
     assert first['start_period'] == '01/01/2024'
-    assert first['end_period'] == '01/04/2024'
+    # ``end_period`` now reports the final day within the quarter
+    assert first['end_period'] == '31/03/2024'
     assert first['days_held'] == 91


### PR DESCRIPTION
## Summary
- compute period ranges and schedule metadata using inclusive end dates
- count days held including both start and end days
- adjust tests expecting end period to be the following day

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6074550448320a44ba09b6178ee87