### PR TITLE
Align configuration pages with landing theme

### DIFF
--- a/templates/powerbi_config.html
+++ b/templates/powerbi_config.html
@@ -2,9 +2,9 @@
 
 {% block title %}Power BI Configuration{% endblock %}
 
-{% block body_attr %}class="gold-nav" data-theme="document"{% endblock %}
 
 {% block head %}
+{{ super() }}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/notifications.css') }}">
 <script src="{{ url_for('static', filename='js/notifications.js') }}"></script>
 <style>

--- a/templates/scenario_comparison.html
+++ b/templates/scenario_comparison.html
@@ -2,12 +2,9 @@
 
 {% block title %}One-Click Scenario Comparison - Novellus Loan Management{% endblock %}
 
-{% block body_attr %}class="gold-nav" data-theme="document"{% endblock %}
 
 {% block head %}
 {{ super() }}
-<link href="{{ url_for('static', filename='css/novellus-theme.css') }}" rel="stylesheet"/>
-<link href="{{ url_for('static', filename='css/currency-themes.css') }}" rel="stylesheet"/>
     <style>
         .scenario-card {
             border: 2px solid #e9ecef;

--- a/templates/snowflake_config.html
+++ b/templates/snowflake_config.html
@@ -2,7 +2,6 @@
 
 {% block title %}Snowflake Configuration{% endblock %}
 
-{% block body_attr %}class="gold-nav" data-theme="document"{% endblock %}
 
 {% block content %}
 <div class="container py-4">

--- a/templates/user_manual.html
+++ b/templates/user_manual.html
@@ -2,9 +2,9 @@
 
 {% block title %}User Manual - Novellus Loan Management{% endblock %}
 
-{% block body_attr %}class="gold-nav" data-theme="document"{% endblock %}
 
 {% block head %}
+{{ super() }}
 <!-- Markdown to HTML JavaScript -->
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <!-- Highlight.js for code syntax highlighting -->


### PR DESCRIPTION
## Summary
- Remove redundant theme links and body attributes from Scenario Comparison page
- Simplify Snowflake, Power BI, and User Manual pages to rely on landing theme

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium', No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ba3230f6fc8320a3baf95d0ce209a1