### PR TITLE
Show running LTV as percent and rename interest factor

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -4545,7 +4545,7 @@ class LoanCalculator:
                     'annual_interest_rate': f"{annual_rate:.2f}%",
                     'interest_pa': f"{daily_rate:.8f}",
                     'scheduled_repayment': f"{currency_symbol}{scheduled_repayment:,.2f}",
-                    'running_ltv': f"{running_ltv:.2f}"
+                    'running_ltv': f"{running_ltv:.2f}%"
                 }
                 if note:
                     entry['note'] = note
@@ -4658,7 +4658,7 @@ class LoanCalculator:
                     'interest_accrued': f"{currency_symbol}{interest_accrued_disp:,.2f}",
                     'interest_retained': f"{currency_symbol}{interest_retained_disp:,.2f}",
                     'interest_refund': f"{currency_symbol}{interest_refund_disp:,.2f}",
-                    'running_ltv': f"{running_ltv:.2f}"
+                    'running_ltv': f"{running_ltv:.2f}%"
                 })
 
                 if remaining_balance <= 0:
@@ -4756,7 +4756,7 @@ class LoanCalculator:
                         'interest_accrued': f"{currency_symbol}{interest_accrued_disp:,.2f}",
                         'interest_retained': f"{currency_symbol}{interest_retained_disp:,.2f}",
                         'interest_refund': f"{currency_symbol}0.00",
-                        'running_ltv': f"{running_ltv:.2f}"
+                        'running_ltv': f"{running_ltv:.2f}%"
                     })
                 elif period < len(payment_dates):
                     if capital_per_payment > remaining_balance:
@@ -4803,7 +4803,7 @@ class LoanCalculator:
                         'interest_accrued': f"{currency_symbol}{interest_accrued_disp:,.2f}",
                         'interest_retained': f"{currency_symbol}{interest_retained_disp:,.2f}",
                         'interest_refund': f"{currency_symbol}{interest_saving_disp:,.2f}",
-                        'running_ltv': f"{running_ltv:.2f}"
+                        'running_ltv': f"{running_ltv:.2f}%"
                     })
                     remaining_balance = closing_balance
                     if remaining_balance == 0:
@@ -4846,7 +4846,7 @@ class LoanCalculator:
                         'interest_accrued': f"{currency_symbol}{interest_accrued_disp:,.2f}",
                         'interest_retained': f"{currency_symbol}{interest_retained_disp:,.2f}",
                         'interest_refund': f"{currency_symbol}{interest_refund_disp:,.2f}",
-                        'running_ltv': f"{running_ltv:.2f}"
+                        'running_ltv': f"{running_ltv:.2f}%"
                     })
                     break
 
@@ -5663,7 +5663,7 @@ class LoanCalculator:
                     'interest_accrued': f"{currency_symbol}{actual_interest_paid:,.2f}",
                     'interest_retained': f"{currency_symbol}{interest_retained_disp:,.2f}",
                     'interest_refund': f"{currency_symbol}{interest_refund_disp:,.2f}",
-                    'running_ltv': f"{running_ltv:.2f}"
+                    'running_ltv': f"{running_ltv:.2f}%"
                 })
 
                 remaining_balance = closing_balance

--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -1070,7 +1070,7 @@ class LoanCalculator {
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Days Held</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Capital Outstanding</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Annual Interest %</th>
-                    <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest P.A.</th>
+                    <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Factor P.D.</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Scheduled Repayment</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Accrued</th>
                     <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Retained</th>

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1033,7 +1033,7 @@
                   <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Days Held</th>
                   <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Capital Outstanding</th>
                   <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Annual Interest %</th>
-                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest P.A.</th>
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Factor P.D.</th>
                   <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Scheduled Repayment</th>
                   <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Accrued</th>
                   <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Retained</th>


### PR DESCRIPTION
## Summary
- Append a percent sign to running LTV values in detailed payment schedules
- Rename schedule column from **Interest P.A.** to **Interest Factor P.D.** in calculator UI

## Testing
- `pip install selenium -q` *(fails: Could not find a version that satisfies the requirement selenium)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pytest -q --ignore=test_calculator_page.py`

------
https://chatgpt.com/codex/tasks/task_e_68b854e8df108320901e67e87df803ac