### PR TITLE
Fix calculator page nav truncation

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -450,7 +450,7 @@
 </style>
 {% endblock %}
 
-{% block main_class %}container-fluid p-0{% endblock %}
+{% block main_class %}container-fluid mt-4 px-4{% endblock %}
 
 {% block content %}
 <h1 class="mb-4">Loan Calculator</h1>


### PR DESCRIPTION
## Summary
- ensure calculator page uses standard container padding to keep navigation bar within viewport

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium'; attempted installation but packages unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2867835483208530cd7ce6ac3273