### PR TITLE
fix calculator script syntax to prevent load error

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1230,8 +1230,6 @@ function toggleLoanEndInputs() {
     document.getElementById('loanTermContainer').style.display = mode === 'term' ? '' : 'none';
     document.getElementById('endDateContainer').style.display = mode === 'term' ? 'none' : '';
 }
-
-}
 // Helper function to trigger calculation update when dates change
 function triggerCalculationUpdate() {
     try {


### PR DESCRIPTION
## Summary
- remove an extra closing brace from calculator page script so the JavaScript loads without errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68b72fc584508320852cc61c2aa4b06f