### PR TITLE
Wrap currency theme initialization in DOMContentLoaded

### DIFF
--- a/static/js/currency-theme-simple.js
+++ b/static/js/currency-theme-simple.js
@@ -3,9 +3,7 @@
  * Minimal, fast currency switching for button colors and logos
  */
 
-// Ensure default currency is applied before styles load
-document.documentElement.setAttribute('data-currency', 'GBP');
-document.body.setAttribute('data-currency', 'GBP');
+// Default currency will be applied once the DOM is ready
 
 class SimpleCurrencyTheme {
     constructor() {
@@ -124,5 +122,7 @@ class SimpleCurrencyTheme {
 
 // Initialize when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {
+    document.documentElement.setAttribute('data-currency', 'GBP');
+    document.body.setAttribute('data-currency', 'GBP');
     window.currencyTheme = new SimpleCurrencyTheme();
 });


### PR DESCRIPTION
## Summary
- delay currency attribute assignments until `DOMContentLoaded`
- initialize currency theme after DOM is ready

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68b731ceba2c832084460f594d2eb49c