### PR TITLE
Add border around navbar icons

### DIFF
--- a/static/css/novellus-theme.css
+++ b/static/css/novellus-theme.css
@@ -595,6 +595,14 @@ h4, h5, h6 {
     color: black;
 }
 
+/* Add thin black border around navbar icons */
+.navbar .btn-nav i,
+.navbar-nav .nav-link i {
+    border: 1px solid #000;
+    border-radius: 2px;
+    padding: 2px;
+}
+
 /* Remove any blue backgrounds */
 .bg-primary {
     background: linear-gradient(135deg, var(--novellus-navy) 0%, var(--novellus-navy-dark) 100%) !important;


### PR DESCRIPTION
## Summary
- add thin black border styling for all navigation icons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f3f578a483209d5f63ae82852f81