### PR TITLE
style: darken layout borders

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -38,7 +38,7 @@
 </head>
 <body {% block body_attr %}{% endblock %}>
     <header>
-    <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: black; border-bottom: 5px solid #AB80B5;">
+    <nav class="navbar navbar-expand-lg navbar-dark" style="background-color: black; border-bottom: 5px solid darkgrey;">
         <div class="container-fluid px-4 d-flex justify-content-between align-items-center position-relative">
             <button class="btn btn-outline-light me-3" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarMenu" aria-controls="sidebarMenu">
                 <i class="fas fa-bars"></i>
@@ -93,7 +93,7 @@
         {% block content %}{% endblock %}
     </main>
 
-    <footer class="bg-light mt-5 py-4" style="border-top: 5px solid #AB80B5;">
+    <footer class="bg-light mt-5 py-4" style="border-top: 5px solid darkgrey;">
         <div class="container-fluid px-4">
             <div class="row align-items-center">
                 <div class="col-md-6 text-center text-md-start">


### PR DESCRIPTION
## Summary
- use dark grey bottom border on the navigation bar
- use dark grey top border on the footer bar

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium'; No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68baa648d03c832084797c0bb043698f