### PR TITLE
Fix missing brace in openScenarioComparison

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1231,6 +1231,7 @@ function toggleLoanEndInputs() {
     document.getElementById('endDateContainer').style.display = mode === 'term' ? 'none' : '';
 }
 
+}
 // Helper function to trigger calculation update when dates change
 function triggerCalculationUpdate() {
     try {
@@ -1934,6 +1935,7 @@ function openScenarioComparison() {
         // Fallback: open scenario comparison with default parameters
         window.open('/scenario-comparison', '_blank');
     }
+}
 
 // Helper function for retrying loan save with new name
 function retryLoanSave() {


### PR DESCRIPTION
## Summary
- add missing closing brace after error handler in `openScenarioComparison`

## Testing
- `python3 -m pytest` *(fails: No module named pytest, environment lacks pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b7233945908320a3a7f615e4c8b7b3