### PR TITLE
Add loan history icon to calculator navbar

### DIFF
--- a/static/css/novellus-theme.css
+++ b/static/css/novellus-theme.css
@@ -572,6 +572,7 @@ h4, h5, h6 {
     border: none;
     color: white;
     font-weight: 600;
+    padding: 5px 5px;
 }
 
 .navbar .btn-nav:hover {

--- a/templates/base.html
+++ b/templates/base.html
@@ -98,6 +98,11 @@
                     <a class="btn btn-nav" href="#" onclick="window.location.reload(); return false;">
                         <i class="fas fa-sync-alt"></i>
                     </a>
+                    {% if request.endpoint == 'calculator_page' %}
+                    <a class="btn btn-nav" href="{{ url_for('loan_history') }}">
+                        <i class="fas fa-history"></i>
+                    </a>
+                    {% endif %}
                     <a class="btn btn-nav" href="{{ url_for('landing_page') }}">
                         <i class="fas fa-home"></i>
                     </a>


### PR DESCRIPTION
## Summary
- Add loan history shortcut icon to calculator navbar next to refresh button
- Reduce navbar button padding to 5px

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68b7757ec7d4832096e6c3c4448e1ed8