### PR TITLE
Reduce calculator layout width

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -443,6 +443,7 @@
     /* Adjust layout spacing and widths */
     .calculator-layout {
         --bs-gutter-x: 2px;
+        width: calc(100% - 10px);
     }
 
     @media (min-width: 992px) {


### PR DESCRIPTION
## Summary
- shrink calculator layout width by 10px for narrower view

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68b9c1267cbc8320a4d44f048f1a7600