### PR TITLE
Ensure navbar uses Novellus gold

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -37,7 +37,7 @@
     {% block head %}{% endblock %}
 </head>
 <body {% block body_attr %}{% endblock %}>
-    <nav class="navbar navbar-expand-lg navbar-dark">
+    <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: #AD965F;">
         <div class="container-fluid px-4 d-flex justify-content-between align-items-center">
             <button class="btn btn-outline-light me-3" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu">
                 <i class="fas fa-bars"></i>


### PR DESCRIPTION
## Summary
- Force navbar background to Novellus gold in base template

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium'; ModuleNotFoundError: No module named 'flask')*
- `pip install flask selenium` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68ba267f798c8320a5ee3f9f1a2af771