### PR TITLE
Simplify navbar to home and refresh

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -37,7 +37,7 @@
     {% block head %}{% endblock %}
 </head>
 <body {% block body_attr %}{% endblock %}>
-    <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: #AD965F;">
+    <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: black;">
         <div class="container-fluid px-4 d-flex justify-content-between align-items-center">
             <button class="btn btn-outline-light me-3" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu">
                 <i class="fas fa-bars"></i>
@@ -51,18 +51,10 @@
                 {% block nav_heading %}{% endblock %}
             </div>
             <div class="d-flex ms-auto gap-2">
-                {% set nav_text_class = 'text-black' if request.endpoint in ['calculator_page', 'loan_history'] else '' %}
-
-                <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('loan_history') }}">
-                    <i class="fas fa-history me-1"></i>Loan History
-                </a>
-                <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('calculator_page') }}">
-                    <i class="fas fa-calculator me-1"></i>Calculator
-                </a>
-                <a class="btn btn-nav {{ nav_text_class }}" href="#" onclick="window.location.reload(); return false;">
+                <a class="btn text-white" style="background-color: black;" href="#" onclick="window.location.reload(); return false;">
                     <i class="fas fa-sync-alt me-1"></i>Refresh
                 </a>
-                <a class="btn btn-nav {{ nav_text_class }}" href="{{ url_for('landing_page') }}">
+                <a class="btn text-white" style="background-color: black;" href="{{ url_for('landing_page') }}">
                     <i class="fas fa-home me-1"></i>Home
                 </a>
             </div>


### PR DESCRIPTION
## Summary
- Keep only Refresh and Home buttons in navigation bar
- Switch navbar background to black with white text

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium'; No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ba2fa0c2bc8320a2404fdc789ad922