### PR TITLE
Fix /home Internal Server Error by updating calculator link

### DIFF
--- a/Requirements.txt
+++ b/Requirements.txt
@@ -1,1 +1,3 @@
 # Minimal requirements for running tests in constrained environments
+selenium>=4.34.2
+chromedriver-autoinstaller>=0.6.2

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -266,7 +266,7 @@
         <div class="offcanvas-body">
             <ul class="nav flex-column">
                 <li class="nav-item"><a class="nav-link" href="/home"><i class="fas fa-home me-2"></i>Home</a></li>
-                <li class="nav-item"><a class="nav-link" href="{{ url_for('calculator') }}"><i class="fas fa-calculator me-2"></i>Loan Calculator</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('calculator_page') }}"><i class="fas fa-calculator me-2"></i>Loan Calculator</a></li>
                 <li class="nav-item"><a class="nav-link" href="https://novelluscapital.sharepoint.com/:x:/s/NovellusLending/EcBD97NZVm9InN-BueGjXLoBOPwoKFv0DEGpMhUZu5Olzw?e=ZutCig" target="_blank"><i class="fas fa-chart-line me-2"></i>Cashbook</a></li>
                 <li class="nav-item"><a class="nav-link" href="https://login.xero.com/identity/user/login?ReturnUrl=%2Fidentity%2Fconnect%2Fauthorize%2Fcallback%3Fclient_id%3Dxero_mx_hybrid-web%26redirect_uri%3Dhttps%253A%252F%252Fmy.xero.com%252Fsignin-oidc%26response_mode%3Dform_post%26response_type%3Dcode%2520id_token%26scope%3Dxero_all-apis%2520openid%2520email%2520profile%26state%3DOpenIdConnect.AuthenticationProperties%253DY-gOrxPXDynk0BeIk6zWph3RQA8aa4TMpONPqwahcU-jldogR5Dvs_nflQwV_MFtEoALb-zLknrirq4TBKNnHR1XtOTdmrj2ufMFgbARYoyWKDvg8WYvarIrbPwuDzQQURFujpB5jTpCgd9XOrdkYAsh6MftvpLYszTndFpossYS7qH-em01Rx3lBT5laI11vgEJJVWYW-8LCSGmjENXAPdNW9U%26nonce%3D638895519124272470.NmQwM2UzMWUtMTU5Yi00Y2U2LTgzMTEtZTliMzhhYzNkZmQ4NTY5YjUzYjktMmM5ZC00ODM4LTg5NjktNzU1YzY2ODVhM2Vh%26x-client-SKU%3DID_NET451%26x-client-ver%3D1.3.13.0" target="_blank"><i class="fas fa-chart-bar me-2"></i>Xero</a></li>
                 <li class="nav-item"><a class="nav-link" href="{{ url_for('user_manual') }}"><i class="fas fa-book me-2"></i>User Manual</a></li>
@@ -296,7 +296,7 @@
                         <p class="nav-card-description">
                             Loan calculations for bridge, term, and development.
                         </p>
-                        <a href="/calculator" class="nav-card-button">
+                        <a href="{{ url_for('calculator_page') }}" class="nav-card-button">
                             Start Calculating
                         </a>
                     </div>


### PR DESCRIPTION
## Summary
- Correct landing page navigation to use `calculator_page` endpoint ensuring /home renders without error
- Declare selenium and chromedriver-autoinstaller in Requirements.txt for browser-based tests

## Testing
- `pip install -r Requirements.txt` *(fails: ProxyError - Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68b9ba4e83e88320872d8d8e6da4e8f2