### PR TITLE
Include interest payment timing in bridge loan summaries

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -716,6 +716,10 @@ class LoanCalculator:
         )
         calculation['periodicInterest'] = float(periodic_interest)
 
+        freq_label = 'Monthly' if payment_frequency == 'monthly' else 'Quarterly'
+        timing_label = 'in Advance' if payment_timing == 'advance' else 'in Arrears'
+        calculation['interestPaymentTiming'] = f"{freq_label} {timing_label}"
+
         # Service-only loans pay interest only each period. Service + capital
         # loans pay the interest plus the agreed capital repayment amount.
         # Capital-payment-only loans retain their provided payment values.

--- a/report_utils.py
+++ b/report_utils.py
@@ -257,6 +257,12 @@ def generate_report_schedule(params: Dict[str, Any]) -> Tuple[List[Dict[str, Any
     summary["monthlyInterestPayment"] = float(monthly_interest)
     summary["quarterlyInterestPayment"] = float(quarterly_interest)
 
+    payment_frequency = params.get("payment_frequency", "monthly")
+    payment_timing = params.get("payment_timing", "arrears")
+    freq_label = "Monthly" if payment_frequency == "monthly" else "Quarterly"
+    timing_label = "in Advance" if payment_timing == "advance" else "in Arrears"
+    summary["interestPaymentTiming"] = f"{freq_label} {timing_label}"
+
     if is_service_and_capital_net and summary:
         gross_amount = Decimal(
             str(

--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -752,6 +752,7 @@ class LoanCalculator {
              repaymentOption === 'retained' ||
              repaymentOption === 'retained_interest');
         const isBridgeServicedOnly = loanType === 'bridge' && repaymentOption === 'service_only';
+        const showBridgeInterestTiming = loanType === 'bridge' && ['service_only', 'service_and_capital', 'capital_payment_only', 'flexible_payment'].includes(repaymentOption);
 
         const paymentFrequency = document.querySelector('input[name="payment_frequency"]:checked')?.value || 'monthly';
         const paymentTiming = document.querySelector('input[name="payment_timing"]:checked')?.value || 'advance';
@@ -980,7 +981,7 @@ class LoanCalculator {
 
         const interestPaymentRow = document.getElementById('interestPaymentTimingRow');
         const interestPaymentEl = document.getElementById('interestPaymentTimingResult');
-        if (isBridgeServicedOnly) {
+        if (showBridgeInterestTiming) {
             if (interestPaymentRow && interestPaymentEl) {
                 const freqLabel = paymentFrequency === 'quarterly' ? 'Quarterly' : 'Monthly';
                 const timingLabel = paymentTiming === 'advance' ? 'in Advance' : 'in Arrears';

--- a/test_interest_payment_timing_row.py
+++ b/test_interest_payment_timing_row.py
@@ -1,0 +1,86 @@
+import sys, types
+import pytest
+
+# Minimal relativedelta stub
+relativedelta_module = types.ModuleType('relativedelta')
+
+class relativedelta:
+    def __init__(self, months=0):
+        self.months = months
+    def __radd__(self, other):
+        from datetime import date
+        month = other.month - 1 + self.months
+        year = other.year + month // 12
+        month = month % 12 + 1
+        day = min(other.day, [31, 29 if year % 4 == 0 and (year % 100 != 0 or year % 400 == 0) else 28,
+                              31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1])
+        return other.replace(year=year, month=month, day=day)
+relativedelta_module.relativedelta = relativedelta
+sys.modules['dateutil'] = types.ModuleType('dateutil')
+sys.modules['dateutil'].relativedelta = relativedelta_module
+sys.modules['dateutil.relativedelta'] = relativedelta_module
+
+from report_utils import generate_report_schedule
+from calculations import LoanCalculator
+
+@pytest.mark.parametrize("repayment_option,payment_frequency,payment_timing,expected", [
+    ('service_only', 'monthly', 'arrears', 'Monthly in Arrears'),
+    ('service_and_capital', 'monthly', 'advance', 'Monthly in Advance'),
+    ('capital_payment_only', 'quarterly', 'arrears', 'Quarterly in Arrears'),
+    ('flexible_payment', 'quarterly', 'advance', 'Quarterly in Advance'),
+])
+def test_interest_payment_timing_in_summary(repayment_option, payment_frequency, payment_timing, expected):
+    params = {
+        'loan_type': 'bridge',
+        'repayment_option': repayment_option,
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'payment_frequency': payment_frequency,
+        'payment_timing': payment_timing,
+        'arrangement_fee_rate': 0,
+        'legal_fees': 0,
+        'site_visit_fee': 0,
+        'title_insurance_rate': 0,
+        'start_date': '2024-01-01',
+    }
+    if repayment_option == 'service_and_capital':
+        params['capital_repayment'] = 10000
+    if repayment_option == 'capital_payment_only':
+        params['capital_repayment'] = 10000
+    if repayment_option == 'flexible_payment':
+        params['flexible_payment'] = 2000
+    _, summary = generate_report_schedule(params)
+    assert summary['interestPaymentTiming'] == expected
+
+
+@pytest.mark.parametrize("repayment_option,payment_frequency,payment_timing,expected", [
+    ('service_only', 'monthly', 'arrears', 'Monthly in Arrears'),
+    ('service_and_capital', 'monthly', 'advance', 'Monthly in Advance'),
+    ('capital_payment_only', 'quarterly', 'arrears', 'Quarterly in Arrears'),
+    ('flexible_payment', 'quarterly', 'advance', 'Quarterly in Advance'),
+])
+def test_interest_payment_timing_in_loan_summary(repayment_option, payment_frequency, payment_timing, expected):
+    params = {
+        'loan_type': 'bridge',
+        'repayment_option': repayment_option,
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'payment_frequency': payment_frequency,
+        'payment_timing': payment_timing,
+        'arrangement_fee_rate': 0,
+        'legal_fees': 0,
+        'site_visit_fee': 0,
+        'title_insurance_rate': 0,
+        'start_date': '2024-01-01',
+    }
+    if repayment_option == 'service_and_capital':
+        params['capital_repayment'] = 10000
+    if repayment_option == 'capital_payment_only':
+        params['capital_repayment'] = 10000
+    if repayment_option == 'flexible_payment':
+        params['flexible_payment'] = 2000
+    calc = LoanCalculator()
+    result = calc.calculate_bridge_loan(params)
+    assert result['interestPaymentTiming'] == expected


### PR DESCRIPTION
## Summary
- include interest payment timing in bridge loan summaries
- display timing row for all bridge repayment options
- test loan summary for correct interest timing across repayment options

## Testing
- `pytest test_interest_payment_timing_row.py`


------
https://chatgpt.com/codex/tasks/task_e_68b84a609988832084bf31227d9d5dbc