### PR TITLE
style: use bold black nav headings

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -2,7 +2,7 @@
 
 {% block title %}Loan Calculator - Novellus{% endblock %}
 
-{% block nav_heading %}<span class="navbar-text"><i class="fas fa-calculator me-2"></i>Loan Calculator</span>{% endblock %}
+{% block nav_heading %}<span class="navbar-text text-black fw-bold"><i class="fas fa-calculator me-2"></i>Loan Calculator</span>{% endblock %}
 
 {% block head %}
 <link href="{{ url_for('static', filename='css/novellus-theme.css') }}" rel="stylesheet"/>

--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -2,7 +2,7 @@
 
 {% block title %}Loan History - Novellus Financial{% endblock %}
 
-{% block nav_heading %}<span class="navbar-text"><i class="fas fa-history me-2"></i>Saved Loan Calculations</span>{% endblock %}
+{% block nav_heading %}<span class="navbar-text text-black fw-bold"><i class="fas fa-history me-2"></i>Saved Loan Calculations</span>{% endblock %}
 
 {% block body_attr %}class="gold-nav" data-theme="document"{% endblock %}
 


### PR DESCRIPTION
## Summary
- ensure calculator page nav heading is black and bold
- style loan history nav heading with black bold text

## Testing
- ⚠️ `pytest test_calculator_page.py` *(missing selenium dependency)*
- ⚠️ `pytest test_database_url.py` *(sqlalchemy missing; test skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b7e9c70cb88320a00cedd736f469df