### PR TITLE
Ensure navbar uses gold background

### DIFF
--- a/static/css/novellus-theme.css
+++ b/static/css/novellus-theme.css
@@ -545,7 +545,8 @@ h4, h5, h6 {
 
 /* Navigation Theme - Override any blue */
 .navbar {
-    background: linear-gradient(135deg, var(--novellus-navy) 0%, var(--novellus-navy-dark) 100%) !important;
+    background-color: #AD965F !important;
+    background-image: none !important;
 }
 
 /* Alternate gold navbar for calculator and loan history pages */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -43,7 +43,8 @@ body {
 
 /* Navigation - Novellus Theme */
 .navbar {
-    background: linear-gradient(135deg, var(--novellus-navy) 0%, var(--primary-color) 0%) !important;
+    background-color: #AD965F !important;
+    background-image: none !important;
     min-height: 60px;
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -37,7 +37,7 @@
     {% block head %}{% endblock %}
 </head>
 <body {% block body_attr %}{% endblock %}>
-    <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: #AD965F !important;">
+    <nav class="navbar navbar-expand-lg navbar-dark">
         <div class="container-fluid px-4 d-flex justify-content-between align-items-center">
             <button class="btn btn-outline-light me-3" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu">
                 <i class="fas fa-bars"></i>


### PR DESCRIPTION
## Summary
- Set default navbar background to gold in style and theme CSS
- Remove inline navbar color from base template to rely on CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium', 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ba20c81ec48320a673f40b1bbd3e5f