### PR TITLE
Refine sidebar navigation

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -89,6 +89,28 @@ body {
     color: rgba(255, 255, 255, 0.9);
 }
 
+/* Sidebar navigation */
+#sidebarMenu {
+    --bs-offcanvas-width: 300px; /* 25% reduction from default width */
+}
+
+#sidebarMenu .nav-link {
+    font-size: 1.1rem; /* increase font size of list items */
+}
+
+#sidebarMenu .nav-link:hover,
+#sidebarMenu .nav-link:focus,
+#sidebarMenu .nav-link.active {
+    background-color: var(--primary-color);
+    color: #fff !important;
+}
+
+#sidebarMenu .nav-link:hover i,
+#sidebarMenu .nav-link:focus i,
+#sidebarMenu .nav-link.active i {
+    color: #fff !important;
+}
+
 /* Cards - Updated for Novellus Theme (moved to novellus-theme.css) */
 
 /* Buttons - Novellus Theme */

--- a/templates/base.html
+++ b/templates/base.html
@@ -69,7 +69,7 @@
             <ul class="nav flex-column">
                 {% for route in nav_routes %}
                 <li class="nav-item">
-                    <a class="nav-link d-flex align-items-center text-black" href="{{ route.url }}">
+                    <a class="nav-link d-flex align-items-center text-black{% if request.path == route.url %} active{% endif %}" href="{{ route.url }}">
                         <i class="{{ route.icon }} me-2 text-black"></i>{{ route.name }}
                     </a>
                 </li>


### PR DESCRIPTION
## Summary
- Enlarge sidebar menu font and reduce offcanvas width
- Highlight hovered and active items with persistent active state

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install flask selenium` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9b33272883209d6b72a4d09c3ba5