### PR TITLE
Normalize loan term days keys

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -549,7 +549,9 @@ def api_calculate():
                         # Apply day-count-aware Excel interest calculation using loan_term_days
                         annual_rate = calc_params.get('annual_rate', 0)
                         loan_term = calc_params.get('loan_term', 12)
-                        loan_term_days = result.get('loan_term_days', calc_params.get('loan_term_days', 0))
+                        loan_term_days = result.get('loanTermDays', calc_params.get('loan_term_days', 0))
+                        result['loanTermDays'] = loan_term_days
+                        result['loan_term_days'] = loan_term_days
                         use_360_days = calc_params.get('use_360_days', False)
                         days_per_year = 360 if use_360_days else 365
 

--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -698,7 +698,7 @@ class LoanCalculator {
         const startDate = results.start_date || results.startDate || '';
         const endDate = results.end_date || results.endDate || '';
         const loanTerm = results.loanTerm || results.loan_term || 0;
-        const loanTermDays = results.loanTermDays || results.loan_term_days || 0;
+        const loanTermDays = results.loanTermDays || 0; // normalized by backend
         const arrangementFee = results.arrangementFee || 0;
         const legalCosts = results.legalCosts || results.legalFees || 0;
         const siteVisitFee = results.siteVisitFee || 0;


### PR DESCRIPTION
## Summary
- Prefer camelCase loanTermDays key in backend and mirror to snake_case for compatibility
- Align frontend calculator to use normalized loanTermDays value

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b60f0490b08320a118c565868157bd