### PR TITLE
Install Snowflake connector with pandas extras

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -240,8 +240,8 @@ print_status "Installing OpenTelemetry dependencies..."
 pip install "opentelemetry-api>=1.25.0" "opentelemetry-sdk>=1.25.0"
 
 # Install Snowflake connector for Snowflake testing feature
-print_status "Installing Snowflake connector..."
-pip install snowflake-connector-python
+print_status "Installing Snowflake connector with pandas support..."
+pip install "snowflake-connector-python[pandas]"
 
 # Create .env file
 print_status "Creating environment configuration..."


### PR DESCRIPTION
## Summary
- install snowflake-connector-python with pandas extras to ensure pandas/pyarrow support

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68b7f95562f48320a2484c2ad01cd855