### PR TITLE
Use nominal periodic interest for bridge loans

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -700,41 +700,18 @@ class LoanCalculator:
             **{k: float(v) for k, v in fees.items()}
         })
 
-        # Always provide reference monthly and quarterly interest payments.
-        # For service-only bridge loans, these are simple nominal
-        # calculations based on the gross loan amount. For other repayment
-        # options, use the exact day-count method so summaries align with
-        # detailed schedules.
+        # Always provide reference monthly and quarterly interest payments
+        # using nominal calculations on the gross loan amount. This keeps
+        # the summary values consistent across all bridge repayment types
+        # and independent of date-based day-count conventions.
         annual_rate_decimal = annual_rate / Decimal('100')
         rounding = Decimal('0.01')
-        if repayment_option == 'service_only':
-            monthly_interest = (
-                gross_amount * annual_rate_decimal / Decimal('12')
-            ).quantize(rounding, rounding=ROUND_HALF_UP)
-            quarterly_interest = (
-                gross_amount * annual_rate_decimal / Decimal('4')
-            ).quantize(rounding, rounding=ROUND_HALF_UP)
-        else:
-            monthly_interest = self._calculate_periodic_interest(
-                gross_amount,
-                annual_rate_decimal,
-                'monthly',
-                start_date,
-                loan_term,
-                payment_timing,
-                loan_term_days,
-                use_360_days,
-            ).quantize(rounding, rounding=ROUND_HALF_UP)
-            quarterly_interest = self._calculate_periodic_interest(
-                gross_amount,
-                annual_rate_decimal,
-                'quarterly',
-                start_date,
-                loan_term,
-                payment_timing,
-                loan_term_days,
-                use_360_days,
-            ).quantize(rounding, rounding=ROUND_HALF_UP)
+        monthly_interest = (
+            gross_amount * annual_rate_decimal / Decimal('12')
+        ).quantize(rounding, rounding=ROUND_HALF_UP)
+        quarterly_interest = (
+            gross_amount * annual_rate_decimal / Decimal('4')
+        ).quantize(rounding, rounding=ROUND_HALF_UP)
         calculation['monthlyInterestPayment'] = float(monthly_interest)
         calculation['quarterlyInterestPayment'] = float(quarterly_interest)
 

--- a/test_capital_payment_schedule_fields.py
+++ b/test_capital_payment_schedule_fields.py
@@ -60,8 +60,7 @@ def test_capital_only_schedule_fields_present():
         for field in required_fields:
             assert field in entry, f"Missing field {field} in period {idx}"
     assert schedule[-1].get('interest_refund') not in (None, ''), 'Interest refund missing in last period'
-    daily_rate = 0.12 / 365
-    days_first = schedule[0]['days_held']
-    days_quarter = sum(p['days_held'] for p in schedule[:3])
-    assert result['monthlyInterestPayment'] == pytest.approx(2000000 * daily_rate * days_first, abs=0.01)
-    assert result['quarterlyInterestPayment'] == pytest.approx(2000000 * daily_rate * days_quarter, abs=0.01)
+    monthly_expected = 2000000 * 0.12 / 12
+    quarterly_expected = 2000000 * 0.12 / 4
+    assert result['monthlyInterestPayment'] == pytest.approx(monthly_expected, abs=0.01)
+    assert result['quarterlyInterestPayment'] == pytest.approx(quarterly_expected, abs=0.01)

--- a/test_capital_payment_summary_monthly_interest.py
+++ b/test_capital_payment_summary_monthly_interest.py
@@ -41,6 +41,6 @@ def test_capital_only_summary_includes_monthly_interest():
     }
     result = calc.calculate_bridge_loan(params)
 
-    expected_monthly_interest = 2000000 * 0.12 / 365 * 31
+    expected_monthly_interest = 2000000 * 0.12 / 12
     assert result['periodicInterest'] == pytest.approx(expected_monthly_interest, abs=0.01)
     assert result['monthlyPayment'] == pytest.approx(10000, abs=0.01)

--- a/test_flexible_payment_schedule_fields.py
+++ b/test_flexible_payment_schedule_fields.py
@@ -30,8 +30,7 @@ def test_flexible_payment_schedule_fields_present():
     for idx, entry in enumerate(schedule, start=1):
         for field in required_fields:
             assert field in entry, f"Missing field {field} in period {idx}"
-    daily_rate = 0.12 / 365
-    days_first = schedule[0]['days_held']
-    days_quarter = sum(p['days_held'] for p in schedule[:3])
-    assert result['monthlyInterestPayment'] == pytest.approx(100000 * daily_rate * days_first, abs=0.01)
-    assert result['quarterlyInterestPayment'] == pytest.approx(100000 * daily_rate * days_quarter, abs=0.01)
+    monthly_expected = 100000 * 0.12 / 12
+    quarterly_expected = 100000 * 0.12 / 4
+    assert result['monthlyInterestPayment'] == pytest.approx(monthly_expected, abs=0.01)
+    assert result['quarterlyInterestPayment'] == pytest.approx(quarterly_expected, abs=0.01)

--- a/test_gross_net_roundtrip_fields.py
+++ b/test_gross_net_roundtrip_fields.py
@@ -35,7 +35,7 @@ def test_gross_to_net_and_back_fields():
     assert gross_result['titleInsurance'] == pytest.approx(3360.0)
     assert gross_result['totalInterest'] == pytest.approx(233447.68)
     assert gross_result['interestOnlyTotal'] == pytest.approx(240000.0)
