### PR TITLE
fix: remove duplicate script imports from calculator

### DIFF
--- a/calculatordev.html
+++ b/calculatordev.html
@@ -1044,7 +1044,6 @@
 
 {% block scripts %}
 <!-- Modern Notification System -->
-<script src="{{ url_for('static', filename='js/notifications.js') }}"></script>
 <script src="{{ url_for('static', filename='js/calculator.js') }}"></script>
 <script>
 // End date calculation functionality with automatic recalculation
@@ -1919,7 +1918,6 @@ function refreshDatabaseInfo() {
 }
 </script>
 <!-- Currency Theme Manager -->
-<script src="{{ url_for('static', filename='js/currency-theme-simple.js') }}"></script>
 <script>
 // Initialize currency theme manager on page load
 document.addEventListener('DOMContentLoaded', function() {

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1185,7 +1185,6 @@
 
 {% block scripts %}
 <!-- Modern Notification System -->
-<script src="{{ url_for('static', filename='js/notifications.js') }}"></script>
 <script src="{{ url_for('static', filename='js/calculator.js') }}"></script>
 <script>
 // End date/term synchronization with automatic recalculation
@@ -2239,7 +2238,6 @@ function refreshDatabaseInfo() {
 }
 </script>
 <!-- Currency Theme Manager -->
-<script src="{{ url_for('static', filename='js/currency-theme-simple.js') }}"></script>
 <script>
 // Initialize currency theme manager on page load
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- prevent NotificationSystem and SimpleCurrencyTheme redeclaration errors by loading scripts once
- rely on base template to include notifications and currency theme scripts

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b71ef35dfc832092b7f60c4f49b334