### PR TITLE
Use nominal rate for bridge service-only interest display

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -700,36 +700,47 @@ class LoanCalculator:
             **{k: float(v) for k, v in fees.items()}
         })
 
-        # Always provide reference monthly and quarterly interest payments
-        # using exact day counts for the first period. This ensures that
-        # summaries align with detailed schedules, especially when the loan
-        # term includes additional days beyond whole months.
+        # Always provide reference monthly and quarterly interest payments.
+        # For service-only bridge loans, these are simple nominal
+        # calculations based on the gross loan amount. For other repayment
+        # options, use the exact day-count method so summaries align with
+        # detailed schedules.
         annual_rate_decimal = annual_rate / Decimal('100')
         rounding = Decimal('0.01')
-        monthly_interest = self._calculate_periodic_interest(
-            gross_amount,
-            annual_rate_decimal,
-            'monthly',
-            start_date,
-            loan_term,
-            payment_timing,
-            loan_term_days,
-            use_360_days,
-        ).quantize(rounding, rounding=ROUND_HALF_UP)
-        quarterly_interest = self._calculate_periodic_interest(
-            gross_amount,
-            annual_rate_decimal,
-            'quarterly',
-            start_date,
-            loan_term,
-            payment_timing,
-            loan_term_days,
-            use_360_days,
-        ).quantize(rounding, rounding=ROUND_HALF_UP)
+        if repayment_option == 'service_only':
+            monthly_interest = (
+                gross_amount * annual_rate_decimal / Decimal('12')
+            ).quantize(rounding, rounding=ROUND_HALF_UP)
+            quarterly_interest = (
+                gross_amount * annual_rate_decimal / Decimal('4')
+            ).quantize(rounding, rounding=ROUND_HALF_UP)
+        else:
+            monthly_interest = self._calculate_periodic_interest(
+                gross_amount,
+                annual_rate_decimal,
+                'monthly',
+                start_date,
+                loan_term,
+                payment_timing,
+                loan_term_days,
+                use_360_days,
+            ).quantize(rounding, rounding=ROUND_HALF_UP)
+            quarterly_interest = self._calculate_periodic_interest(
+                gross_amount,
+                annual_rate_decimal,
+                'quarterly',
+                start_date,
+                loan_term,
+                payment_timing,
+                loan_term_days,
+                use_360_days,
+            ).quantize(rounding, rounding=ROUND_HALF_UP)
         calculation['monthlyInterestPayment'] = float(monthly_interest)
         calculation['quarterlyInterestPayment'] = float(quarterly_interest)
 
-        periodic_interest = monthly_interest if payment_frequency == 'monthly' else quarterly_interest
+        periodic_interest = (
+            monthly_interest if payment_frequency == 'monthly' else quarterly_interest
+        )
         calculation['periodicInterest'] = float(periodic_interest)
 
         # Service-only loans pay interest only each period. Service + capital

