### PR TITLE
Add global sidebar navigation and base landing layout

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -179,26 +179,7 @@ except ImportError as e:
 @app.route('/')
 def landing_page():
     """Landing page with professional navigation cards"""
-
-    # Build a list of available GET routes that don't require parameters.
-    # This ensures the left navigation menu can display links for all
-    # accessible pages without breaking when routes expect arguments.
-    nav_routes = []
-    for rule in app.url_map.iter_rules():
-        if "GET" in rule.methods and len(rule.arguments) == 0 and not rule.rule.startswith('/static'):
-            try:
-                nav_routes.append({
-                    "rule": rule.rule,
-                    "url": url_for(rule.endpoint),
-                })
-            except Exception:
-                # Skip routes that cannot be built (e.g. missing dependencies)
-                continue
-
-    # Sort routes alphabetically by their URL path for consistent ordering
-    nav_routes.sort(key=lambda r: r["url"])
-
-    return render_template('landing.html', nav_routes=nav_routes)
+    return render_template('landing.html')
 
 @app.route('/home')  
 def index():
@@ -1574,6 +1555,21 @@ def inject_user():
 @app.context_processor
 def inject_now():
     return dict(now=datetime.utcnow())
+
+@app.context_processor
+def inject_nav_routes():
+    nav_routes = []
+    for rule in app.url_map.iter_rules():
+        if "GET" in rule.methods and len(rule.arguments) == 0 and not rule.rule.startswith('/static'):
+            try:
+                nav_routes.append({
+                    "rule": rule.rule,
+                    "url": url_for(rule.endpoint),
+                })
+            except Exception:
+                continue
+    nav_routes.sort(key=lambda r: r["url"])
+    return dict(nav_routes=nav_routes)
 
 @app.route('/download-professional-quote', methods=['POST'])
 @cross_origin()

--- a/templates/base.html
+++ b/templates/base.html
@@ -39,6 +39,9 @@
 <body {% block body_attr %}{% endblock %}>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
         <div class="container-fluid px-4 d-flex justify-content-between align-items-center">
+            <button class="btn btn-outline-light me-3" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu">
+                <i class="fas fa-bars"></i>
+            </button>
             <a class="navbar-brand d-flex align-items-center" href="{{ url_for('index') }}">
                 <img src="{{ url_for('static', filename='novellus_logo.png') }}" alt="Novellus" height="32" class="me-2 navbar-logo" id="navbarLogo" style="height: 32px; width: auto; object-fit: contain; filter: brightness(100%) saturate(100%);">
                 <span class="fw-bold"></span>
@@ -47,29 +50,40 @@
             <div class="navbar-title mx-auto">
                 {% block nav_heading %}{% endblock %}
             </div>
-                    <div class="d-flex ms-auto gap-2">
-                    {% set nav_text_class = 'text-black' if request.endpoint in ['calculator_page', 'loan_history'] else '' %}
+            <div class="d-flex ms-auto gap-2">
+                {% set nav_text_class = 'text-black' if request.endpoint in ['calculator_page', 'loan_history'] else '' %}
 
-                    <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('loan_history') }}">
-                        <i class="fas fa-history me-1"></i>Loan History
-                    </a>
-                    <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('calculator_page') }}">
-                        <i class="fas fa-calculator me-1"></i>Calculator
-                    </a>
-                    <a class="btn btn-nav {{ nav_text_class }}" href="#" onclick="window.location.reload(); return false;">
-                        <i class="fas fa-sync-alt me-1"></i>Refresh
-                    </a>
-                    <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('landing_page') }}">
-                        <i class="fas fa-home me-1"></i>Home
-                    </a>
-                    </div>
-
-                </div>
+                <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('loan_history') }}">
+                    <i class="fas fa-history me-1"></i>Loan History
+                </a>
+                <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('calculator_page') }}">
+                    <i class="fas fa-calculator me-1"></i>Calculator
+                </a>
+                <a class="btn btn-nav {{ nav_text_class }}" href="#" onclick="window.location.reload(); return false;">
+                    <i class="fas fa-sync-alt me-1"></i>Refresh
+                </a>
+                <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('landing_page') }}">
+                    <i class="fas fa-home me-1"></i>Home
+                </a>
             </div>
         </div>
     </nav>
 
