### PR TITLE
Use toast notifications on calculator page

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -1304,7 +1304,11 @@ class LoanCalculator {
     }
 
     showError(message) {
-        alert('Error: ' + message);
+        if (window.notifications) {
+            window.notifications.error('Error: ' + message);
+        } else {
+            alert('Error: ' + message);
+        }
     }
 
     // All other UI helper methods remain the same...
@@ -1754,12 +1758,20 @@ class LoanCalculator {
             });
 
             if (totalAmount <= 0) {
-                alert('Please enter a valid total loan amount');
+                if (window.notifications) {
+                    window.notifications.warning('Please enter a valid total loan amount');
+                } else {
+                    alert('Please enter a valid total loan amount');
+                }
                 return;
             }
 
             if (!startDate) {
-                alert('Please select a start date');
+                if (window.notifications) {
+                    window.notifications.warning('Please select a start date');
+                } else {
+                    alert('Please select a start date');
+                }
                 return;
             }
 
@@ -1811,7 +1823,11 @@ class LoanCalculator {
             
         } catch (error) {
             console.error('Error in generateTranches:', error);
-            alert('Error generating tranches: ' + error.message);
+            if (window.notifications) {
+                window.notifications.error('Error generating tranches: ' + error.message);
+            } else {
+                alert('Error generating tranches: ' + error.message);
+            }
         }
     }
 

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -136,6 +136,8 @@ class NotificationSystem {
 
 // Global notification instance
 const notifications = new NotificationSystem();
+// Expose notification system globally for pages checking window.notifications
+window.notifications = notifications;
 
 // Global functions for easy access
 function showNotification(message, type = 'info', duration = 8000) {

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -7,6 +7,7 @@
 {% block head %}
 <link href="{{ url_for('static', filename='css/novellus-theme.css') }}" rel="stylesheet"/>
 <link href="{{ url_for('static', filename='css/currency-themes.css') }}" rel="stylesheet"/>
+<link rel="stylesheet" href="{{ url_for('static', filename='css/notifications.css') }}"/>
 <style>
     /* Calculator and results section styling moved to novellus-theme.css */
     
@@ -1773,15 +1774,23 @@ document.addEventListener('DOMContentLoaded', async function() {
             // Check if loan name is provided
             const loanName = document.getElementById('loanName').value.trim();
             if (!loanName) {
-                alert('Please enter a loan name before saving.');
+                if (window.notifications) {
+                    window.notifications.show('Please enter a loan name before saving.', 'warning');
+                } else {
+                    alert('Please enter a loan name before saving.');
+                }
                 document.getElementById('loanName').focus();
                 return;
             }
-            
+
             // Check if results section is visible (calculation completed)
             const resultsSection = document.getElementById('resultsSection');
             if (!resultsSection || resultsSection.style.display === 'none') {
-                alert('Please calculate the loan first before saving.');
+                if (window.notifications) {
+                    window.notifications.show('Please calculate the loan first before saving.', 'warning');
+                } else {
+                    alert('Please calculate the loan first before saving.');
+                }
                 return;
             }
             


### PR DESCRIPTION
## Summary
- expose NotificationSystem globally so pages can use window.notifications
- switch calculator save flow and tranche generation to use toast notifications
- load notification styles and replace alerts on calculator page

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68b80fbc9ffc83208a71d8283a72579f