### PR TITLE
Align calculator EUR color theme with branding

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -14,7 +14,8 @@
     --light-color: #f8f9fa;
     --dark-color: #212529;
     --gbp-color: #AD965F;
-    --eur-color: #509195;
+    /* Updated EUR theme to use green palette */
+    --eur-color: #509664;
     --font-family: 'Brother1816', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     --border-radius: 0.375rem;
     --box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075);
@@ -61,8 +62,9 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .btn-eur:hover {
-    background-color: #467e82;
-    border-color: #467e82;
+    /* Darker shade for EUR hover state */
+    background-color: #3d7450;
+    border-color: #3d7450;
     color: white;
 }
 

--- a/static/js/currency-theme-simple.js
+++ b/static/js/currency-theme-simple.js
@@ -47,7 +47,8 @@ class SimpleCurrencyTheme {
     updateButtons(currency) {
         const colors = {
             'GBP': { primary: '#AD965F', dark: '#AD965F' },
-            'EUR': { primary: '#509195', dark: '#509195' }
+            // Updated EUR palette to match green branding
+            'EUR': { primary: '#509664', dark: '#3d7450' }
         };
         
         const color = colors[currency];
@@ -98,7 +99,8 @@ class SimpleCurrencyTheme {
     updateThemeElements(currency) {
         const colors = {
             'GBP': { primary: '#AD965F', dark: '#AD965F' },
-            'EUR': { primary: '#509664', dark: '#509195' }
+            // Use consistent green tones for EUR elements
+            'EUR': { primary: '#509664', dark: '#3d7450' }
         };
         
         const color = colors[currency];


### PR DESCRIPTION
## Summary
- use consistent green palette when EUR is selected
- update button hover styling and theme manager colors

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium'; ModuleNotFoundError: No module named 'flask')*
- `pip install flask selenium` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2b59e9388320a075b3289997f9ff