-    <main class="container-fluid mt-4 px-4">
+    <div class="offcanvas offcanvas-start" tabindex="-1" id="sidebarMenu" aria-labelledby="sidebarMenuLabel">
+        <div class="offcanvas-header">
+            <h5 class="offcanvas-title" id="sidebarMenuLabel">Menu</h5>
+            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+        </div>
+        <div class="offcanvas-body">
+            <ul class="nav flex-column">
+                {% for route in nav_routes %}
+                <li class="nav-item"><a class="nav-link" href="{{ route.url }}">{{ route.rule }}</a></li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+
+    <main class="{% block main_class %}container-fluid mt-4 px-4{% endblock %}">
         {% with messages = get_flashed_messages(with_categories=true) %}
             {% if messages %}
                 {% for category, message in messages %}

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -1,21 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Novellus Loan Management System</title>
-    <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
-    
-    <!-- Bootstrap CSS -->
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <!-- Font Awesome -->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+{% extends 'base.html' %}
+{% block title %}Novellus Loan Management System{% endblock %}
 
-    <!-- Custom CSS -->
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/novellus-theme.css') }}">
+{% block head %}
+    {{ super() }}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/notifications.css') }}">
-    
     <style>
         /* Landing page specific styles */
         .landing-hero {
@@ -34,43 +22,36 @@
             left: 0;
             right: 0;
             bottom: 0;
-
             z-index: 1;
         }
-        
         .hero-content {
             position: relative;
             z-index: 2;
             color: white;
             text-align: center;
         }
-        
         .logo-container {
             margin-bottom: 2rem;
         }
-        
         .logo-container img {
             max-height: 120px;
             width: auto;
             filter: drop-shadow(0 4px 8px rgba(0,0,0,0.3));
         }
-        
         .hero-title {
             font-size: 3.5rem;
             font-weight: 700;
             margin-bottom: 1rem;
-            text-shadow: 2px 2px 4px rgba(51, 51, 51, 0.5);
-            color: rgb(51, 51, 51);;
+            text-shadow: 2px 2px 4px rgba(51,51,51,0.5);
+            color: rgb(51,51,51);
         }
-        
         .hero-subtitle {
             font-size: 1.5rem;
             margin-bottom: 3rem;
-            text-shadow: 1px 1px 2px rgba(51, 51, 51, 0.5);
-            color: rgb(51, 51, 51);;
+            text-shadow: 1px 1px 2px rgba(51,51,51,0.5);
+            color: rgb(51,51,51);
             font-weight: 300;
         }
-        
         .navigation-cards {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
@@ -80,7 +61,6 @@
             padding: 0 1rem;
             justify-items: center;
         }
-
         .nav-card {
             background: rgba(255, 255, 255, 0.95);
             border-radius: 15px;
@@ -94,32 +74,27 @@
             align-items: center;
             border: 2px solid #AD965F;
         }
-        
         .nav-card:hover {
             transform: translateY(-10px);
             box-shadow: 0 15px 45px rgba(0,0,0,0.2);
-            background: rgba(255, 255, 255, 1);
+            background: rgba(255,255,255,1);
         }
-        
         .nav-card-icon {
             font-size: 3rem;
             margin-bottom: 1rem;
             color: #AD965F;
         }
-        
         .nav-card-title {
             font-size: 1.5rem;
             font-weight: 600;
             margin-bottom: 1rem;
             color: #1E2B3A;
         }
-        
         .nav-card-description {
             color: #6c757d;
             margin-bottom: 1.5rem;
             line-height: 1.6;
         }
