### PR TITLE
Refine interest calculation toggles for clarity

### DIFF
--- a/static/css/novellus-theme.css
+++ b/static/css/novellus-theme.css
@@ -990,5 +990,16 @@ h4, h5, h6 {
 .btn-group.interest-toggle > .btn {
     flex: 0 0 calc(100% / 3);
     max-width: calc(100% / 3);
+    white-space: normal;
+}
 
+/* Interest calculation options (simple/compound) shown as toggles */
+.btn-group.interest-type-toggle {
+    flex-wrap: wrap;
+}
+
+.btn-group.interest-type-toggle > .btn {
+    flex: 0 0 calc(100% / 2);
+    max-width: calc(100% / 2);
+    white-space: normal;
 }

--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -320,10 +320,15 @@ class LoanCalculator {
             });
         }
 
-        // Interest calculation type changes
-        const interestTypeSelect = document.getElementById('interestType');
-        if (interestTypeSelect) {
-            interestTypeSelect.addEventListener('change', () => {
+        // Interest calculation type changes (toggle buttons)
+        const interestTypeRadios = document.querySelectorAll('input[name="interestTypeToggle"]');
+        interestTypeRadios.forEach(radio => {
+            radio.addEventListener('change', () => {
+                const hidden = document.getElementById('interestType');
+                if (hidden) {
+                    hidden.value = radio.value;
+                    hidden.dispatchEvent(new Event('change'));
+                }
                 try {
                     console.log('Interest calculation type changed');
                     // Recalculate automatically if we already have results
@@ -334,7 +339,7 @@ class LoanCalculator {
                     console.error('Error handling interest type change:', error);
                 }
             });
-        }
+        });
 
         // Input formatting disabled to prevent field clearing issues
 
@@ -1539,31 +1544,34 @@ class LoanCalculator {
             const netAmountSection = document.getElementById('netAmountSection');
             const grossAmountSection = document.getElementById('grossAmountSection');
             
+            const interestTypeRadios = document.querySelectorAll('input[name="interestTypeToggle"]');
             if (loanType === 'development' || loanType === 'development2') {
                 // Development loans default to net amount input
                 document.getElementById('netAmount').checked = true;
                 document.getElementById('grossAmount').checked = false;
                 if (netAmountSection) netAmountSection.style.display = 'block';
                 if (grossAmountSection) grossAmountSection.style.display = 'none';
-                
+
                 // Set interest calculation type to compound daily for development loans
-                const interestTypeSelect = document.getElementById('interestType');
-                if (interestTypeSelect) {
-                    interestTypeSelect.value = 'compound_daily';
-                    interestTypeSelect.disabled = true;
+                const compoundDaily = document.getElementById('interestCompoundDaily');
+                if (compoundDaily) {
+                    compoundDaily.checked = true;
                 }
+                const interestTypeHidden = document.getElementById('interestType');
+                if (interestTypeHidden) {
+                    interestTypeHidden.value = 'compound_daily';
+                    interestTypeHidden.dispatchEvent(new Event('change'));
+                }
+                interestTypeRadios.forEach(r => r.disabled = true);
             } else {
                 // Bridge and term loans default to gross amount input
                 document.getElementById('grossAmount').checked = true;
                 document.getElementById('netAmount').checked = false;
                 if (grossAmountSection) grossAmountSection.style.display = 'block';
                 if (netAmountSection) netAmountSection.style.display = 'none';
-                
+
                 // Enable interest calculation type selection for non-development loans
-                const interestTypeSelect = document.getElementById('interestType');
-                if (interestTypeSelect) {
-                    interestTypeSelect.disabled = false;
-                }
+                interestTypeRadios.forEach(r => r.disabled = false);
             }
             
             // Show/hide additional params container

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -583,13 +583,18 @@
 </div>
 <!-- Interest Type -->
 <div class="">
-<label class="form-label">Interest Calculation</label>
-<select class="form-select" id="interestType" name="interest_type" required="">
-<option selected="" value="simple">Simple Interest</option>
-<option value="compound_daily">Compound Daily</option>
-<option value="compound_monthly">Compound Monthly</option>
-<option value="compound_quarterly">Compound Quarterly</option>
-</select>
+    <label class="form-label">Interest Calculation</label>
+    <div class="btn-group w-100 flex-wrap interest-type-toggle" role="group" aria-label="Interest Calculation">
+        <input type="radio" class="btn-check" name="interestTypeToggle" id="interestSimple" value="simple" checked>
+        <label class="btn btn-outline-primary" for="interestSimple">Simple Interest</label>
+        <input type="radio" class="btn-check" name="interestTypeToggle" id="interestCompoundDaily" value="compound_daily">
+        <label class="btn btn-outline-primary" for="interestCompoundDaily">Compound Daily</label>
+        <input type="radio" class="btn-check" name="interestTypeToggle" id="interestCompoundMonthly" value="compound_monthly">
+        <label class="btn btn-outline-primary" for="interestCompoundMonthly">Compound Monthly</label>
+        <input type="radio" class="btn-check" name="interestTypeToggle" id="interestCompoundQuarterly" value="compound_quarterly">
+        <label class="btn btn-outline-primary" for="interestCompoundQuarterly">Compound Quarterly</label>
+    </div>
+    <input type="hidden" id="interestType" name="interest_type" value="simple">
 </div>
 <!-- Start Date -->
 <div class="">


### PR DESCRIPTION
## Summary
- Let interest calculation type buttons wrap text and span three per row
- Convert interest calculation selector to toggle buttons with full text
- Update JS logic to handle new interest-type toggles and development-loan defaults

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68b7576aa2588320ac636c413cfae287