### PR TITLE
Fix bridge retained interest summary fields

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -746,7 +746,11 @@ class LoanCalculator {
         const loanType = document.getElementById('loanType').value;
         const repaymentOption = document.getElementById('repaymentOption').value;
 
-        const isBridgeRetainedOnly = loanType === 'bridge' && repaymentOption === 'retained';
+        // Treat both legacy and current values as retained interest for bridge loans
+        const isBridgeRetainedOnly = loanType === 'bridge' &&
+            (repaymentOption === 'none' ||
+             repaymentOption === 'retained' ||
+             repaymentOption === 'retained_interest');
         const isBridgeServicedOnly = loanType === 'bridge' && repaymentOption === 'service_only';
 
         const paymentFrequency = document.querySelector('input[name="payment_frequency"]:checked')?.value || 'monthly';


### PR DESCRIPTION
## Summary
- Hide End LTV and Interest Only Total rows for bridge loans with retained interest by recognizing all retained option values in calculator JS

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium; proxy connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b84617805c8320a9e46180b20b1ede