### PR TITLE
Fix missing base assets on calculator page

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -3,6 +3,7 @@
 {% block title %}Loan Calculator - Novellus{% endblock %}
 
 {% block head %}
+{{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/notifications.css') }}"/>
 <style>
     /* Calculator and results section styling moved to novellus-theme.css */
@@ -1203,6 +1204,7 @@
 {% endblock %}
 
 {% block scripts %}
+{{ super() }}
 <!-- Modern Notification System -->
 <script src="{{ url_for('static', filename='js/notifications.js') }}"></script>
 <script src="{{ url_for('static', filename='js/calculator.js') }}"></script>


### PR DESCRIPTION
## Summary
- Ensure `calculator.html` imports base template assets via `super()` in head and scripts blocks

## Testing
- `pytest -q test_calculator_page.py::test_calculator_page_runs_without_js_errors` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install flask flask_sqlalchemy ...` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1e61ef9c83209563326a55464fe8