### PR TITLE
Convert rate inputs when toggled

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -1678,24 +1678,39 @@ class LoanCalculator {
     toggleRateInputs() {
         const rateInputTypeRadio = document.querySelector('input[name="rate_input_type"]:checked');
         if (!rateInputTypeRadio) return;
-        
+
         const rateInputType = rateInputTypeRadio.value;
         const monthlyRateInput = document.getElementById('monthlyRateInput');
         const annualRateInput = document.getElementById('annualRateInput');
-        
+        const monthlyRateValue = document.getElementById('monthlyRateValue');
+        const annualRateValue = document.getElementById('annualRateValue');
+
         console.log('Toggle rate inputs:', rateInputType);
-        
+
         if (monthlyRateInput && annualRateInput) {
             if (rateInputType === 'monthly') {
+                if (monthlyRateValue && annualRateValue) {
+                    const annual = parseFloat(annualRateValue.value);
+                    if (!isNaN(annual)) {
+                        monthlyRateValue.value = (annual / 12).toFixed(4);
+                    }
+                }
                 monthlyRateInput.style.setProperty('display', 'flex', 'important');
                 annualRateInput.style.setProperty('display', 'none', 'important');
                 console.log('Showing monthly input, hiding annual input');
             } else {
+                if (monthlyRateValue && annualRateValue) {
+                    const monthly = parseFloat(monthlyRateValue.value);
+                    if (!isNaN(monthly)) {
+                        annualRateValue.value = (monthly * 12).toFixed(4);
+                    }
+                }
                 monthlyRateInput.style.setProperty('display', 'none', 'important');
                 annualRateInput.style.setProperty('display', 'flex', 'important');
                 console.log('Hiding monthly input, showing annual input');
             }
         }
+        this.updateRateEquivalenceNote();
     }
 
     setDefaultDate() {
@@ -2010,9 +2025,17 @@ class LoanCalculator {
         const monthlyInput = document.getElementById('monthlyRateInput');
         const annualInput = document.getElementById('annualRateInput');
         const monthlyRadio = document.getElementById('monthlyRate');
-        
+        const monthlyValue = document.getElementById('monthlyRateValue');
+        const annualValue = document.getElementById('annualRateValue');
+
         if (monthlyRadio && monthlyRadio.checked) {
             console.log('Toggle rate inputs:', 'monthly');
+            if (monthlyValue && annualValue) {
+                const annual = parseFloat(annualValue.value);
+                if (!isNaN(annual)) {
+                    monthlyValue.value = (annual / 12).toFixed(4);
+                }
+            }
             if (monthlyInput) {
                 monthlyInput.style.setProperty('display', 'flex', 'important');
                 console.log('Showing monthly input, hiding annual input');
@@ -2022,6 +2045,12 @@ class LoanCalculator {
             }
         } else {
             console.log('Toggle rate inputs:', 'annual');
+            if (monthlyValue && annualValue) {
+                const monthly = parseFloat(monthlyValue.value);
+                if (!isNaN(monthly)) {
+                    annualValue.value = (monthly * 12).toFixed(4);
+                }
+            }
             if (monthlyInput) {
                 monthlyInput.style.setProperty('display', 'none', 'important');
             }


### PR DESCRIPTION
## Summary
- Convert annual rate to monthly when switching to monthly input and vice versa
- Keep rate equivalence note in sync with converted values

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b977e0b3788320b1523d3a9cbcb8b5