### PR TITLE
Allow schedule exports without login

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -875,7 +875,6 @@ def excel_style_breakdown():
         return jsonify({'success': False, 'error': str(e)}), 500
 
 @app.route('/api/export-schedule', methods=['POST'])
-@login_required
 def api_export_schedule():
     """Export payment schedule as CSV"""
     try:
@@ -899,7 +898,6 @@ def api_export_schedule():
 
 
 @app.route('/api/export-schedule-xlsx', methods=['POST'])
-@login_required
 def api_export_schedule_xlsx():
     """Export payment and tranche schedules as XLSX workbook"""
     try:

--- a/test_export_schedule_xlsx_no_auth.py
+++ b/test_export_schedule_xlsx_no_auth.py
@@ -1,0 +1,26 @@
+import pytest
+
+pytest.importorskip("flask")
+pytest.importorskip("app")
+
+from app import app
+
+
+def test_export_schedule_xlsx_no_auth():
+    """Excel export endpoint should be accessible without authentication."""
+    client = app.test_client()
+    payload = {
+        "payment_schedule": [],
+        "tranche_schedule": [],
+        "annual_rate": 10,
+        "start_date": "2024-01-01",
+        "loan_term": 12,
+        "use_360_days": False,
+    }
+    res = client.post("/api/export-schedule-xlsx", json=payload)
+    assert res.status_code == 200
+    assert (
+        res.headers.get("Content-Type")
+        == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    assert res.data, "No file content returned"


### PR DESCRIPTION
## Summary
- Remove login requirement from schedule export endpoints so Excel/CSV downloads work without authentication
- Add regression test ensuring Excel export returns file content without needing login

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install flask flask_sqlalchemy flask_login flask_jwt_extended` *(fails: Could not find a version that satisfies the requirement flask)*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bdfc6fac83208f60742ccc1fa7dc