### PR TITLE
Disable gross amount selection for development loans

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -1769,12 +1769,19 @@ class LoanCalculator {
             // Show/hide amount input section based on loan type
             const netAmountSection = document.getElementById('netAmountSection');
             const grossAmountSection = document.getElementById('grossAmountSection');
+            const grossAmountRadio = document.getElementById('grossAmount');
+            const grossAmountLabel = document.querySelector('label[for="grossAmount"]');
+            const netAmountRadio = document.getElementById('netAmount');
             
             const interestTypeRadios = document.querySelectorAll('input[name="interestTypeToggle"]');
             if (loanType === 'development' || loanType === 'development2') {
-                // Development loans default to net amount input
-                document.getElementById('netAmount').checked = true;
-                document.getElementById('grossAmount').checked = false;
+                // Development loans default to net amount input and disallow gross amount selection
+                if (netAmountRadio) netAmountRadio.checked = true;
+                if (grossAmountRadio) {
+                    grossAmountRadio.checked = false;
+                    grossAmountRadio.disabled = true;
+                }
+                if (grossAmountLabel) grossAmountLabel.classList.add('disabled');
                 if (netAmountSection) netAmountSection.style.display = 'block';
                 if (grossAmountSection) grossAmountSection.style.display = 'none';
 
@@ -1790,9 +1797,13 @@ class LoanCalculator {
                 }
                 interestTypeRadios.forEach(r => r.disabled = true);
             } else {
-                // Bridge and term loans default to gross amount input
-                document.getElementById('grossAmount').checked = true;
-                document.getElementById('netAmount').checked = false;
+                // Bridge and term loans default to gross amount input and allow switching
+                if (grossAmountRadio) {
+                    grossAmountRadio.disabled = false;
+                    grossAmountRadio.checked = true;
+                }
+                if (grossAmountLabel) grossAmountLabel.classList.remove('disabled');
+                if (netAmountRadio) netAmountRadio.checked = false;
                 if (grossAmountSection) grossAmountSection.style.display = 'block';
                 if (netAmountSection) netAmountSection.style.display = 'none';
 

--- a/test_calculator_page.py
+++ b/test_calculator_page.py
@@ -59,3 +59,16 @@ def test_calculator_page_runs_without_js_errors(live_server):
         assert not logs, f"JavaScript errors found: {logs}"
     finally:
         driver.quit()
+
+
+def test_development_loan_disables_gross_amount(live_server):
+    driver = _get_chrome_driver()
+    try:
+        driver.get(live_server + "/calculator")
+        driver.find_element(By.ID, "loanTypeDevelopment").click()
+        WebDriverWait(driver, 5).until(
+            lambda d: not d.find_element(By.ID, "grossAmount").is_enabled()
+        )
+        assert not driver.find_element(By.ID, "grossAmount").is_enabled()
+    finally:
+        driver.quit()


### PR DESCRIPTION
## Summary
- Prevent choosing gross amount when loan type is development
- Add Selenium test ensuring gross option is disabled for development loans

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68b9a528183c832091643199d975892c