### PR TITLE
Remove refresh buttons from calculator and loan history pages

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -456,9 +456,6 @@
     <div>
         <h2><i class="fas fa-calculator me-2"></i>Loan Calculator</h2>
     </div>
-    <button type="button" class="btn btn-outline-secondary" id="refreshButton" onclick="window.location.reload();">
-        <i class="fas fa-sync-alt"></i> Refresh
-    </button>
 </div>
 <div class="row calculator-layout">
 <!-- Calculator Form -->

--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -20,9 +20,6 @@
                     <h2><i class="fas fa-history me-2"></i>Saved Loan Calculations</h2>
                 </div>
                 <div class="d-flex gap-2">
-                    <button class="btn btn-outline-primary" onclick="loanHistory.loadLoans(true)" title="Refresh loan list">
-                        <i class="fas fa-sync-alt me-2"></i>Refresh
-                    </button>
                     <a href="{{ url_for('calculator_page') }}" class="btn btn-novellus-gold">
                         <i class="fas fa-calculator me-2"></i>New Calculation
                     </a>
@@ -177,9 +174,8 @@ class LoanHistoryManager {
         document.getElementById('editLoanButton').addEventListener('click', () => this.editLoan());
     }
 
-    async loadLoans(isManualRefresh = false) {
+    async loadLoans() {
         try {
-            this.isManualRefresh = isManualRefresh;
             console.log('Starting to load loans...');
             this.showState('loading');
             
@@ -212,12 +208,6 @@ class LoanHistoryManager {
                 this.showState('table');
                 this.renderLoansTable();
                 this.updateTimestamp();
-                
-                // Show success notification for manual refresh
-                if (window.notifications && this.isManualRefresh) {
-                    window.notifications.success(`Refreshed: ${this.loans.length} loans loaded`);
-                    this.isManualRefresh = false;
-                }
             }
             
         } catch (error) {


### PR DESCRIPTION
## Summary
- Remove page-level refresh button from calculator view
- Drop refresh button and manual refresh logic from loan history page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68b76dc109d4832095c0774ca5badbaa