### PR TITLE
Reduce horizontal padding in calculator section

### DIFF
--- a/static/css/novellus-theme.css
+++ b/static/css/novellus-theme.css
@@ -671,7 +671,8 @@ h4, h5, h6 {
     background: linear-gradient(135deg, var(--novellus-background) 0%, var(--novellus-card-bg) 100%);
     border: 1px solid var(--novellus-border);
     border-radius: 12px;
-    padding: 2rem;
+    /* Reduce horizontal padding for tighter layout */
+    padding: 2rem 5px;
     box-shadow: 0 4px 12px rgba(30, 43, 58, 0.06);
 }
 


### PR DESCRIPTION
## Summary
- tighten horizontal spacing in `.calculator-section` by reducing left and right padding to 5px for a more compact layout

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68b77ce1b15083208c0662e179f292b4