### PR TITLE
Add Start LTV computation and reporting for development loans

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -1346,6 +1346,12 @@ class LoanCalculator:
         loan_term_days = int(params.get("loan_term_days", 0))
         ltv = (gross_amount_solution / property_value * 100) if property_value > 0 else 0
 
+        opening_balance = net_advance_day1 + legals + arrangement_fee + title_insurance + site_visit_fee
+        start_ltv = (
+            opening_balance * (1 + (annual_interest_rate / 365) * loan_term_days)
+            / property_value * 100
+        ) if property_value > 0 else 0
+
         end_date_str = params.get("end_date")
         if end_date_str:
             end_date = datetime.strptime(end_date_str, "%Y-%m-%d")
@@ -1365,6 +1371,8 @@ class LoanCalculator:
             'day1Advance': self._round(net_advance_day1, 3),
             'propertyValue': self._round(property_value, 3),
             'ltv': self._round(ltv, 3),
+            'startLTV': self._round(start_ltv, 3),
+            'startLtv': self._round(start_ltv, 3),
             'currency': params.get('currency', 'GBP'),
             'loanTerm': loan_term,
             'loanTermDays': loan_term_days,

--- a/calculatordev.html
+++ b/calculatordev.html
@@ -901,9 +901,9 @@
 <td class="fw-bold px-3 text-end" id="netDay1AdvanceResult" style="color: #000 !important; background: #f8f9fa;">-</td>
 </tr>
 <tr style="border: 1px solid #000;">
-<td class="px-3" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;">LTV Ratio</td>
+<td class="px-3" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;">Start LTV</td>
 <td class="text-end px-3" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;"></td>
-<td class="fw-bold px-3 text-end" id="ltvRatioResult" style="color: #000 !important; background: #f8f9fa;">-</td>
+<td class="fw-bold px-3 text-end" id="startLTVResult" style="color: #000 !important; background: #f8f9fa;">-</td>
 </tr>
 <tr style="border: 1px solid #000;">
 <td class="px-3" style="color: #000 !important; border-right: 1px solid #000; background: white;">End LTV</td>

--- a/calculatordev.js
+++ b/calculatordev.js
@@ -624,7 +624,7 @@ class LoanCalculator {
         const titleInsuranceEl = document.getElementById('titleInsuranceResult');
         const totalInterestEl = document.getElementById('totalInterestResult');
         const netDay1AdvanceEl = document.getElementById('netDay1AdvanceResult');
-        const ltvRatioEl = document.getElementById('ltvRatioResult');
+        const startLTVEl = document.getElementById('startLTVResult');
         const totalNetAdvanceEl = document.getElementById('totalNetAdvanceResult');
         const valuationEl = document.getElementById('propertyValueResult');
         const endLTVEl = document.getElementById('endLTVResult');
@@ -668,12 +668,10 @@ class LoanCalculator {
             netDay1AdvanceEl.textContent = displayDay1Advance.toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2});
         }
         
-        // Calculate and display LTV ratio (use backend values if available)
-        if (ltvRatioEl && propertyValue > 0) {
-            const ltvRatio = results.ltv || (grossAmount / propertyValue * 100);
-            ltvRatioEl.textContent = ltvRatio.toFixed(2) + '%';
-        } else if (ltvRatioEl) {
-            ltvRatioEl.textContent = '0.00%';
+        // Display Start LTV from backend results
+        if (startLTVEl) {
+            const startLTV = results.startLTV || results.startLtv || 0;
+            startLTVEl.textContent = startLTV.toFixed(2) + '%';
         }
         
         // Display End LTV based on closing balance of last month from payment schedule

--- a/simple_report_generator.py
+++ b/simple_report_generator.py
@@ -60,6 +60,8 @@ class WorkingReportGenerator:
                 ['Net Advance', f"£{float(loan.net_advance or 0):,.2f}"],
                 ['Total Interest', f"£{float(loan.total_interest or 0):,.2f}"],
                 ['Property Value', f"£{float(loan.property_value or 0):,.2f}"],
+                ['Start LTV', f"{float(loan.start_ltv or 0):.2f}%"],
+                ['End LTV', f"{float(loan.end_ltv or 0):.2f}%"],
                 ['Loan Term (Months)', str(getattr(loan, 'loan_term_months', getattr(loan, 'loan_term', 'N/A')))],
                 ['Interest Rate', f"{float(loan.interest_rate or 0):.2f}%"],
                 ['Created Date', loan.created_at.strftime('%Y-%m-%d %H:%M') if loan.created_at else 'N/A']
@@ -139,6 +141,8 @@ class WorkingReportGenerator:
                 ('Net Advance', float(loan.net_advance or 0), currency_format),
                 ('Total Interest', float(loan.total_interest or 0), currency_format),
                 ('Property Value', float(loan.property_value or 0), currency_format),
+                ('Start LTV', f"{float(loan.start_ltv or 0):.2f}%", data_format),
+                ('End LTV', f"{float(loan.end_ltv or 0):.2f}%", data_format),
                 ('Loan Term (Months)', getattr(loan, 'loan_term_months', getattr(loan, 'loan_term', 'N/A')), data_format),
                 ('Interest Rate', f"{float(loan.interest_rate or 0):.2f}%", data_format),
                 ('Created Date', loan.created_at.strftime('%Y-%m-%d %H:%M') if loan.created_at else 'N/A', data_format)


### PR DESCRIPTION
## Summary
- compute Start LTV for Development2 loans using first-period opening balance and interest
- show Start LTV in calculator results and loan summary report
- include Start and End LTV in generated PDF/Excel reports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b62639201c8320b86ea5c67b4b0f2e