### PR TITLE
Register routes when running app module

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,3 +69,6 @@ def load_user(user_id):
 with app.app_context():
     db.create_all()
     logging.info("Database tables created")
+
+# Import routes to ensure they are registered when running the app directly
+import routes  # noqa: F401


### PR DESCRIPTION
## Summary
- ensure app imports `routes` so landing page works when using `flask run` or other direct app invocations

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68b9bc72401c8320946a53a9433436f2