-        
         .nav-card-button {
             background-color: #AD965F;
             color: white;
@@ -132,20 +107,17 @@
             transition: all 0.3s ease;
             margin-top: auto;
         }
-
         .nav-card-button:hover {
             background-color: #977c4d;
             color: white;
             transform: scale(1.05);
             text-decoration: none;
         }
-        
         .features-section {
             padding: 4rem 0;
             background: rgba(255, 255, 255, 0.1);
             backdrop-filter: blur(1px);
         }
-        
         .feature-list {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
@@ -154,266 +126,126 @@
             margin: 0 auto;
             padding: 0 1rem;
         }
-        
         .feature-item {
             display: flex;
             align-items: center;
             color: black;
             font-size: 1.1rem;
         }
-        
         .feature-item i {
             color: #DAA520;
             margin-right: 1rem;
             font-size: 1.3rem;
         }
-        
         @media (max-width: 768px) {
-            .hero-title {
-                font-size: 2.5rem;
-            }
-            
-            .hero-subtitle {
-                font-size: 1.2rem;
-            }
-            
-            .navigation-cards {
-                grid-template-columns: 1fr;
-                gap: 1rem;
-            }
-            
-            .nav-card {
-                padding: 1rem;
-            }
-        }
-
-        /* Navigation button styles for footer links */
-        .nav-btn {
-            font-weight: 600;
-            padding: 8px 16px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            transition: all 0.3s ease;
-            border: 2px solid;
-            white-space: nowrap;
-            font-size: 0.9rem;
-        }
-
-        .nav-btn:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 4px 8px rgba(0,0,0,0.2);
-        }
-
-        .nav-btn.btn-info {
-            background-color: #17a2b8;
-            border-color: #17a2b8;
-        }
-
-        .nav-btn.btn-info:hover {
-            background-color: #138496;
-            border-color: #138496;
-        }
-
-        .nav-btn.btn-secondary {
-            background-color: #6c757d;
-            border-color: #6c757d;
-        }
-
-        .nav-btn.btn-secondary:hover {
-            background-color: #5a6268;
-            border-color: #5a6268;
-        }
-
-        .nav-btn.btn-warning {
-            background-color: #ffc107;
-            border-color: #ffc107;
-        }
-
-        .nav-btn.btn-warning:hover {
-            background-color: #e0a800;
-            border-color: #e0a800;
-        }
-
-        .nav-btn.btn-maroon {
-            background-color: #800000;
-            border-color: #800000;
-            color: #fff;
-        }
-
-        .nav-btn.btn-maroon:hover {
-            background-color: #660000;
-            border-color: #660000;
+            .hero-title { font-size: 2.5rem; }
+            .hero-subtitle { font-size: 1.2rem; }
+            .navigation-cards { grid-template-columns: 1fr; gap: 1rem; }
+            .nav-card { padding: 1rem; }
         }
     </style>
-</head>
-<body>
-    <nav class="navbar navbar-expand-lg navbar-dark bg-primary" style="background-color: #AD965F !important; border: 2px solid rgb(0, 0, 0) !important; color: white !important; background-image: none !important;">
-        <div class="container-fluid px-4 d-flex align-items-center">
-            <button class="btn btn-outline-light me-3" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu">
-                <i class="fas fa-bars"></i>
-            </button>
-            <a class="navbar-brand d-flex align-items-center" href="/home">
-                <img src="/static/novellus_logo.png" alt="Novellus" height="32" class="me-2 navbar-logo" id="navbarLogo" style="height: 32px; width: auto; object-fit: contain; filter: brightness(100%) saturate(100%);">
-                <span class="fw-bold"></span>
-            </a>
-        </div>
-    </nav>
+{% endblock %}
 
