### PR TITLE
Ensure loan navigation links are always visible

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -89,19 +89,13 @@
                     <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('scenario_comparison_page') }}">
                         <i class="fas fa-chart-line me-1"></i>Scenario Comparison
                     </a>
-                    {% if request.endpoint != 'loan_history' %}
+                    {% endif %}
                     <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('loan_history') }}">
                         <i class="fas fa-history me-1"></i>Loan History
                     </a>
-                    {% endif %}
-                    {% block nav_calculator %}
-                    {% if request.endpoint != 'calculator_page' %}
                     <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('calculator_page') }}">
                         <i class="fas fa-calculator me-1"></i>Calculator
                     </a>
-                    {% endif %}
-                    {% endblock %}
-                    {% endif %}
                     <a class="btn btn-nav {{ nav_text_class }}" href="#" onclick="window.location.reload(); return false;">
                         <i class="fas fa-sync-alt me-1"></i>Refresh
                     </a>

--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -12,7 +12,6 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/currency-themes.css') }}">
 {% endblock %}
 
-{% block nav_calculator %}{% endblock %}
 
 {% block content %}
 <!-- Notification container for consistent notifications -->


### PR DESCRIPTION
## Summary
- Always display Loan History and Calculator buttons in the navbar
- Remove loan-history template override hiding the calculator link

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68b9aa14eeb08320956920fcce63ca8d