### PR TITLE
style: make home icon visible in navbar

### DIFF
--- a/static/css/novellus-theme.css
+++ b/static/css/novellus-theme.css
@@ -579,6 +579,15 @@ h4, h5, h6 {
     color: white;
 }
 
+/* Ensure the home icon is visible against the gold background */
+.navbar .btn-nav .fa-home {
+    color: black;
+}
+
+.navbar .btn-nav:hover .fa-home {
+    color: black;
+}
+
 /* Remove any blue backgrounds */
 .bg-primary {
     background: linear-gradient(135deg, var(--novellus-navy) 0%, var(--novellus-navy-dark) 100%) !important;


### PR DESCRIPTION
## Summary
- keep home button icon visible in navbar by coloring it black and preserving hover state

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68b765acacb08320b348a338bcec893f