### PR TITLE
Center navbar headings

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -75,6 +75,14 @@ body {
 }
 
 /* Navbar heading */
+.navbar-title {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+}
+
 .navbar-title .navbar-text {
     font-size: 1.25rem;
     font-weight: 500;

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,7 +38,7 @@
 </head>
 <body {% block body_attr %}{% endblock %}>
     <nav class="navbar navbar-expand-lg navbar-dark border border-dark" style="background-color: black;">
-        <div class="container-fluid px-4 d-flex justify-content-between align-items-center">
+        <div class="container-fluid px-4 d-flex justify-content-between align-items-center position-relative">
             <button class="btn btn-outline-light me-3" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu">
                 <i class="fas fa-bars"></i>
             </button>
@@ -47,7 +47,7 @@
                 <span class="fw-bold"></span>
             </a>
 
-            <div class="navbar-title mx-auto">
+            <div class="navbar-title">
                 {% block nav_heading %}{% endblock %}
             </div>
             <div class="d-flex ms-auto gap-2">


### PR DESCRIPTION
## Summary
- Center navbar titles across pages
- Add CSS rules to absolutely center navigation heading

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium'; also missing Flask)*


------
https://chatgpt.com/codex/tasks/task_e_68ba948d532083209eb783df0660d1fb