### PR TITLE
Align Loan History navbar with default theme

### DIFF
--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -4,8 +4,6 @@
 
 {% block nav_heading %}<span class="navbar-text text-black fw-bold"><i class="fas fa-history me-2"></i>Saved Loan Calculations</span>{% endblock %}
 
-{% block body_attr %}class="gold-nav" data-theme="document"{% endblock %}
-
 {% block extra_head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/notifications.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/currency-themes.css') }}">


### PR DESCRIPTION
## Summary
- Remove custom `body` attributes from Loan History page to use standard navbar styling
- Clean up extra whitespace in the template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68b7f62d0a708320a3f57a976a1194b5