### PR TITLE
Fix loan history JS and reduce global error noise

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -503,13 +503,18 @@ window.addEventListener('offline', function() {
 
 // Global error handler
 window.addEventListener('error', function(event) {
+    // Ignore errors from loading resources like images or scripts
+    if (!event.error) {
+        return;
+    }
+
     console.error('Global error:', event.error);
-    
+
     // Don't show error toast for script loading errors in development
     if (event.filename && event.filename.includes('localhost')) {
         return;
     }
-    
+
     Novellus.utils.showToast('An unexpected error occurred', 'danger');
 });
 

--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -224,8 +224,7 @@ class LoanHistoryManager {
         } catch (error) {
             console.error('Error loading loans:', error);
             this.showError(error.message);
-                            window.notifications.error(`Failed to load loans: ${error.message}`);
-            }
+            window.notifications.error(`Failed to load loans: ${error.message}`);
         }
     }
 


### PR DESCRIPTION
## Summary
- Fix malformed catch block in loan history script so saved loans load correctly
- Ignore resource loading errors in global handler to prevent excessive toast notifications

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b71c5ffd988320bc9db558a31237f3