### PR TITLE
Ensure report day counts include end date

### DIFF
--- a/report_utils.py
+++ b/report_utils.py
@@ -194,8 +194,9 @@ def generate_report_schedule(params: Dict[str, Any]) -> Tuple[List[Dict[str, Any
             start = row.get('start_period')
             end = row.get('end_period')
             if start and end:
-                day_count = (datetime.strptime(end, '%d/%m/%Y') - datetime.strptime(start, '%d/%m/%Y')).days
-                row['days_held'] = day_count
+                day_count = (datetime.strptime(end, '%d/%m/%Y') - datetime.strptime(start, '%d/%m/%Y')).days + 1
+                if int(row.get('days_held', 0)) != day_count:
+                    row['days_held'] = day_count
             else:
                 day_count = int(row.get('days_held', 0))
 


### PR DESCRIPTION
## Summary
- Adjust report schedule day count to treat end date as inclusive
- Avoid recalculating days_held when already correct

## Testing
- `pytest test_report_interest_days_held.py test_report_service_and_capital_interest.py test_report_service_only_interest_payments.py test_payment_schedule_day_counts.py test_gross_net_roundtrip_fields.py`

------
https://chatgpt.com/codex/tasks/task_e_68b6c6e26670832096f9c0965b39574b