### PR TITLE
Use Brother 1816 as default Chart.js font

### DIFF
--- a/static/js/chart-enhancements.js
+++ b/static/js/chart-enhancements.js
@@ -4,7 +4,7 @@
  */
 
 // Global Chart.js configurations with bigger fonts for better visibility
-Chart.defaults.font.family = "'Brother1816', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif";
+Chart.defaults.font.family = "'Brother 1816', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif";
 Chart.defaults.font.size = 16; // Increased from default 12 to 16
 Chart.defaults.color = '#495057';
 

--- a/static/js/charts.js
+++ b/static/js/charts.js
@@ -590,7 +590,7 @@ class ChartManager {
 window.chartManager = new ChartManager();
 
 // Chart.js default configuration
-Chart.defaults.font.family = "'Brother1816', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif";
+Chart.defaults.font.family = "'Brother 1816', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif";
 Chart.defaults.color = '#495057';
 Chart.defaults.plugins.legend.labels.usePointStyle = true;
 Chart.defaults.plugins.tooltip.backgroundColor = 'rgba(0, 0, 0, 0.8)';


### PR DESCRIPTION
## Summary
- Use "Brother 1816" font for Chart.js defaults in enhancement utilities
- Apply "Brother 1816" font to general Chart.js configuration

## Testing
- `node - <<'NODE'
... ...
NODE`
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install flask selenium` *(fails: Could not find a version that satisfies the requirement flask (from versions: none))*

------
https://chatgpt.com/codex/tasks/task_e_68baa6b89c8c8320aa1f7d6b5176d847