-    <div class="offcanvas offcanvas-start" tabindex="-1" id="sidebarMenu" aria-labelledby="sidebarMenuLabel">
-        <div class="offcanvas-header">
-            <h5 class="offcanvas-title" id="sidebarMenuLabel">Menu</h5>
-            <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
-        </div>
-        <div class="offcanvas-body">
-            <ul class="nav flex-column">
-                {% for route in nav_routes %}
-                <li class="nav-item"><a class="nav-link" href="{{ route.url }}">{{ route.rule }}</a></li>
-                {% endfor %}
-            </ul>
-        </div>
-    </div>
-    <div class="landing-hero">
-        <div class="container">
-            <div class="hero-content">
-                <div class="logo-container">
-                    <img src="{{ url_for('static', filename='novellus_logo.png') }}" alt="Novellus Logo" class="logo" style="width: 100%; max-width: 700px; object-fit: contain; filter: brightness(100%) saturate(100%);">
+{% block main_class %}p-0{% endblock %}
+
+{% block content %}
+<div class="landing-hero">
+    <div class="container">
+        <div class="hero-content">
+            <div class="logo-container">
+                <img src="{{ url_for('static', filename='novellus_logo.png') }}" alt="Novellus Logo" class="logo" style="width: 100%; max-width: 700px; object-fit: contain; filter: brightness(100%) saturate(100%);">
+            </div>
+
+            <h1 class="hero-title">PROPERTY & BRIDGING FINANCE LENDER</h1>
+            <p class="hero-subtitle">We provide fast unregulated bridging finance solutions for your short-term lending requirements.</p>
+
+            <div class="navigation-cards">
+                <div class="nav-card">
+                    <div class="nav-card-icon">
+                        <i class="fas fa-calculator"></i>
+                    </div>
+                    <h3 class="nav-card-title">Loan Calculator</h3>
+                    <p class="nav-card-description">
+                        Loan calculations for bridge, term, and development.
+                    </p>
+                    <a href="{{ url_for('calculator_page') }}" class="nav-card-button">
+                        Start Calculating
+                    </a>
                 </div>
-                
-                <h1 class="hero-title">PROPERTY & BRIDGING FINANCE LENDER</h1>
-                <p class="hero-subtitle">We provide fast unregulated bridging finance solutions for your short-term lending requirements.</p>
-                
-                <div class="navigation-cards">
-                    <div class="nav-card">
-                        <div class="nav-card-icon">
-                            <i class="fas fa-calculator"></i>
-                        </div>
-                        <h3 class="nav-card-title">Loan Calculator</h3>
-                        <p class="nav-card-description">
-                            Loan calculations for bridge, term, and development.
-                        </p>
-                        <a href="{{ url_for('calculator_page') }}" class="nav-card-button">
-                            Start Calculating
-                        </a>
-                    </div>
-                    
-                    <div class="nav-card">
-                        <div class="nav-card-icon">
-                            <i class="fas fa-chart-line"></i>
-                        </div>
-                        <h3 class="nav-card-title">Cashbook</h3>
-                        <p class="nav-card-description">
-                            View and manage your loan cashflow.                        </p>
-                        <a href="https://novelluscapital.sharepoint.com/:x:/s/NovellusLending/EcBD97NZVm9InN-BueGjXLoBOPwoKFv0DEGpMhUZu5Olzw?e=ZutCig" class="nav-card-button" target="_blank">
-                            Cashbook Excel
-                        </a>
-                    </div>
-                    
-                    <div class="nav-card">
-                        <div class="nav-card-icon">
-                            <i class="fas fa-chart-bar"></i>
-                        </div>
-                        <h3 class="nav-card-title">Xero</h3>
-                        <p class="nav-card-description">
-                            View and manage Novellus Accounts.
 
