### PR TITLE
Respect calendar days in periodic interest and schedules

### DIFF
--- a/test_capital_payment_schedule_fields.py
+++ b/test_capital_payment_schedule_fields.py
@@ -60,5 +60,8 @@ def test_capital_only_schedule_fields_present():
         for field in required_fields:
             assert field in entry, f"Missing field {field} in period {idx}"
     assert schedule[-1].get('interest_refund') not in (None, ''), 'Interest refund missing in last period'
-    assert result['monthlyInterestPayment'] == pytest.approx(2000000 * 0.12 / 12, abs=0.01)
-    assert result['quarterlyInterestPayment'] == pytest.approx(2000000 * 0.12 / 4, abs=0.01)
+    daily_rate = 0.12 / 365
+    days_first = schedule[0]['days_held']
+    days_quarter = sum(p['days_held'] for p in schedule[:3])
+    assert result['monthlyInterestPayment'] == pytest.approx(2000000 * daily_rate * days_first, abs=0.01)
+    assert result['quarterlyInterestPayment'] == pytest.approx(2000000 * daily_rate * days_quarter, abs=0.01)

--- a/test_capital_payment_summary_monthly_interest.py
+++ b/test_capital_payment_summary_monthly_interest.py
@@ -41,6 +41,6 @@ def test_capital_only_summary_includes_monthly_interest():
     }
     result = calc.calculate_bridge_loan(params)
 
-    expected_monthly_interest = 2000000 * 0.12 / 12
+    expected_monthly_interest = 2000000 * 0.12 / 365 * 31
     assert result['periodicInterest'] == pytest.approx(expected_monthly_interest, abs=0.01)
     assert result['monthlyPayment'] == pytest.approx(10000, abs=0.01)

--- a/test_flexible_payment_schedule_fields.py
+++ b/test_flexible_payment_schedule_fields.py
@@ -30,5 +30,8 @@ def test_flexible_payment_schedule_fields_present():
     for idx, entry in enumerate(schedule, start=1):
         for field in required_fields:
             assert field in entry, f"Missing field {field} in period {idx}"
-    assert result['monthlyInterestPayment'] == pytest.approx(100000 * 0.12 / 12, abs=0.01)
-    assert result['quarterlyInterestPayment'] == pytest.approx(100000 * 0.12 / 4, abs=0.01)
+    daily_rate = 0.12 / 365
+    days_first = schedule[0]['days_held']
+    days_quarter = sum(p['days_held'] for p in schedule[:3])
+    assert result['monthlyInterestPayment'] == pytest.approx(100000 * daily_rate * days_first, abs=0.01)
+    assert result['quarterlyInterestPayment'] == pytest.approx(100000 * daily_rate * days_quarter, abs=0.01)

--- a/test_gross_net_roundtrip_fields.py
+++ b/test_gross_net_roundtrip_fields.py
@@ -35,7 +35,7 @@ def test_gross_to_net_and_back_fields():
     assert gross_result['titleInsurance'] == pytest.approx(3360.0)
     assert gross_result['totalInterest'] == pytest.approx(233447.68)
     assert gross_result['interestOnlyTotal'] == pytest.approx(240000.0)
-    expected_monthly_interest = 2000000 * 0.12 / 12
+    expected_monthly_interest = 2000000 * 0.12 / 365 * 31
     assert gross_result['periodicInterest'] == pytest.approx(expected_monthly_interest, abs=0.01)
 
     net_params = dict(params, amount_input_type='net', net_amount=Decimal('1934640'))

