### PR TITLE
Change navbar color to #AD965F

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -37,7 +37,7 @@
     {% block head %}{% endblock %}
 </head>
 <body {% block body_attr %}{% endblock %}>
-    <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: #AD965F !important;">
         <div class="container-fluid px-4 d-flex justify-content-between align-items-center">
             <button class="btn btn-outline-light me-3" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu">
                 <i class="fas fa-bars"></i>


### PR DESCRIPTION
## Summary
- Recolor navbar to Novellus gold (#AD965F)

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium'; No module named 'flask')*
- `pip install -r Requirements.txt` *(fails: Could not find a version that satisfies the requirement selenium>=4.34.2; 403 Forbidden)*
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1eda2a0c8320ae4e029074aa3e8b