### PR TITLE
Refactor summary card generation

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -142,6 +142,8 @@
         padding: 1rem;
         text-align: center;
         color: #fff;
+        height: 100%;
+        background-color: var(--primary-color);
     }
 
     .summary-card .summary-value {
@@ -155,10 +157,6 @@
         font-weight: 500;
     }
 
-    .bg-purple {
-        background-color: #6f42c1 !important;
-    }
-    
     /* Better spacing for wide screens */
     @media (min-width: 1200px) {
         .calculator-section {


### PR DESCRIPTION
## Summary
- Map loan and repayment combinations to summary card descriptors, showing formulas, inputs, derived values and outputs
- Style summary cards with the active currency theme color to fix EUR/GBP mismatches

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'selenium'; No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68baaee8ecd48320a9ab9f9b47e0d529