### PR TITLE
Ensure reports accessible only after saving loan

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1616,6 +1616,7 @@ function initializeEditMode() {
 
 // Power BI report utilities
 let powerBIReports = {};
+let isLoanSaved = false;
 
 async function loadPowerBIReports() {
     try {
@@ -1736,7 +1737,7 @@ function updateReportsButton(loan) {
     const btn = document.getElementById('openReportsBtn');
     const menu = document.getElementById('reportDropdownMenu');
     if (!btn || !menu) return;
-    if (!loan || !loan.loan_name) {
+    if (!loan || !loan.loan_name || !isLoanSaved) {
         btn.disabled = true;
         menu.innerHTML = '';
         return;
@@ -1750,7 +1751,8 @@ document.addEventListener('DOMContentLoaded', async function() {
     await loadPowerBIReports();
     // Initialize edit mode
     initializeEditMode();
-    if (window.editMode && window.editMode.loanId) {
+    isLoanSaved = !!(window.editMode && window.editMode.loanId);
+    if (isLoanSaved) {
         updateReportsButton(getLoanForReport());
     } else {
         updateReportsButton(null);
@@ -1859,6 +1861,9 @@ document.addEventListener('DOMContentLoaded', async function() {
             }
             
             const result = await response.json();
+
+            // Mark loan as saved and enable reports
+            isLoanSaved = true;
 
             // Show success notification
             if (window.notifications) {


### PR DESCRIPTION
## Summary
- Add `isLoanSaved` flag to track whether current loan is persisted
- Disable Loan Summary report button until loan data is saved in Snowflake
- Activate report button automatically after successful save or when editing saved loan

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b70543b76083209cf151f3a3d9ede1