### PR TITLE
Add header to landing page

### DIFF
--- a/templates/landing.html
+++ b/templates/landing.html
@@ -243,6 +243,13 @@
     </style>
 </head>
 <body>
+    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+        <div class="container">
+            <a class="navbar-brand" href="{{ url_for('landing_page') }}">
+                <img src="{{ url_for('static', filename='novellus_logo.png') }}" alt="Novellus" height="32">
+            </a>
+        </div>
+    </nav>
     <div class="landing-hero">
         <div class="container">
             <div class="hero-content">


### PR DESCRIPTION
## Summary
- Add a Bootstrap navbar header with Novellus logo to the landing page for consistent branding

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68b803efc8908320b88cd8af390a568e