### PR TITLE
Fix landing page navbar color and logo

### DIFF
--- a/templates/landing.html
+++ b/templates/landing.html
@@ -244,10 +244,10 @@
     </style>
 </head>
 <body>
-    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <nav class="navbar navbar-expand-lg navbar-light" style="background: #AD965F !important; background-color: #AD965F !important;">
         <div class="container-fluid px-4 d-flex justify-content-between align-items-center">
             <a class="navbar-brand d-flex align-items-center" href="{{ url_for('landing_page') }}">
-                <img src="{{ url_for('static', filename='novellus_logo.png') }}" alt="Novellus" height="32">
+                <img src="/static/novellus_logo.png" alt="Novellus" height="32" class="me-2 navbar-logo" id="navbarLogo" style="height: 32px; width: auto; object-fit: contain; filter: none;">
             </a>
         </div>
     </nav>


### PR DESCRIPTION
## Summary
- set landing page navbar to Novellus gold
- replace navbar logo with provided version

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b87334804c8320bb6e1c7893ce23ef