### PR TITLE
Remove custom calculator navbar styling

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -2,8 +2,6 @@
 
 {% block title %}Loan Calculator - Novellus{% endblock %}
 
-{% block body_attr %}class="gold-nav"{% endblock %}
-
 {% block head %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/notifications.css') }}"/>
 <style>


### PR DESCRIPTION
## Summary
- Remove gold-nav body class from calculator template to use base header and footer

## Testing
- `pytest` *(fails: No module named 'selenium', No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ba1cdcf8c0832095ccf6e1d4fa2e73