### PR TITLE
Show current page name in sidebar menu label

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -71,7 +71,7 @@
 
     <div class="offcanvas offcanvas-start" tabindex="-1" id="sidebarMenu" aria-labelledby="sidebarMenuLabel">
         <div class="offcanvas-header">
-            <h5 class="offcanvas-title" id="sidebarMenuLabel">Menu</h5>
+            <h5 class="offcanvas-title" id="sidebarMenuLabel">{{ request.endpoint.replace('_', ' ').title() if request.endpoint else 'Menu' }}</h5>
             <button type="button" class="btn-close text-reset" data-bs-dismiss="offcanvas" aria-label="Close"></button>
         </div>
         <div class="offcanvas-body">


### PR DESCRIPTION
## Summary
- Display current page name in the sidebar menu header instead of a static label.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium', ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ba27e6bb14832093f0ca0618977a8e