### PR TITLE
feat: update bridge serviced summary

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -746,7 +746,9 @@ class LoanCalculator {
         const loanType = document.getElementById('loanType').value;
         const repaymentOption = document.getElementById('repaymentOption').value;
         const isBridgeRetainedOnly = loanType === 'bridge' && repaymentOption === 'retained';
+        const isBridgeServicedOnly = loanType === 'bridge' && repaymentOption === 'service_only';
         const paymentFrequency = document.querySelector('input[name="payment_frequency"]:checked')?.value || 'monthly';
+        const paymentTiming = document.querySelector('input[name="payment_timing"]:checked')?.value || 'advance';
 
         // Update the display elements
         const moneyFormat = {minimumFractionDigits: 2, maximumFractionDigits: 2};
@@ -786,7 +788,7 @@ class LoanCalculator {
         
         // Display End LTV based on closing balance of last month from payment schedule
         const endLTVRow = endLTVEl ? endLTVEl.closest('tr') : null;
-        if (isBridgeRetainedOnly) {
+        if (isBridgeRetainedOnly || isBridgeServicedOnly) {
             if (endLTVRow) endLTVRow.style.display = 'none';
         } else if (endLTVEl && propertyValue > 0) {
             let endLTV = 0;
@@ -905,7 +907,7 @@ class LoanCalculator {
             (repaymentOption === 'service_and_capital' || repaymentOption === 'capital_payment_only' || repaymentOption === 'flexible_payment')
         );
 
-        if (isBridgeRetainedOnly) {
+        if (isBridgeRetainedOnly || isBridgeServicedOnly) {
             if (interestOnlyTotalRow) interestOnlyTotalRow.style.display = 'none';
             if (interestSavingsRow) interestSavingsRow.style.display = 'none';
         } else if (shouldShowInterestComparison) {
@@ -969,7 +971,20 @@ class LoanCalculator {
         } else {
             if (periodicInterestRow) periodicInterestRow.style.display = 'none';
         }
-        
+
+        const interestPaymentRow = document.getElementById('interestPaymentTimingRow');
+        const interestPaymentEl = document.getElementById('interestPaymentTimingResult');
+        if (isBridgeServicedOnly) {
+            if (interestPaymentRow && interestPaymentEl) {
+                const freqLabel = paymentFrequency === 'quarterly' ? 'Quarterly' : 'Monthly';
+                const timingLabel = paymentTiming === 'advance' ? 'in Advance' : 'in Arrears';
+                interestPaymentRow.style.display = 'table-row';
+                interestPaymentEl.textContent = `${freqLabel} ${timingLabel}`;
+            }
+        } else if (interestPaymentRow) {
+            interestPaymentRow.style.display = 'none';
+        }
+
         // Display detailed payment schedule if available (for all loan types)
         this.displayDetailedPaymentSchedule(results);
 

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -959,6 +959,11 @@
 <td class="text-end px-3 currency-symbol" style="color: #000 !important; border-right: 1px solid #000; background: white;">£</td>
 <td class="fw-bold px-3 text-end" id="periodicInterestResult" style="color: #000 !important; background: white;">-</td>
 </tr>
+<tr id="interestPaymentTimingRow" style="border: 1px solid #000; display: none;">
+<td class="px-3" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;">Interest Payment</td>
+<td class="text-end px-3" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;"></td>
+<td class="fw-bold px-3 text-end" id="interestPaymentTimingResult" style="color: #000 !important; background: #f8f9fa;">-</td>
+</tr>
 <tr style="border: 1px solid #000;">
 <td class="px-3" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;">Net Day 1 Advance</td>
 <td class="text-end px-3 currency-symbol" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;">£</td>

--- a/templates/calculator_w.html
+++ b/templates/calculator_w.html
@@ -866,6 +866,11 @@
 <td class="text-end px-3 currency-symbol" style="color: #000 !important; border-right: 1px solid #000; background: white;">£</td>
 <td class="fw-bold px-3 text-end" id="periodicInterestResult" style="color: #000 !important; background: white;">-</td>
 </tr>
+<tr id="interestPaymentTimingRow" style="border: 1px solid #000; display: none;">
+<td class="px-3" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;">Interest Payment</td>
+<td class="text-end px-3" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;"></td>
+<td class="fw-bold px-3 text-end" id="interestPaymentTimingResult" style="color: #000 !important; background: #f8f9fa;">-</td>
+</tr>
 <tr style="border: 1px solid #000;">
 <td class="px-3" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;">Net Day 1 Advance</td>
 <td class="text-end px-3 currency-symbol" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;">£</td>


### PR DESCRIPTION
## Summary
- hide interest-only total and end LTV for bridge loans with serviced interest
- show interest payment frequency and timing in loan summary

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68b8436e5ffc83209ff359cb99e5687a