### PR TITLE
Add labels to calculator and loan history navbar icons

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -102,11 +102,11 @@
                     </a>
                     {% if request.endpoint == 'calculator_page' %}
                     <a class="btn btn-nav" href="{{ url_for('loan_history') }}">
-                        <i class="fas fa-history"></i>
+                        <i class="fas fa-history me-1"></i>Loan History
                     </a>
                     {% else %}
                     <a class="btn btn-nav" href="{{ url_for('calculator_page') }}">
-                        <i class="fas fa-calculator"></i>
+                        <i class="fas fa-calculator me-1"></i>Calculator
                     </a>
                     {% endif %}
                     <a class="btn btn-nav" href="{{ url_for('landing_page') }}">


### PR DESCRIPTION
## Summary
- Show descriptive text next to the conditional calculator/loan history icons in the navbar for better clarity.

## Testing
- ⚠️ `pytest -q` *(missing selenium dependency)*
- ⚠️ `pip install selenium -q` *(403 Client Error: Forbidden)*
- ✅ `pytest --ignore test_calculator_page.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7ef0b8d948320a6da355cc150e8d3