### PR TITLE
Use gross amount for term loan interest display

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -978,32 +978,23 @@ class LoanCalculator:
         })
 
         # Always provide reference monthly and quarterly interest payments
-        # using exact day counts for the first period when dates are supplied.
+        # using nominal calculations on the gross loan amount. This keeps
+        # the summary values consistent across all term loan repayment types
+        # and independent of date-based day-count conventions.
+        annual_rate_decimal = annual_rate / Decimal('100')
         rounding = Decimal('0.01')
-        monthly_interest = self._calculate_periodic_interest(
-            gross_amount,
-            annual_rate / Decimal('100'),
-            'monthly',
-            start_date,
-            loan_term,
-            payment_timing,
-            loan_term_days,
-            use_360_days,
+        monthly_interest = (
+            gross_amount * annual_rate_decimal / Decimal('12')
         ).quantize(rounding, rounding=ROUND_HALF_UP)
-        quarterly_interest = self._calculate_periodic_interest(
-            gross_amount,
-            annual_rate / Decimal('100'),
-            'quarterly',
-            start_date,
-            loan_term,
-            payment_timing,
-            loan_term_days,
-            use_360_days,
+        quarterly_interest = (
+            gross_amount * annual_rate_decimal / Decimal('4')
         ).quantize(rounding, rounding=ROUND_HALF_UP)
         calculation['monthlyInterestPayment'] = float(monthly_interest)
         calculation['quarterlyInterestPayment'] = float(quarterly_interest)
 
-        periodic_interest = monthly_interest if payment_frequency == 'monthly' else quarterly_interest
+        periodic_interest = (
+            monthly_interest if payment_frequency == 'monthly' else quarterly_interest
+        )
         calculation['periodicInterest'] = float(periodic_interest)
 
         if repayment_option == 'service_only':

--- a/test_term_interest_payment_display.py
+++ b/test_term_interest_payment_display.py
@@ -1,0 +1,59 @@
+import sys, types
+from decimal import Decimal
+import pytest
+
+# Provide minimal stub for dateutil.relativedelta
+relativedelta_module = types.ModuleType('relativedelta')
+class relativedelta:
+    def __init__(self, months=0):
+        self.months = months
+    def __radd__(self, other):
+        from datetime import date
+        month = other.month - 1 + self.months
+        year = other.year + month // 12
+        month = month % 12 + 1
+        day = min(other.day, [31, 29 if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0) else 28,
+                              31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1])
+        return other.replace(year=year, month=month, day=day)
+relativedelta_module.relativedelta = relativedelta
+sys.modules['dateutil'] = types.ModuleType('dateutil')
+sys.modules['dateutil'].relativedelta = relativedelta_module
+sys.modules['dateutil.relativedelta'] = relativedelta_module
+
+from calculations import LoanCalculator
+
+
+@pytest.mark.parametrize("repayment_option", ['service_only', 'service_and_capital'])
+@pytest.mark.parametrize("amount_input_type", ['gross', 'net'])
+@pytest.mark.parametrize("payment_frequency", ['monthly', 'quarterly'])
+def test_term_summary_interest_payments_use_gross_amount(repayment_option, amount_input_type, payment_frequency):
+    calc = LoanCalculator()
+    params = {
+        'loan_type': 'term',
+        'repayment_option': repayment_option,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'payment_frequency': payment_frequency,
+        'payment_timing': 'arrears',
+        'start_date': '2024-01-01',
+        'arrangement_fee_rate': 0,
+        'legal_fees': 0,
+        'site_visit_fee': 0,
+        'title_insurance_rate': 0,
+    }
+    if amount_input_type == 'gross':
+        params['gross_amount'] = 600000
+    else:
+        params['amount_input_type'] = 'net'
+        params['net_amount'] = 600000
+    if repayment_option == 'service_and_capital':
+        params['capital_repayment'] = 5000
+
+    result = calc.calculate_term_loan(params)
+    gross = Decimal(str(result['grossAmount']))
+    expected_monthly = gross * Decimal('0.12') / Decimal('12')
+    expected_quarterly = gross * Decimal('0.12') / Decimal('4')
+    assert result['monthlyInterestPayment'] == pytest.approx(float(expected_monthly), abs=0.01)
+    assert result['quarterlyInterestPayment'] == pytest.approx(float(expected_quarterly), abs=0.01)
+    expected_periodic = expected_monthly if payment_frequency == 'monthly' else expected_quarterly
+    assert result['periodicInterest'] == pytest.approx(float(expected_periodic), abs=0.01)


### PR DESCRIPTION
## Summary
- ensure term loan monthly and quarterly interest fields use gross amount with simple rate division
- add tests covering service-only and service+capital term loans for gross and net inputs

## Testing
- `pytest -q` *(fails: pytest not installed)*
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b6d3c63b54832081673fca493468a9