### PR TITLE
Enable landing page navigation without authentication

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -71,6 +71,17 @@
                                 <i class="fas fa-quote-left me-1"></i>Quotes
                             </a>
                         </li>
+                    {% else %}
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('login') }}">
+                                <i class="fas fa-sign-in-alt me-1"></i>Login
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link" href="{{ url_for('register') }}">
+                                <i class="fas fa-user-plus me-1"></i>Register
+                            </a>
+                        </li>
                     {% endif %}
                 </ul>
 


### PR DESCRIPTION
## Summary
- Show login and registration links in the navbar when no user is logged in, ensuring the left-side menu works on the landing page

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement due to proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bfd4af5c83208cdcc3b938bd5849