### PR TITLE
Add primary-colored navigation buttons to header

### DIFF
--- a/static/css/novellus-theme.css
+++ b/static/css/novellus-theme.css
@@ -566,6 +566,19 @@ h4, h5, h6 {
     color: var(--novellus-gold) !important;
 }
 
+/* Primary-colored buttons in the navbar */
+.navbar .btn-nav {
+    background: linear-gradient(135deg, var(--novellus-gold) 0%, var(--novellus-gold-dark) 100%);
+    border: none;
+    color: white;
+    font-weight: 600;
+}
+
+.navbar .btn-nav:hover {
+    background: linear-gradient(135deg, var(--novellus-gold) 0%, var(--novellus-gold-dark) 100%);
+    color: white;
+}
+
 /* Remove any blue backgrounds */
 .bg-primary {
     background: linear-gradient(135deg, var(--novellus-navy) 0%, var(--novellus-navy-dark) 100%) !important;

--- a/templates/base.html
+++ b/templates/base.html
@@ -57,16 +57,6 @@
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('calculator_page') }}">
-                                <i class="fas fa-calculator me-1"></i>Calculator
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="/scenario-comparison">
-                                <i class="fas fa-chart-line me-1"></i>Scenario Comparison
-                            </a>
-                        </li>
-                        <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('applications') }}">
                                 <i class="fas fa-file-alt me-1"></i>Applications
                             </a>
@@ -76,23 +66,31 @@
                                 <i class="fas fa-quote-left me-1"></i>Quotes
                             </a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('user_manual') }}">
-                                <i class="fas fa-book me-1"></i>User Manual
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('powerbi_config') }}">
-                                <i class="fas fa-cog me-1"></i>Power BI Config
-                            </a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="{{ url_for('snowflake_config') }}">
-                                <i class="fas fa-database me-1"></i>Snowflake Config
-                            </a>
-                        </li>
                     {% endif %}
                 </ul>
+
+                {% if current_user.is_authenticated %}
+                <div class="d-flex ms-auto gap-2">
+                    <a class="btn btn-nav" href="{{ url_for('powerbi_config') }}">
+                        <i class="fas fa-cog me-1"></i>Power BI Config
+                    </a>
+                    <a class="btn btn-nav" href="{{ url_for('snowflake_config') }}">
+                        <i class="fas fa-database me-1"></i>Snowflake Config
+                    </a>
+                    <a class="btn btn-nav" href="{{ url_for('user_manual') }}">
+                        <i class="fas fa-book me-1"></i>User Manual
+                    </a>
+                    <a class="btn btn-nav" href="{{ url_for('scenario_comparison_page') }}">
+                        <i class="fas fa-chart-line me-1"></i>Scenario Comparison
+                    </a>
+                    <a class="btn btn-nav" href="{{ url_for('loan_history') }}">
+                        <i class="fas fa-history me-1"></i>Loan History
+                    </a>
+                    <a class="btn btn-nav" href="{{ url_for('calculator_page') }}">
+                        <i class="fas fa-calculator me-1"></i>Calculator
+                    </a>
+                </div>
+                {% endif %}
                 
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Add right-aligned header buttons linking to Power BI config, Snowflake config, User Manual, Scenario Comparison, Loan History, and Calculator
- Style header buttons with new `.btn-nav` class using Novellus primary colours

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68b75fcdbd548320ab4c8faff75e5b10