### PR TITLE
fix: correct body background color

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -25,7 +25,7 @@
     --danger-color: #dc3545;
     --warning-color: #CDA44C;  /* Light Gold for warnings */
     --info-color: #2D3A49;  /* Light Navy for info */
-    --light-color: #AD965F;  /* Novellus Background */
+    --light-color: #FFFFFF;  /* Page Background */
     --dark-color: #1E2B3A;  /* Novellus Navy */
     --font-family: 'Brother 1816', Arial, sans-serif;
 }


### PR DESCRIPTION
## Summary
- use white background on page body

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68b94be9f7248320a768d879e5971b99