### PR TITLE
Fix body tag spacing to enable gold navbar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -36,7 +36,7 @@
     
     {% block head %}{% endblock %}
 </head>
-<body{% block body_attr %}{% endblock %}>
+<body {% block body_attr %}{% endblock %}>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
         <div class="container-fluid px-4 d-flex justify-content-between align-items-center">
             <a class="navbar-brand d-flex align-items-center" href="{{ url_for('index') }}">


### PR DESCRIPTION
## Summary
- add missing space after `<body` in base template so child templates can inject attributes

## Testing
- `python - <<'PY'
base=open('templates/base.html').read()
rendered=base.replace('{% block body_attr %}{% endblock %}','class="gold-nav"')
print('<body class="gold-nav">' in rendered)
PY`
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68b951e6a5e4832095fbefd508139161