### PR TITLE
Improve term loan visibility in loan history

### DIFF
--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -227,7 +227,8 @@ class LoanHistoryManager {
 
         this.filteredLoans = this.loans.filter(loan => {
             const matchesSearch = loan.loan_name.toLowerCase().includes(searchTerm);
-            const matchesType = !loanTypeFilter || loan.loan_type.toLowerCase() === loanTypeFilter;
+            const normalizedType = this.normalizeLoanType(loan.loan_type);
+            const matchesType = !loanTypeFilter || normalizedType === loanTypeFilter;
             const loanOrg = loan.currency === 'EUR' ? 'Novellus Finance limited' : 'Novellus Limited';
             const matchesOrg = !orgFilter || loanOrg === orgFilter;
             return matchesSearch && matchesType && matchesOrg;
@@ -877,7 +878,10 @@ class LoanHistoryManager {
             case 'bridge':
                 return 'bg-warning bg-opacity-25 text-dark';
             case 'term':
-                return 'bg-info bg-opacity-25 text-dark';
+            case 'term loan':
+            case 'term_loan':
+            case 'termloan':
+                return 'bg-light text-dark border border-info';
             case 'development':
             case 'development2':
                 return 'bg-success bg-opacity-25 text-dark';
@@ -888,10 +892,24 @@ class LoanHistoryManager {
 
     formatLoanType(type) {
         const lower = type.toLowerCase();
+        if (lower.startsWith('term')) {
+            return 'Term';
+        }
         if (lower === 'development2' || lower === 'development') {
             return 'Development';
         }
         return lower.charAt(0).toUpperCase() + lower.slice(1);
+    }
+
+    normalizeLoanType(type) {
+        const lower = type.toLowerCase();
+        if (lower.startsWith('term')) {
+            return 'term';
+        }
+        if (lower.startsWith('development')) {
+            return 'development2';
+        }
+        return lower;
     }
 
     formatRepaymentOption(option) {


### PR DESCRIPTION
## Summary
- Ensure term loans display with a light badge and dark text for readability
- Normalize loan type values for filtering and display so "term" variants appear correctly

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium' and 'flask')*
- `pip install flask selenium` *(fails: Could not find a version that satisfies the requirement flask – 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9d200f808320b5bde44260a594e5