### PR TITLE
Fix nav tab text visibility

### DIFF
--- a/static/css/currency-themes.css
+++ b/static/css/currency-themes.css
@@ -576,11 +576,11 @@ a:hover {
 }
 
 .nav-link {
-    color: var(--primary-color) !important;
+    color: var(--primary-color);
 }
 
 .nav-link:hover {
-    color: var(--primary-dark) !important;
+    color: var(--primary-dark);
 }
 
 /* Loan History Table */


### PR DESCRIPTION
## Summary
- remove global `!important` styling for nav links so tab text colors can be overridden

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b717437be48320a090a38e08289723