--- a/test_periodic_interest_summary_visibility.py
+++ b/test_periodic_interest_summary_visibility.py
@@ -48,10 +48,12 @@ def test_periodic_interest_visible_and_correct(repayment_option, payment_frequen
         params['flexible_payment'] = 10000
 
     result = calc.calculate_bridge_loan(params)
-    divisor = 12 if payment_frequency == 'monthly' else 4
-    expected = 600000 * 0.12 / divisor
+    daily_rate = 0.12 / 365
+    days_month = 31
+    days_quarter = 91
+    expected = 600000 * daily_rate * (days_month if payment_frequency == 'monthly' else days_quarter)
 
     assert result['periodicInterest'] == pytest.approx(expected, abs=0.01)
-    assert result['monthlyInterestPayment'] == pytest.approx(600000 * 0.12 / 12, abs=0.01)
-    assert result['quarterlyInterestPayment'] == pytest.approx(600000 * 0.12 / 4, abs=0.01)
+    assert result['monthlyInterestPayment'] == pytest.approx(600000 * daily_rate * days_month, abs=0.01)
+    assert result['quarterlyInterestPayment'] == pytest.approx(600000 * daily_rate * days_quarter, abs=0.01)
     assert result['periodicInterest'] > 0

--- a/test_sc_only_summary.py
+++ b/test_sc_only_summary.py
@@ -39,7 +39,7 @@ def test_sc_only_uses_service_capital_logic_without_savings():
         'start_date': '2024-01-01',
     }
     result = calc.calculate_bridge_loan(params)
-    expected_interest = Decimal('1000000') * Decimal('0.12') / Decimal('12')
+    expected_interest = Decimal('1000000') * Decimal('0.12') / Decimal('365') * Decimal('31')
     assert result['monthlyPayment'] == pytest.approx(float(expected_interest + Decimal('5000')), abs=0.01)
     assert result.get('interestSavings', 0) == 0
     assert result.get('interestOnlyTotal', 0) == 0

--- a/test_service_capital_summary_monthly_interest.py
+++ b/test_service_capital_summary_monthly_interest.py
@@ -39,7 +39,7 @@ def test_service_and_capital_summary_shows_interest_and_capital():
         'start_date': '2024-01-01',
     }
     result = calc.calculate_bridge_loan(params)
-    expected_interest = 1000000 * 0.12 / 12
+    expected_interest = 1000000 * 0.12 / 365 * 31
     assert result['periodicInterest'] == pytest.approx(expected_interest, abs=0.01)
     assert result['monthlyPayment'] == pytest.approx(expected_interest + 5000, abs=0.01)
 
@@ -62,6 +62,6 @@ def test_service_and_capital_summary_net_input_uses_gross_amount():
     }
     result = calc.calculate_bridge_loan(params)
     gross = Decimal(str(result['grossAmount']))
-    expected_interest = gross * Decimal('0.12') / 12
+    expected_interest = gross * Decimal('0.12') / Decimal('365') * Decimal('31')
     assert result['periodicInterest'] == pytest.approx(float(expected_interest), abs=0.01)
     assert result['monthlyPayment'] == pytest.approx(float(expected_interest) + 5000, abs=0.01)

--- a/test_service_only_summary_matches_schedule.py
+++ b/test_service_only_summary_matches_schedule.py
@@ -47,5 +47,8 @@ def test_service_only_summary_matches_schedule():
     assert diff < Decimal('0.02')
     diff_interest_only = (Decimal(str(result['interestOnlyTotal'])) - interest_total).copy_abs()
     assert diff_interest_only < Decimal('0.02')
-    assert result['monthlyInterestPayment'] == pytest.approx(100000 * 0.12 / 12, abs=0.01)
-    assert result['quarterlyInterestPayment'] == pytest.approx(100000 * 0.12 / 4, abs=0.01)
+    daily_rate = 0.12 / 365
+    days_first = schedule[0]['days_held']
+    days_quarter = sum(p['days_held'] for p in schedule[:3])
+    assert result['monthlyInterestPayment'] == pytest.approx(100000 * daily_rate * days_first, abs=0.01)
+    assert result['quarterlyInterestPayment'] == pytest.approx(100000 * daily_rate * days_quarter, abs=0.01)


### PR DESCRIPTION
## Summary
- derive per-period interest from actual days instead of a 30.4375-day approximation
- extend payment dates and period ranges when loan term days spill past whole months
- update tests to validate day-based interest calculations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b61cd517c083208f80dc5a35b070bd