### PR TITLE
Align development interest calculation with period days held

### DIFF
--- a/test_development_net_to_gross_day_count.py
+++ b/test_development_net_to_gross_day_count.py
@@ -1,0 +1,22 @@
+from calculations import LoanCalculator
+
+
+def test_development_net_to_gross_day_count():
+    calc = LoanCalculator()
+    params = {
+        'net_amount': 100000,
+        'loan_term': 12,
+        'annual_rate': 12,
+        'start_date': '2025-09-01',
+        'day1_advance': 100000,
+        'arrangement_fee_rate': 0,
+        'legal_fees': 0,
+        'site_visit_fee': 0,
+        'title_insurance_rate': 0,
+        'tranches': [],
+    }
+    result = calc.calculate_development_loan(params)
+    first = result['detailed_payment_schedule'][0]
+    assert first['days_held'] == 30
+    exponent = int(first['interest_calculation'].split('^')[1])
+    assert exponent == 30


### PR DESCRIPTION
## Summary
- Use precomputed period_ranges days_held for development schedule interest exponent
- Apply period dates to detailed payment schedule entries
- Add regression test ensuring first development period uses 30-day compound exponent

## Testing
- `pytest -q test_development_net_to_gross_day_count.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d2d5af908320ad288707f998afa5