### PR TITLE
Add Novellus purple borders to nav and footer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -37,8 +37,8 @@
     {% block head %}{% endblock %}
 </head>
 <body {% block body_attr %}{% endblock %}>
-    <header class="border border-dark">
-    <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: black;">
+    <header>
+    <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: black; border-bottom: 5px solid #AB80B5;">
         <div class="container-fluid px-4 d-flex justify-content-between align-items-center position-relative">
             <button class="btn btn-outline-light me-3" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu">
                 <i class="fas fa-bars"></i>
@@ -93,7 +93,7 @@
         {% block content %}{% endblock %}
     </main>
 
-    <footer class="bg-light mt-5 py-4 border border-dark">
+    <footer class="bg-light mt-5 py-4" style="border-top: 5px solid #AB80B5;">
         <div class="container-fluid px-4">
             <div class="row align-items-center">
                 <div class="col-md-6 text-center text-md-start">


### PR DESCRIPTION
## Summary
- Use Novellus purple for a bold bottom border on navigation bar
- Add matching top border to footer

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium'; No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ba9c069cd48320b9097f906d1a2734