### PR TITLE
Switch calculator selections to toggle buttons

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -214,6 +214,37 @@ class LoanCalculator {
             }
         });
 
+        // Sync radio toggle inputs with hidden fields
+        document.querySelectorAll('input[name="loanTypeToggle"]').forEach(radio => {
+            radio.addEventListener('change', () => {
+                const hidden = document.getElementById('loanType');
+                if (hidden) {
+                    hidden.value = radio.value;
+                    hidden.dispatchEvent(new Event('change'));
+                }
+            });
+        });
+
+        document.querySelectorAll('input[name="repaymentOptionToggle"]').forEach(radio => {
+            radio.addEventListener('change', () => {
+                const hidden = document.getElementById('repaymentOption');
+                if (hidden) {
+                    hidden.value = radio.value;
+                    hidden.dispatchEvent(new Event('change'));
+                }
+            });
+        });
+
+        document.querySelectorAll('input[name="currency"]').forEach(radio => {
+            radio.addEventListener('change', () => {
+                const hidden = document.getElementById('currency');
+                if (hidden) {
+                    hidden.value = radio.value;
+                    hidden.dispatchEvent(new Event('change'));
+                }
+            });
+        });
+
         // Amount input type toggles
         document.querySelectorAll('input[name="amount_input_type"]').forEach(radio => {
             radio.addEventListener('change', () => {
@@ -1275,72 +1306,45 @@ class LoanCalculator {
     updateRepaymentOptions() {
         try {
             const loanTypeElement = document.getElementById('loanType');
-            const repaymentSelect = document.getElementById('repaymentOption');
-            
-            if (!loanTypeElement || !repaymentSelect) {
-                console.warn('Loan type or repayment option elements not found');
+            if (!loanTypeElement) {
+                console.warn('Loan type element not found');
                 return;
             }
-            
+
             const loanType = loanTypeElement.value;
-            console.log('Updating repayment options for loan type:', loanType);
-            
-            // Store current selection to preserve it if possible
-            const currentValue = repaymentSelect.value;
-            
-            // Clear existing options
-            repaymentSelect.innerHTML = '';
-            
-            let options = [];
-            
-            if (loanType === 'bridge') {
-                options = [
-                    { value: 'none', text: 'Retained Interest (Interest Only)' },
-                    { value: 'service_only', text: 'Service Only (Interest Payments)' },
-                    { value: 'service_and_capital', text: 'Service + Capital (Principal & Interest)' },
-                    { value: 'sc_only', text: 'S+C Only (Principal & Interest)' },
-                    { value: 'capital_payment_only', text: 'Capital Payment Only (Interest Retained)' },
-                    { value: 'flexible_payment', text: 'Flexible Payment Schedule' }
-                ];
-            } else if (loanType === 'term') {
-                options = [
-                    { value: 'service_only', text: 'Serviced Interest (Interest Payments)' },
-                    { value: 'service_and_capital', text: 'Serviced + Capital Repayment (Principal & Interest)' }
-                ];
-            } else if (loanType === 'development') {
-                options = [
-                    { value: 'none', text: 'Retained Interest (Interest Only)' }
-                ];
-            } else if (loanType === 'development2') {
-                options = [
-                    { value: 'none', text: 'Retained Interest (Excel Goal Seek)' }
-                ];
-            }
-            
-            // Add options to select
-            options.forEach(option => {
-                const optionElement = document.createElement('option');
-                optionElement.value = option.value;
-                optionElement.textContent = option.text;
-                repaymentSelect.appendChild(optionElement);
+            const optionsMap = {
+                bridge: ['none', 'service_only', 'service_and_capital', 'sc_only', 'capital_payment_only', 'flexible_payment'],
+                term: ['service_only', 'service_and_capital'],
+                development: ['none'],
+                development2: ['none']
+            };
+            const allowed = optionsMap[loanType] || [];
+
+            document.querySelectorAll('input[name="repaymentOptionToggle"]').forEach(radio => {
+                const label = document.querySelector(`label[for="${radio.id}"]`);
+                const show = allowed.includes(radio.value);
+                radio.style.display = show ? '' : 'none';
+                if (label) label.style.display = show ? '' : 'none';
+                if (!show && radio.checked) {
+                    radio.checked = false;
+                }
             });
-            
-            // Try to preserve the previous selection if it exists in new options
-            const validOption = options.find(opt => opt.value === currentValue);
-            if (validOption) {
-                repaymentSelect.value = currentValue;
-            } else {
-                // For term loans, default to 'service_only', otherwise default to first option
-                if (loanType === 'term') {
-                    repaymentSelect.value = 'service_only';
-                } else {
-                    repaymentSelect.value = options[0].value;
+
+            let checked = document.querySelector('input[name="repaymentOptionToggle"]:checked');
+            if (!checked && allowed.length) {
+                const first = document.querySelector(`input[name="repaymentOptionToggle"][value="${allowed[0]}"]`);
+                if (first) {
+                    first.checked = true;
+                    checked = first;
                 }
             }
-            
+
+            const hidden = document.getElementById('repaymentOption');
+            if (hidden && checked) {
+                hidden.value = checked.value;
+            }
+
             console.log('Repayment options updated successfully');
-            
-            // Update 360-day option visibility
             this.update360DayVisibility();
         } catch (error) {
             console.error('Error in updateRepaymentOptions:', error);

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -459,34 +459,47 @@
 </div>
 <!-- Loan Type Selection -->
 <div class="">
-<label class="form-label" for="loanType">Loan Type</label>
-<select class="form-select" id="loanType" name="loan_type" required="">
-<option value="bridge">Bridge Loan</option>
-<option value="term">Term Loan</option>
-<!-- <option value="development">Development Loan</option>-->
-<option value="development2">Development Loan</option>
-</select>
+<label class="form-label">Loan Type</label>
+<div class="btn-group w-100" role="group" aria-label="Loan Type">
+    <input type="radio" class="btn-check" name="loanTypeToggle" id="loanTypeBridge" value="bridge" checked>
+    <label class="btn btn-outline-primary" for="loanTypeBridge">Bridge Loan</label>
+    <input type="radio" class="btn-check" name="loanTypeToggle" id="loanTypeTerm" value="term">
+    <label class="btn btn-outline-primary" for="loanTypeTerm">Term Loan</label>
+    <input type="radio" class="btn-check" name="loanTypeToggle" id="loanTypeDevelopment" value="development2">
+    <label class="btn btn-outline-primary" for="loanTypeDevelopment">Development Loan</label>
+</div>
+<input type="hidden" id="loanType" name="loan_type" value="bridge">
 </div>
 <!-- Repayment Option -->
 <div class="">
-<label class="form-label" for="repaymentOption">Interest Calculation Type</label>
-<select class="form-select" id="repaymentOption" name="repayment_option" required="">
-<option value="none">Retained Interest (Interest Only)</option>
-<option value="service_only">Service Only (Interest Payments)</option>
-<option value="service_and_capital">Service + Capital (Principal &amp; Interest)</option>
-<option value="sc_only">S+C Only (Principal &amp; Interest)</option>
-<option value="capital_payment_only">Capital Payment Only (Interest Retained)</option>
-<option value="flexible_payment">Flexible Payment Schedule</option>
-</select>
+<label class="form-label">Interest Calculation Type</label>
+<div class="btn-group w-100 flex-wrap" role="group" aria-label="Interest Calculation Type">
+    <input type="radio" class="btn-check" name="repaymentOptionToggle" id="repaymentNone" value="none" checked>
+    <label class="btn btn-outline-primary" for="repaymentNone">Retained Interest (Interest Only)</label>
+    <input type="radio" class="btn-check" name="repaymentOptionToggle" id="repaymentServiceOnly" value="service_only">
+    <label class="btn btn-outline-primary" for="repaymentServiceOnly">Service Only (Interest Payments)</label>
+    <input type="radio" class="btn-check" name="repaymentOptionToggle" id="repaymentServiceCapital" value="service_and_capital">
+    <label class="btn btn-outline-primary" for="repaymentServiceCapital">Service + Capital (Principal &amp; Interest)</label>
+    <input type="radio" class="btn-check" name="repaymentOptionToggle" id="repaymentSCOnly" value="sc_only">
+    <label class="btn btn-outline-primary" for="repaymentSCOnly">S+C Only (Principal &amp; Interest)</label>
+    <input type="radio" class="btn-check" name="repaymentOptionToggle" id="repaymentCapitalOnly" value="capital_payment_only">
+    <label class="btn btn-outline-primary" for="repaymentCapitalOnly">Capital Payment Only (Interest Retained)</label>
+    <input type="radio" class="btn-check" name="repaymentOptionToggle" id="repaymentFlexible" value="flexible_payment">
+    <label class="btn btn-outline-primary" for="repaymentFlexible">Flexible Payment Schedule</label>
+</div>
+<input type="hidden" id="repaymentOption" name="repayment_option" value="none">
 </div>
 
 <!-- Currency -->
 <div class="">
-<label class="form-label" for="currency">Currency</label>
-<select class="form-select" id="currency" name="currency">
-<option value="GBP">GBP (£)</option>
-<option value="EUR">EUR (€)</option>
-</select>
+<label class="form-label">Currency</label>
+<div class="btn-group w-100" role="group" aria-label="Currency">
+    <input type="radio" class="btn-check" name="currency" id="currencyGBP" value="GBP" checked>
+    <label class="btn btn-outline-primary" for="currencyGBP">GBP (£)</label>
+    <input type="radio" class="btn-check" name="currency" id="currencyEUR" value="EUR">
+    <label class="btn btn-outline-primary" for="currencyEUR">EUR (€)</label>
+</div>
+<input type="hidden" id="currency" value="GBP">
 </div>
 <!-- Property Value -->
 <div class="">
@@ -815,9 +828,6 @@
 </button>
 <button class="btn btn-outline-secondary" id="cancelEditBtn" style="display: none;" type="button">
 <i class="fas fa-times me-2"></i>Cancel Edit
-                    </button>
-<button class="btn btn-outline-primary" type="button" onclick="openScenarioComparison()">
-<i class="fas fa-chart-line me-2"></i>Scenario Comparison
                     </button>
 </div>
 </form>
@@ -1879,53 +1889,6 @@ document.addEventListener('DOMContentLoaded', async function() {
         }
     });
 });
-
-// Function to open scenario comparison with current form data
-function openScenarioComparison() {
-    try {
-        // Collect all form data using the global collectFormData function
-        const formData = window.loanCalculator ? window.loanCalculator.collectFormData() : collectFormData();
-        
-        // Build URL with parameters - using safe access to avoid undefined errors
-        const params = new URLSearchParams({
-            loan_type: formData.loan_type || 'bridge',
-            gross_amount: formData.gross_amount || formData.net_amount || 1000000,
-            net_amount: formData.net_amount || 0,
-            gross_amount_type: formData.gross_amount_type || 'fixed',
-            gross_amount_percentage: formData.gross_amount_percentage || 0,
-            annual_rate: formData.annual_rate || (formData.monthly_rate ? formData.monthly_rate * 12 : 12),
-            monthly_rate: formData.monthly_rate || 0,
-            rate_input_type: formData.rate_input_type || 'annual',
-            loan_term: formData.loan_term || 12,
-            start_date: formData.start_date || '',
-            end_date: formData.end_date || '',
-            property_value: formData.property_value || 2000000,
-            currency: formData.currency || 'GBP',
-            amount_input_type: formData.amount_input_type || 'gross',
-            arrangement_fee_rate: formData.arrangement_fee_rate || 0,
-            legal_fees: formData.legal_fees || 0,
-            site_visit_fee: formData.site_visit_fee || 0,
-            title_insurance_rate: formData.title_insurance_rate || 0,
-            repayment_option: formData.repayment_option || 'none',
-            interest_type: formData.interest_type || 'simple',
-            payment_timing: formData.payment_timing || 'arrears',
-            payment_frequency: formData.payment_frequency || 'monthly',
-            capital_repayment: formData.capital_repayment || 0,
-            flexible_payment: formData.flexible_payment || 0,
-            day1_advance: formData.day1_advance || 0,
-            use_360_days: formData.use_360_days || 'false'
-        });
-        
-        // Open scenario comparison in new tab with current parameters
-        const url = `/scenario-comparison?${params.toString()}`;
-        window.open(url, '_blank');
-        
-    } catch (error) {
-        console.error('Error opening scenario comparison:', error);
-        // Fallback: open scenario comparison with default parameters
-        window.open('/scenario-comparison', '_blank');
-    }
-}
 
 // Helper function for retrying loan save with new name
 function retryLoanSave() {


### PR DESCRIPTION
## Summary
- Replace loan type, interest calculation, and currency dropdowns with toggle button groups
- Remove scenario comparison button and supporting function
- Sync new toggles with hidden inputs and adjust repayment option logic

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68b74aa5ad6c83208fa95508576eb7b5