### PR TITLE
Improve calculator layout spacing

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -61,8 +61,7 @@
     /* Full width utilization */
     .container-fluid {
         max-width: 98% !important;
-        padding-left: 15px !important;
-        padding-right: 15px !important;
+        padding: 5px !important;
     }
     
     /* Ensure proper form field sizing */
@@ -442,11 +441,11 @@
 
     @media (min-width: 992px) {
         .calculator-layout .user-input-col {
-            width: calc(33.333333% + 10px);
+            width: calc(33.333333% + 25px);
         }
 
         .calculator-layout .results-col {
-            width: calc(66.666667% - 10px);
+            width: calc(66.666667% - 25px);
         }
     }
 


### PR DESCRIPTION
## Summary
- Reduce page container padding to 5px
- Expand calculator user-input column by 15px for more entry space

## Testing
- `pytest -q test_calculator_page.py` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*
- `pytest -q test_database_url.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7799e60608320b59dee1b12e69d48