-                        </p>
-                        <a href="https://login.xero.com/identity/user/login?ReturnUrl=%2Fidentity%2Fconnect%2Fauthorize%2Fcallback%3Fclient_id%3Dxero_mx_hybrid-web%26redirect_uri%3Dhttps%253A%252F%252Fmy.xero.com%252Fsignin-oidc%26response_mode%3Dform_post%26response_type%3Dcode%2520id_token%26scope%3Dxero_all-apis%2520openid%2520email%2520profile%26state%3DOpenIdConnect.AuthenticationProperties%253DY-gOrxPXDynk0BeIk6zWph3RQA8aa4TMpONPqwahcU-jldogR5Dvs_nflQwV_MFtEoALb-zLknrirq4TBKNnHR1XtOTdmrj2ufMFgbARYoyWKDvg8WYvarIrbPwuDzQQURFujpB5jTpCgd9XOrdkYAsh6MftvpLYszTndFpossYS7qH-em01Rx3lBT5laI11vgEJJVWYW-8LCSGmjENXAPdNW9U%26nonce%3D638895519124272470.NmQwM2UzMWUtMTU5Yi00Y2U2LTgzMTEtZTliMzhhYzNkZmQ4NTY5YjUzYjktMmM5ZC00ODM4LTg5NjktNzU1YzY2ODVhM2Vh%26x-client-SKU%3DID_NET451%26x-client-ver%3D1.3.13.0" class="nav-card-button" target="_blank">
-                            Xero Application
-                        </a>
+                <div class="nav-card">
+                    <div class="nav-card-icon">
+                        <i class="fas fa-chart-line"></i>
                     </div>
-
-                    
-                    <div class="nav-card">
-                        <div class="nav-card-icon">
-                            <i class="fas fa-book"></i>
-                        </div>
-                        <h3 class="nav-card-title">User Manual</h3>
-                        <p class="nav-card-description">
-                            System documentation &nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp&nbsp
-                        </p>
-                        <a href="/user-manual" class="nav-card-button">
-                            View Manual
-                        </a>
-                    </div>
+                    <h3 class="nav-card-title">Cashbook</h3>
+                    <p class="nav-card-description">
+                        View and manage your loan cashflow.
+                    </p>
+                    <a href="https://novelluscapital.sharepoint.com/:x:/s/NovellusLending/EcBD97NZVm9InN-BueGjXLoBOPwoKFv0DEGpMhUZu5Olzw?e=ZutCig" class="nav-card-button" target="_blank">
+                        Cashbook Excel
+                    </a>
                 </div>
-                
-                <div class="features-section">
-                    <div class="feature-list">
-                        <div class="feature-item">
-                            <i class="fas fa-check-circle"></i>
-                            <span>Bridging loan financing in the UK from 500000 to 50m .</span>
-                        </div>
+
+                <div class="nav-card">
+                    <div class="nav-card-icon">
+                        <i class="fas fa-chart-bar"></i>
+                    </div>
+                    <h3 class="nav-card-title">Xero</h3>
+                    <p class="nav-card-description">
+                        View and manage Novellus Accounts.
+                    </p>
+                    <a href="https://login.xero.com/identity/user/login?ReturnUrl=%2Fidentity%2Fconnect%2Fauthorize%2Fcallback%3Fclient_id%3Dxero_mx_hybrid-web%26redirect_uri%3Dhttps%253A%252F%252Fmy.xero.com%252Fsignin-oidc%26response_mode%3Dform_post%26response_type%3Dcode%2520id_token%26scope%3Dxero_all-apis%2520openid%2520email%2520profile%26state%3DOpenIdConnect.AuthenticationProperties%253DY-gOrxPXDynk0BeIk6zWph3RQA8aa4TMpONPqwahcU-jldogR5Dvs_nflQwV_MFtEoALb-zLknrirq4TBKNnHR1XtOTdmrj2ufMFgbARYoyWKDvg8WYvarIrbPwuDzQQURFujpB5jTpCgd9XOrdkYAsh6MftvpLYszTndFpossYS7qH-em01Rx3lBT5laI11vgEJJVWYW-8LCSGmjENXAPdNW9U%26nonce%3D638895519124272470.NmQwM2UzMWUtMTU5Yi00Y2U2LTgzMTEtZTliMzhhYzNkZmQ4NTY5YjUzYjktMmM5ZC00ODM4LTg5NjktNzU1YzY2ODVhM2Vh%26x-client-SKU%3DID_NET451%26x-client-ver%3D1.3.13.0" class="nav-card-button" target="_blank">
+                        Xero Application
+                    </a>
+                </div>
+
+                <div class="nav-card">
+                    <div class="nav-card-icon">
+                        <i class="fas fa-book"></i>
+                    </div>
+                    <h3 class="nav-card-title">User Manual</h3>
+                    <p class="nav-card-description">
+                        System documentation &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                    </p>
+                    <a href="{{ url_for('user_manual') }}" class="nav-card-button">
+                        View Manual
+                    </a>
+                </div>
+            </div>
+
+            <div class="features-section">
+                <div class="feature-list">
+                    <div class="feature-item">
+                        <i class="fas fa-check-circle"></i>
+                        <span>Bridging loan financing in the UK from 500000 to 50m .</span>
                     </div>
                 </div>
             </div>
         </div>
     </div>
