### PR TITLE
Move loan history new calculation button to navbar

### DIFF
--- a/static/css/novellus-theme.css
+++ b/static/css/novellus-theme.css
@@ -581,12 +581,14 @@ h4, h5, h6 {
 
 /* Ensure the icons are visible against the gold background */
 .navbar .btn-nav .fa-home,
-.navbar .btn-nav .fa-sync-alt {
+.navbar .btn-nav .fa-sync-alt,
+.navbar .btn-nav .fa-calculator {
     color: black;
 }
 
 .navbar .btn-nav:hover .fa-home,
-.navbar .btn-nav:hover .fa-sync-alt {
+.navbar .btn-nav:hover .fa-sync-alt,
+.navbar .btn-nav:hover .fa-calculator {
     color: black;
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -91,9 +91,11 @@
                     <a class="btn btn-nav" href="{{ url_for('loan_history') }}">
                         <i class="fas fa-history me-1"></i>Loan History
                     </a>
+                    {% block nav_calculator %}
                     <a class="btn btn-nav" href="{{ url_for('calculator_page') }}">
                         <i class="fas fa-calculator me-1"></i>Calculator
                     </a>
+                    {% endblock %}
                     {% endif %}
                     <a class="btn btn-nav" href="#" onclick="window.location.reload(); return false;">
                         <i class="fas fa-sync-alt"></i>

--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -11,18 +11,18 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/currency-themes.css') }}">
 {% endblock %}
 
+{% block nav_calculator %}
+<a class="btn btn-nav" href="{{ url_for('calculator_page') }}">
+    <i class="fas fa-calculator"></i>
+</a>
+{% endblock %}
+
 {% block content %}
 <!-- Notification container for consistent notifications -->
 <div id="notification-container" style="position: fixed; top: 80px; right: 20px; z-index: 9999;"></div>
 <div class="container-fluid mt-4">
     <div class="row">
         <div class="col-12">
-            <div class="text-end mb-3">
-                <a href="{{ url_for('calculator_page') }}" class="btn btn-novellus-gold">
-                    <i class="fas fa-calculator me-2"></i>New Calculation
-                </a>
-            </div>
-
             <!-- Search and Filter Controls -->
             <div class="card mb-4">
                 <div class="card-body">


### PR DESCRIPTION
## Summary
- Show a calculator icon in the loan history navbar to start a new calculation.
- Remove the page-level New Calculation button.
- Ensure navbar calculator icon uses black color styling.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68b774d14a808320ad5852616ed5ee59