### PR TITLE
Hide 360-day calculation checkbox for short-term loans

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -587,7 +587,7 @@
 <small id="rateEquivalenceNote" class="form-text text-muted"></small>
 </div>
 <!-- Daily Rate Calculation Method -->
-<div class="">
+<div class="" id="use360DaysSection">
 <div class="form-check">
 <input class="form-check-input" id="use360Days" name="use_360_days" type="checkbox" value="true"/>
 <label class="form-check-label" for="use360Days">
@@ -1231,6 +1231,15 @@ function calculateEndDate() {
             end.setUTCDate(end.getUTCDate() - 1);
             const endStr = `${end.getUTCFullYear()}-${String(end.getUTCMonth() + 1).padStart(2, '0')}-${String(end.getUTCDate()).padStart(2, '0')}`;
             endDateEl.value = endStr;
+
+            const startUTC = Date.UTC(sy, sm - 1, sd);
+            const endUTC = Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate());
+            const daysDiff = Math.floor((endUTC - startUTC) / 86400000) + 1;
+            const loanTermDaysEl = document.getElementById('loanTermDaysResult');
+            if (loanTermDaysEl) loanTermDaysEl.textContent = daysDiff;
+            if (window.loanCalculator && typeof window.loanCalculator.update360DayVisibility === 'function') {
+                window.loanCalculator.update360DayVisibility();
+            }
             triggerCalculationUpdate();
         }
     } else {
@@ -1244,6 +1253,9 @@ function calculateEndDate() {
             const daysDiff = Math.floor((endUTC - startUTC) / 86400000) + 1;
             const loanTermDaysEl = document.getElementById('loanTermDaysResult');
             if (loanTermDaysEl) loanTermDaysEl.textContent = daysDiff;
+            if (window.loanCalculator && typeof window.loanCalculator.update360DayVisibility === 'function') {
+                window.loanCalculator.update360DayVisibility();
+            }
 
             let monthsDiff = (ey - sy) * 12 + (em - sm);
             if (ed < sd) {

--- a/templates/calculator_w.html
+++ b/templates/calculator_w.html
@@ -457,7 +457,7 @@
 </select>
 </div>
 <!-- Daily Rate Calculation Method -->
-<div class="">
+<div class="" id="use360DaysSection">
 <div class="form-check">
 <input class="form-check-input" id="use360Days" name="use_360_days" type="checkbox" value="true"/>
 <label class="form-check-label" for="use360Days">
@@ -1029,6 +1029,13 @@ function calculateEndDate() {
         const endDateInput = document.getElementById('endDate');
         endDateInput.value = end.toISOString().split('T')[0];
 
+        const daysDiff = Math.floor((end - start) / 86400000) + 1;
+        const loanTermDaysEl = document.getElementById('loanTermDaysResult');
+        if (loanTermDaysEl) loanTermDaysEl.textContent = daysDiff;
+        if (window.loanCalculator && typeof window.loanCalculator.update360DayVisibility === 'function') {
+            window.loanCalculator.update360DayVisibility();
+        }
+
         console.log(`Calculated end date for ${loanTerm}-month loan: ${startDate} to ${end.toISOString().split('T')[0]}`);
 
         // Trigger calculation update if calculator instance exists and form has data
@@ -1053,6 +1060,11 @@ function recalculateLoanTerm() {
         const end = new Date(endDate);
         const daysDiff = Math.floor((end - start) / 86400000) + 1;
         console.log(`Manual date change: ${daysDiff} days between ${startDate} and ${endDate}`);
+        const loanTermDaysEl = document.getElementById('loanTermDaysResult');
+        if (loanTermDaysEl) loanTermDaysEl.textContent = daysDiff;
+        if (window.loanCalculator && typeof window.loanCalculator.update360DayVisibility === 'function') {
+            window.loanCalculator.update360DayVisibility();
+        }
 
         let monthsDiff = (end.getFullYear() - start.getFullYear()) * 12 +
                          (end.getMonth() - start.getMonth());


### PR DESCRIPTION
## Summary
- Wrap 360-day calculation option in a dedicated section for toggling
- Compute term days and hide the 360-day checkbox when loan length is 365 or 366 days
- Apply leap-year aware visibility logic in both calculator templates and shared JS

## Testing
- `pytest --ignore=test_calculator_page.py --ignore=test_calculator_term_end_date_toggle.py -q`
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a8727be48320838d21b605e9348a