### PR TITLE
fix: hide horizontal scroll bars on calculator and loan history pages

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -30,6 +30,10 @@
     --font-family: 'Brother 1816', Arial, sans-serif;
 }
 
+html, body {
+    overflow-x: hidden; /* Prevent horizontal scrollbars on all pages */
+}
+
 body {
     font-family: var(--font-family);
     line-height: 1.6;


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling across the app to remove stray horizontal scrollbars on calculator and loan history pages

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68b7eaa6aec4832090a96a23e847b5c7