### PR TITLE
Hide nav buttons on their respective pages

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -89,13 +89,17 @@
                     <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('scenario_comparison_page') }}">
                         <i class="fas fa-chart-line me-1"></i>Scenario Comparison
                     </a>
+                    {% if request.endpoint != 'loan_history' %}
                     <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('loan_history') }}">
                         <i class="fas fa-history me-1"></i>Loan History
                     </a>
+                    {% endif %}
                     {% block nav_calculator %}
+                    {% if request.endpoint != 'calculator_page' %}
                     <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('calculator_page') }}">
                         <i class="fas fa-calculator me-1"></i>Calculator
                     </a>
+                    {% endif %}
                     {% endblock %}
                     {% endif %}
                     <a class="btn btn-nav {{ nav_text_class }}" href="#" onclick="window.location.reload(); return false;">


### PR DESCRIPTION
## Summary
- Hide Loan History button when visiting loan history page
- Hide Calculator button when visiting calculator page

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68b9a1c173708320bcd541e4c3630320