### PR TITLE
feat: apply Novellus currency theme to Excel exports

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -909,6 +909,7 @@ def api_export_schedule_xlsx():
             'start_date': data.get('start_date'),
             'loan_term': data.get('loan_term'),
             'use_360_days': data.get('use_360_days', False),
+            'currency': data.get('currency', 'GBP'),
         }
 
         excel_gen = NovellussExcelGenerator()


### PR DESCRIPTION
## Summary
- style Excel exports with Novellus currency theme including dynamic symbols, number formats and brand colors
- pass currency to Excel export API to activate theme

## Testing
- `pytest test_export_schedule_xlsx_currency_strings.py test_export_schedule_xlsx_no_auth.py` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68ba13a00198832094b9bde5525ff6c9