### PR TITLE
Align landing page header color with calculator

### DIFF
--- a/templates/landing.html
+++ b/templates/landing.html
@@ -7,11 +7,12 @@
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
     
     <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+
     <!-- Custom CSS -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/novellus-theme.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/notifications.css') }}">
     
@@ -244,8 +245,8 @@
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-        <div class="container">
-            <a class="navbar-brand" href="{{ url_for('landing_page') }}">
+        <div class="container-fluid px-4 d-flex justify-content-between align-items-center">
+            <a class="navbar-brand d-flex align-items-center" href="{{ url_for('landing_page') }}">
                 <img src="{{ url_for('static', filename='novellus_logo.png') }}" alt="Novellus" height="32">
             </a>
         </div>


### PR DESCRIPTION
## Summary
- Load Bootstrap 5.1.3, Font Awesome 6.0.0, and shared styles on the landing page
- Match navigation bar layout and classes to ensure header color aligns with calculator page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(failed: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68b816324a348320ac12a0c4739553eb