### PR TITLE
Improve toggle usability and spacing

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -384,6 +384,12 @@ Novellus.components = {
  * Event Handlers
  */
 document.addEventListener('DOMContentLoaded', function() {
+    // Add tooltips to toggle buttons
+    document.querySelectorAll('.btn-group label.btn').forEach(btn => {
+        btn.setAttribute('title', btn.textContent.trim());
+        btn.setAttribute('data-bs-toggle', 'tooltip');
+    });
+
     // Initialize Bootstrap components
     Novellus.components.initTooltips();
     Novellus.components.initPopovers();

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -182,7 +182,7 @@
         color: var(--novellus-gold) !important;
         background-color: transparent !important;
         margin: 0 !important;
-        padding: 0.25rem 0.5rem !important;
+        padding: 0.25rem 0.25rem !important;
         font-size: 0.75rem !important;
         line-height: 1.2 !important;
         border-radius: 0 !important;
@@ -276,7 +276,7 @@
         color: var(--novellus-gold) !important;
         background-color: transparent !important;
         margin: 0 !important;
-        padding: 0.25rem 0.5rem !important;
+        padding: 0.25rem 0.25rem !important;
         font-size: 0.75rem !important;
         line-height: 1.2 !important;
         border-radius: 0 !important;


### PR DESCRIPTION
## Summary
- Reduce horizontal padding on toggle buttons to maximize visible text
- Show button label text as a tooltip on all toggle buttons

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68b75ebf42b08320a3d45b50785f03fc