### PR TITLE
Add UI to manage saved Snowflake configuration

### DIFF
--- a/templates/snowflake_config.html
+++ b/templates/snowflake_config.html
@@ -6,7 +6,19 @@
 <div class="container py-4">
     <h2 class="mb-3">Snowflake Configuration</h2>
     <p>Store your Snowflake connection settings and verify the connection.</p>
-    <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#snowflakeModal">
+    <div id="savedConfig" class="card border mb-3" style="display:none;">
+        <div class="card-body d-flex justify-content-between align-items-center">
+            <div id="savedDetails" class="small"></div>
+            <div class="d-flex gap-2">
+                <button type="button" class="btn btn-sm btn-primary" onclick="editConfig()">Edit</button>
+                <button type="button" class="btn btn-sm btn-info text-white" onclick="testConnection()" title="Test Connection">
+                    <i class="fas fa-vial"></i>
+                </button>
+                <button type="button" class="btn btn-sm btn-danger" onclick="deleteConfig()">Delete</button>
+            </div>
+        </div>
+    </div>
+    <button id="openModalBtn" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#snowflakeModal">
         <i class="fas fa-database me-1"></i>Configure Snowflake
     </button>
     <div id="testResult" class="mt-3"></div>
@@ -63,7 +75,15 @@ async function loadConfig() {
     const resp = await fetch('/api/snowflake/config');
     if (!resp.ok) return;
     const data = await resp.json();
-    if (!data) return;
+    const savedDiv = document.getElementById('savedConfig');
+    const detailsDiv = document.getElementById('savedDetails');
+    const openBtn = document.getElementById('openModalBtn');
+    if (!data) {
+        savedDiv.style.display = 'none';
+        openBtn.style.display = 'inline-block';
+        return;
+    }
+    openBtn.style.display = 'none';
     const form = document.getElementById('snowflakeForm');
     form.account.value = data.account || '';
     form.user.value = data.user || '';
@@ -71,6 +91,14 @@ async function loadConfig() {
     form.database.value = data.database || '';
     form.schema.value = data.schema || '';
     form.token.value = data.token || '';
+    detailsDiv.innerHTML = `
+        <div><strong>Account:</strong> ${data.account || ''}</div>
+        <div><strong>User:</strong> ${data.user || ''}</div>
+        <div><strong>Warehouse:</strong> ${data.warehouse || ''}</div>
+        <div><strong>Database:</strong> ${data.database || ''}</div>
+        <div><strong>Schema:</strong> ${data.schema || ''}</div>
+    `;
+    savedDiv.style.display = 'block';
 }
 
 async function saveConfig(e) {
@@ -93,6 +121,7 @@ async function saveConfig(e) {
     if (resp.ok) {
         await testConnection();
         bootstrap.Modal.getInstance(document.getElementById('snowflakeModal')).hide();
+        loadConfig();
     }
 }
 
@@ -109,6 +138,20 @@ async function testConnection() {
     } catch (err) {
         resultDiv.innerHTML = '<div class="alert alert-danger">Connection failed.</div>';
     }
+}
+
+function editConfig() {
+    loadConfig();
+    const modal = new bootstrap.Modal(document.getElementById('snowflakeModal'));
+    modal.show();
+}
+
+async function deleteConfig() {
+    if (!confirm('Delete Snowflake configuration?')) return;
+    await fetch('/api/snowflake/config', {method: 'DELETE'});
+    document.getElementById('savedConfig').style.display = 'none';
+    document.getElementById('openModalBtn').style.display = 'inline-block';
+    document.getElementById('testResult').innerHTML = '';
 }
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Display saved Snowflake settings on the config page
- Allow editing, testing, and deleting a stored Snowflake configuration

## Testing
- `pytest test_snowflake_config_persistence.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b703bfe2dc8320ae16e8ac0afc7653