### PR TITLE
Add primary-colored home button to header

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -89,6 +89,11 @@
                     <a class="btn btn-nav" href="{{ url_for('calculator_page') }}">
                         <i class="fas fa-calculator me-1"></i>Calculator
                     </a>
+                    {% if request.endpoint in ['powerbi_config', 'snowflake_config', 'user_manual', 'scenario_comparison_page', 'loan_history', 'calculator_page'] %}
+                    <a class="btn btn-nav" href="{{ url_for('landing_page') }}">
+                        <i class="fas fa-home me-1"></i>Home
+                    </a>
+                    {% endif %}
                 </div>
                 {% endif %}
                 

--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -26,9 +26,6 @@
                     <a href="{{ url_for('calculator_page') }}" class="btn btn-novellus-gold">
                         <i class="fas fa-calculator me-2"></i>New Calculation
                     </a>
-                    <a href="{{ url_for('landing_page') }}" class="btn btn-outline-primary">
-                        <i class="fas fa-home me-2"></i>Home
-                    </a>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Add a Home button to the navigation bar when viewing configuration, comparison, history, or calculator pages
- Style Home button with existing primary colors and remove redundant content-level Home link on loan history page

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68b762c9be6083209a82047732ca8241