--- a/test_periodic_interest_summary_visibility.py
+++ b/test_periodic_interest_summary_visibility.py
@@ -48,12 +48,26 @@ def test_periodic_interest_visible_and_correct(repayment_option, payment_frequen
         params['flexible_payment'] = 10000
 
     result = calc.calculate_bridge_loan(params)
-    daily_rate = 0.12 / 365
-    days_month = 31
-    days_quarter = 91
-    expected = 600000 * daily_rate * (days_month if payment_frequency == 'monthly' else days_quarter)
+    if repayment_option == 'service_only':
+        monthly_expected = 600000 * 0.12 / 12
+        quarterly_expected = 600000 * 0.12 / 4
+        expected = monthly_expected if payment_frequency == 'monthly' else quarterly_expected
+        assert result['periodicInterest'] == pytest.approx(expected, abs=0.01)
+        assert result['monthlyInterestPayment'] == pytest.approx(monthly_expected, abs=0.01)
+        assert result['quarterlyInterestPayment'] == pytest.approx(quarterly_expected, abs=0.01)
+    else:
+        daily_rate = 0.12 / 365
+        days_month = 31
+        days_quarter = 91
+        expected = 600000 * daily_rate * (
+            days_month if payment_frequency == 'monthly' else days_quarter
+        )
 
-    assert result['periodicInterest'] == pytest.approx(expected, abs=0.01)
-    assert result['monthlyInterestPayment'] == pytest.approx(600000 * daily_rate * days_month, abs=0.01)
-    assert result['quarterlyInterestPayment'] == pytest.approx(600000 * daily_rate * days_quarter, abs=0.01)
+        assert result['periodicInterest'] == pytest.approx(expected, abs=0.01)
+        assert result['monthlyInterestPayment'] == pytest.approx(
+            600000 * daily_rate * days_month, abs=0.01
+        )
+        assert result['quarterlyInterestPayment'] == pytest.approx(
+            600000 * daily_rate * days_quarter, abs=0.01
+        )
     assert result['periodicInterest'] > 0

--- a/test_service_only_periodic_interest.py
+++ b/test_service_only_periodic_interest.py
@@ -1,0 +1,70 @@
+import sys, types
+import pytest
+from decimal import Decimal
+from calculations import LoanCalculator
+
+# Provide minimal stub for dateutil.relativedelta to avoid external dependency
+relativedelta_module = types.ModuleType('relativedelta')
+
+
+class relativedelta:  # pragma: no cover - simple stub
+    def __init__(self, months=0):
+        self.months = months
+
+    def __radd__(self, other):
+        from datetime import date
+
+        month = other.month - 1 + self.months
+        year = other.year + month // 12
+        month = month % 12 + 1
+        day = min(
+            other.day,
+            [
+                31,
+                29 if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0) else 28,
+                31,
+                30,
+                31,
+                30,
+                31,
+                31,
+                30,
+                31,
+                30,
+                31,
+            ][month - 1],
+        )
+        return other.replace(year=year, month=month, day=day)
+
+
+relativedelta_module.relativedelta = relativedelta
+sys.modules['dateutil'] = types.ModuleType('dateutil')
+sys.modules['dateutil'].relativedelta = relativedelta_module
+sys.modules['dateutil.relativedelta'] = relativedelta_module
+
+@pytest.mark.parametrize("amount_input", [
+    {"gross_amount": 150000},
+    {"amount_input_type": "net", "net_amount": 150000},
+])
+def test_service_only_monthly_and_quarterly_interest(amount_input):
+    calc = LoanCalculator()
+    params = {
+        "loan_type": "bridge",
+        "repayment_option": "service_only",
+        "annual_rate": 12,
+        "loan_term": 12,
+        "payment_frequency": "monthly",
+        "payment_timing": "arrears",
+        "arrangement_fee_rate": 0,
+        "legal_fees": 0,
+        "site_visit_fee": 0,
+        "title_insurance_rate": 0,
+        "start_date": "2024-01-01",
+    }
+    params.update(amount_input)
+    result = calc.calculate_bridge_loan(params)
+    gross = Decimal(str(result["grossAmount"]))
+    expected_monthly = gross * Decimal("0.12") / Decimal("12")
+    expected_quarterly = gross * Decimal("0.12") / Decimal("4")
+    assert result["monthlyInterestPayment"] == pytest.approx(float(expected_monthly), abs=0.01)
+    assert result["quarterlyInterestPayment"] == pytest.approx(float(expected_quarterly), abs=0.01)

--- a/test_service_only_summary_matches_schedule.py
+++ b/test_service_only_summary_matches_schedule.py
@@ -47,8 +47,7 @@ def test_service_only_summary_matches_schedule():
     assert diff < Decimal('0.02')
     diff_interest_only = (Decimal(str(result['interestOnlyTotal'])) - interest_total).copy_abs()
     assert diff_interest_only < Decimal('0.02')
-    daily_rate = 0.12 / 365
-    days_first = schedule[0]['days_held']
-    days_quarter = sum(p['days_held'] for p in schedule[:3])
-    assert result['monthlyInterestPayment'] == pytest.approx(100000 * daily_rate * days_first, abs=0.01)
-    assert result['quarterlyInterestPayment'] == pytest.approx(100000 * daily_rate * days_quarter, abs=0.01)
+    expected_monthly = 100000 * 0.12 / 12
+    expected_quarterly = 100000 * 0.12 / 4
+    assert result['monthlyInterestPayment'] == pytest.approx(expected_monthly, abs=0.01)
+    assert result['quarterlyInterestPayment'] == pytest.approx(expected_quarterly, abs=0.01)


### PR DESCRIPTION
## Summary
- compute monthly and quarterly interest for bridge service-only loans using gross amount times annual rate
- add coverage ensuring service-only interest display uses gross amount for both gross and net inputs
- update existing tests to reflect nominal calculation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6b9a5ac708320894803eb453b382a