### PR TITLE
Center-align loan page headings

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -452,10 +452,8 @@
 {% endblock %}
 
 {% block content %}
-<div class="d-flex justify-content-between align-items-start">
-    <div>
-        <h2><i class="fas fa-calculator me-2"></i>Loan Calculator</h2>
-    </div>
+<div class="text-center mb-3">
+    <h2><i class="fas fa-calculator me-2"></i>Loan Calculator</h2>
 </div>
 <div class="row calculator-layout">
 <!-- Calculator Form -->

--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -15,11 +15,9 @@
 <div class="container-fluid mt-4">
     <div class="row">
         <div class="col-12">
-            <div class="d-flex justify-content-between align-items-start mb-3">
-                <div>
-                    <h2><i class="fas fa-history me-2"></i>Saved Loan Calculations</h2>
-                </div>
-                <div class="d-flex gap-2">
+            <div class="mb-3 position-relative text-center">
+                <h2 class="mb-0"><i class="fas fa-history me-2"></i>Saved Loan Calculations</h2>
+                <div class="position-absolute top-0 end-0">
                     <a href="{{ url_for('calculator_page') }}" class="btn btn-novellus-gold">
                         <i class="fas fa-calculator me-2"></i>New Calculation
                     </a>


### PR DESCRIPTION
## Summary
- Center Loan History heading and keep New Calculation button positioned on the right
- Center Loan Calculator heading

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68b7705b2d2083209da3e8df4847d5dc