### PR TITLE
Respect end date in development schedules

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -6866,7 +6866,21 @@ class LoanCalculator:
 
         payment_timing = quote_data.get('payment_timing', 'advance')
         payment_frequency = quote_data.get('payment_frequency', 'monthly')
-        loan_term_days = quote_data.get('loanTermDays') or quote_data.get('loan_term_days')
+
+        end_date_val = quote_data.get('end_date')
+        if end_date_val:
+            if isinstance(end_date_val, datetime):
+                end_date = end_date_val
+            else:
+                end_date = datetime.strptime(end_date_val, '%Y-%m-%d')
+            end_date = self._normalize_date(end_date)
+            start_date_norm = self._normalize_date(start_date)
+            actual_days = (end_date - start_date_norm).days + 1
+            loan_term = max(1, round(actual_days / 30.4375))
+            loan_term_days = actual_days
+        else:
+            loan_term_days = quote_data.get('loanTermDays') or quote_data.get('loan_term_days')
+
         payment_dates = self._generate_payment_dates(start_date, loan_term, payment_frequency, payment_timing, loan_term_days)
         period_ranges = self._compute_period_ranges(start_date, payment_dates, loan_term, payment_timing, loan_term_days)
 

--- a/test_development_end_date_schedule.py
+++ b/test_development_end_date_schedule.py
@@ -1,0 +1,20 @@
+from calculations import LoanCalculator
+
+
+def test_development_schedule_respects_end_date():
+    calc = LoanCalculator()
+    quote = {
+        'loan_type': 'development',
+        'grossAmount': 100000,
+        'loanTerm': 12,
+        'interestRate': 12,
+        'repaymentOption': 'service_only',
+        'start_date': '2025-09-01',
+        'end_date': '2026-05-31',
+        'arrangementFee': 0,
+        'totalLegalFees': 0,
+        'tranches': []
+    }
+    schedule = calc.generate_payment_schedule(quote)
+    assert len(schedule) == 9
+    assert schedule[-1]['payment_date'] == '2026-05-31'


### PR DESCRIPTION
## Summary
- derive development loan term from provided end_date
- ensure payment dates and period ranges use computed loan_term_days
- add regression test for development end date schedules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b615cd5db083208ec04696faef8fcb