### PR TITLE
Split interest calculation toggle into rows of three

### DIFF
--- a/static/css/novellus-theme.css
+++ b/static/css/novellus-theme.css
@@ -980,3 +980,13 @@ h4, h5, h6 {
 .download-option-card:hover {
     animation: pulse 2s infinite;
 }
+
+/* Ensure Interest Calculation Type toggle shows three options per row */
+.btn-group.interest-toggle {
+    flex-wrap: wrap;
+}
+
+.btn-group.interest-toggle > .btn {
+    flex: 0 0 calc(100% / 3);
+    max-width: calc(100% / 3);
+}

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -473,7 +473,7 @@
 <!-- Repayment Option -->
 <div class="">
 <label class="form-label">Interest Calculation Type</label>
-<div class="btn-group w-100 flex-wrap" role="group" aria-label="Interest Calculation Type">
+<div class="btn-group w-100 flex-wrap interest-toggle" role="group" aria-label="Interest Calculation Type">
     <input type="radio" class="btn-check" name="repaymentOptionToggle" id="repaymentNone" value="none" checked>
     <label class="btn btn-outline-primary" for="repaymentNone">Retained Interest</label>
     <input type="radio" class="btn-check" name="repaymentOptionToggle" id="repaymentServiceOnly" value="service_only">


### PR DESCRIPTION
## Summary
- ensure Interest Calculation Type toggle shows three options per row

## Testing
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68b7521298088320beb8f69e89787dc7