+</div>
+{% endblock %}
 
-    <footer class="bg-light py-4">
-        <div class="container">
-            <div class="row row-cols-1 row-cols-md-5 g-2">
-                <div class="col">
-                    <a class="btn btn-info text-white w-100 nav-btn" href="{{ url_for('powerbi_config') }}">
-                        <i class="fas fa-cog me-1"></i>Power BI Configuration
-                    </a>
-                </div>
-                <div class="col">
-                    <a class="btn btn-info text-white w-100 nav-btn" href="{{ url_for('snowflake_config') }}">
-                        <i class="fas fa-database me-1"></i>Snowflake Config
-                    </a>
-                </div>
-                <div class="col">
-                    <a class="btn btn-secondary text-white w-100 nav-btn" href="{{ url_for('user_manual') }}">
-                        <i class="fas fa-book me-1"></i>User Manual
-                    </a>
-                </div>
-                <div class="col">
-                    <a class="btn btn-warning text-dark w-100 nav-btn" href="{{ url_for('scenario_comparison_page') }}">
-                        <i class="fas fa-chart-line me-1"></i>Compare
-                    </a>
-                </div>
-                <div class="col">
-                    <a class="btn btn-maroon text-white w-100 nav-btn" href="{{ url_for('loan_history') }}">
-                        <i class="fas fa-history me-1"></i>History
-                    </a>
-                </div>
-            </div>
-        </div>
-    </footer>
-
-    <!-- Bootstrap JS -->
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    
-    <!-- Custom JavaScript -->
-    <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+{% block scripts %}
+    {{ super() }}
     <script src="{{ url_for('static', filename='js/notifications.js') }}"></script>
-    
     <script>
-        // Landing page specific JavaScript
         document.addEventListener('DOMContentLoaded', function() {
-            // Add smooth scroll animation to cards
             const cards = document.querySelectorAll('.nav-card');
-            
             const observerOptions = {
                 threshold: 0.1,
                 rootMargin: '0px 0px -50px 0px'
             };
-            
             const observer = new IntersectionObserver((entries) => {
                 entries.forEach(entry => {
                     if (entry.isIntersecting) {
-                        entry.target.style.opacity = '1';
-                        entry.target.style.transform = 'translateY(0)';
+                        entry.target.classList.add('visible');
+                        observer.unobserve(entry.target);
                     }
                 });
             }, observerOptions);
-            
-            cards.forEach((card, index) => {
-                card.style.opacity = '0';
-                card.style.transform = 'translateY(50px)';
-                card.style.transition = `all 0.6s ease ${index * 0.1}s`;
-                observer.observe(card);
-            });
+            cards.forEach(card => observer.observe(card));
         });
     </script>
-</body>
-</html>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- Add offcanvas sidebar navigation to `base.html` showing all available routes
- Provide nav routes via context processor and simplify `landing_page`
- Refactor landing page to extend `base.html` and use shared header/footer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install flask selenium` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68ba16d3829883209c2af8c6c9f2da0c