### PR TITLE
Remove default focus outlines from buttons and form fields

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -484,8 +484,8 @@ footer {
 .btn:focus,
 .form-control:focus,
 .form-select:focus {
-    outline: 2px solid var(--primary-color);
-    outline-offset: 2px;
+    outline: none;
+    box-shadow: none;
 }
 
 /* High Contrast Mode */


### PR DESCRIPTION
## Summary
- Remove browser focus outline and box-shadow from `.btn`, `.form-control`, and `.form-select` elements.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68b75d0159a88320960d7918dfdae57b