### PR TITLE
style: apply gold navbar to select pages

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -42,6 +42,12 @@ body {
     background: linear-gradient(135deg, var(--secondary-color) 0%, var(--dark-color) 100%) !important;
 }
 
+/* Alternate gold navbar for select pages */
+.gold-nav .navbar {
+    background-color: #EEB142 !important;
+    background-image: none !important;
+}
+
 .navbar-brand {
     font-weight: 700;
     font-size: 1.5rem;

--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -2,7 +2,7 @@
 
 {% block title %}Loan History - Novellus Financial{% endblock %}
 
-{% block body_attr %}data-theme="document"{% endblock %}
+{% block body_attr %}class="gold-nav" data-theme="document"{% endblock %}
 
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/notifications.css') }}">

--- a/templates/powerbi_config.html
+++ b/templates/powerbi_config.html
@@ -2,7 +2,7 @@
 
 {% block title %}Power BI Configuration{% endblock %}
 
-{% block body_attr %}data-theme="document"{% endblock %}
+{% block body_attr %}class="gold-nav" data-theme="document"{% endblock %}
 
 {% block head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/notifications.css') }}">

--- a/templates/scenario_comparison.html
+++ b/templates/scenario_comparison.html
@@ -2,7 +2,7 @@
 
 {% block title %}One-Click Scenario Comparison - Novellus Loan Management{% endblock %}
 
-{% block body_attr %}data-theme="document"{% endblock %}
+{% block body_attr %}class="gold-nav" data-theme="document"{% endblock %}
 
 {% block head %}
 {{ super() }}

--- a/templates/snowflake_config.html
+++ b/templates/snowflake_config.html
@@ -2,7 +2,7 @@
 
 {% block title %}Snowflake Configuration{% endblock %}
 
-{% block body_attr %}data-theme="document"{% endblock %}
+{% block body_attr %}class="gold-nav" data-theme="document"{% endblock %}
 
 {% block content %}
 <div class="container py-4">

--- a/templates/user_manual.html
+++ b/templates/user_manual.html
@@ -2,7 +2,7 @@
 
 {% block title %}User Manual - Novellus Loan Management{% endblock %}
 
-{% block body_attr %}data-theme="document"{% endblock %}
+{% block body_attr %}class="gold-nav" data-theme="document"{% endblock %}
 
 {% block head %}
 <!-- Markdown to HTML JavaScript -->


### PR DESCRIPTION
## Summary
- add gold navbar option and use it on config, manual, comparison and history pages

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68b745e3cc7c8320afe9c5ebf6306897