### PR TITLE
Display page names in sidebar menu

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -1565,6 +1565,7 @@ def inject_nav_routes():
                 nav_routes.append({
                     "rule": rule.rule,
                     "url": url_for(rule.endpoint),
+                    "name": rule.endpoint.replace('_', ' ').title(),
                 })
             except Exception:
                 continue

--- a/templates/base.html
+++ b/templates/base.html
@@ -77,7 +77,7 @@
         <div class="offcanvas-body">
             <ul class="nav flex-column">
                 {% for route in nav_routes %}
-                <li class="nav-item"><a class="nav-link" href="{{ route.url }}">{{ route.rule }}</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ route.url }}">{{ route.name }}</a></li>
                 {% endfor %}
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- Use route endpoint names to derive human-readable labels for sidebar links
- Show page names instead of URL paths in the sidebar menu

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium'; No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68ba26c44b8c8320b871dd204dc48522