-    expected_monthly_interest = 2000000 * 0.12 / 365 * 31
+    expected_monthly_interest = 2000000 * 0.12 / 12
     assert gross_result['periodicInterest'] == pytest.approx(expected_monthly_interest, abs=0.01)
 
     net_params = dict(params, amount_input_type='net', net_amount=Decimal('1934640'))

--- a/test_periodic_interest_summary_visibility.py
+++ b/test_periodic_interest_summary_visibility.py
@@ -25,7 +25,12 @@ sys.modules['dateutil.relativedelta'] = relativedelta_module
 from calculations import LoanCalculator
 
 
-@pytest.mark.parametrize("repayment_option", ['service_only', 'capital_payment_only', 'flexible_payment'])
+@pytest.mark.parametrize("repayment_option", [
+    'service_only',
+    'service_and_capital',
+    'capital_payment_only',
+    'flexible_payment'
+])
 @pytest.mark.parametrize("payment_frequency", ['monthly', 'quarterly'])
 def test_periodic_interest_visible_and_correct(repayment_option, payment_frequency):
     calc = LoanCalculator()
@@ -42,32 +47,17 @@ def test_periodic_interest_visible_and_correct(repayment_option, payment_frequen
         'payment_frequency': payment_frequency,
         'start_date': '2024-01-01',
     }
-    if repayment_option == 'capital_payment_only':
+    if repayment_option in ['service_and_capital', 'capital_payment_only']:
         params['capital_repayment'] = 10000
     if repayment_option == 'flexible_payment':
         params['flexible_payment'] = 10000
 
     result = calc.calculate_bridge_loan(params)
-    if repayment_option == 'service_only':
-        monthly_expected = 600000 * 0.12 / 12
-        quarterly_expected = 600000 * 0.12 / 4
-        expected = monthly_expected if payment_frequency == 'monthly' else quarterly_expected
-        assert result['periodicInterest'] == pytest.approx(expected, abs=0.01)
-        assert result['monthlyInterestPayment'] == pytest.approx(monthly_expected, abs=0.01)
-        assert result['quarterlyInterestPayment'] == pytest.approx(quarterly_expected, abs=0.01)
-    else:
-        daily_rate = 0.12 / 365
-        days_month = 31
-        days_quarter = 91
-        expected = 600000 * daily_rate * (
-            days_month if payment_frequency == 'monthly' else days_quarter
-        )
+    monthly_expected = 600000 * 0.12 / 12
+    quarterly_expected = 600000 * 0.12 / 4
+    expected = monthly_expected if payment_frequency == 'monthly' else quarterly_expected
 
-        assert result['periodicInterest'] == pytest.approx(expected, abs=0.01)
-        assert result['monthlyInterestPayment'] == pytest.approx(
-            600000 * daily_rate * days_month, abs=0.01
-        )
-        assert result['quarterlyInterestPayment'] == pytest.approx(
-            600000 * daily_rate * days_quarter, abs=0.01
-        )
+    assert result['periodicInterest'] == pytest.approx(expected, abs=0.01)
+    assert result['monthlyInterestPayment'] == pytest.approx(monthly_expected, abs=0.01)
+    assert result['quarterlyInterestPayment'] == pytest.approx(quarterly_expected, abs=0.01)
     assert result['periodicInterest'] > 0

--- a/test_sc_only_summary.py
+++ b/test_sc_only_summary.py
@@ -39,7 +39,7 @@ def test_sc_only_uses_service_capital_logic_without_savings():
         'start_date': '2024-01-01',
     }
     result = calc.calculate_bridge_loan(params)
-    expected_interest = Decimal('1000000') * Decimal('0.12') / Decimal('365') * Decimal('31')
+    expected_interest = Decimal('1000000') * Decimal('0.12') / Decimal('12')
     assert result['monthlyPayment'] == pytest.approx(float(expected_interest + Decimal('5000')), abs=0.01)
     assert result.get('interestSavings', 0) == 0
     assert result.get('interestOnlyTotal', 0) == 0

--- a/test_service_capital_summary_monthly_interest.py
+++ b/test_service_capital_summary_monthly_interest.py
@@ -39,7 +39,7 @@ def test_service_and_capital_summary_shows_interest_and_capital():
         'start_date': '2024-01-01',
     }
     result = calc.calculate_bridge_loan(params)
-    expected_interest = 1000000 * 0.12 / 365 * 31
+    expected_interest = 1000000 * 0.12 / 12
     assert result['periodicInterest'] == pytest.approx(expected_interest, abs=0.01)
     assert result['monthlyPayment'] == pytest.approx(expected_interest + 5000, abs=0.01)
 
@@ -62,6 +62,6 @@ def test_service_and_capital_summary_net_input_uses_gross_amount():
     }
     result = calc.calculate_bridge_loan(params)
     gross = Decimal(str(result['grossAmount']))
-    expected_interest = gross * Decimal('0.12') / Decimal('365') * Decimal('31')
+    expected_interest = gross * Decimal('0.12') / Decimal('12')
     assert result['periodicInterest'] == pytest.approx(float(expected_interest), abs=0.01)
     assert result['monthlyPayment'] == pytest.approx(float(expected_interest) + 5000, abs=0.01)


### PR DESCRIPTION
## Summary
- Calculate bridge loan monthly/quarterly interest as gross_amount × annual_rate/12 or /4 for all repayment options
- Expand periodic interest tests to cover all bridge repayment types and validate new formula
- Update existing tests to expect nominal interest payments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6c021a7248320a5416c292bb05e8b