### PR TITLE
Shrink calculation breakdown modal cards

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -2999,13 +2999,13 @@ class LoanCalculator {
         const renderSection = (title, items) => {
             if (!items || items.length === 0) return '';
             const cards = items.map(i => `
-                <div class="col-md-4 col-sm-6">
+                <div class="col-lg-2 col-md-3 col-sm-4 col-6">
                     <div class="summary-card" data-currency="${currencyCode}">
                         <div class="summary-value">${i.value}</div>
                         <div class="summary-label">${i.label}</div>
                     </div>
                 </div>`).join('');
-            return `<h6 class="mt-3">${title}</h6><div class="row g-2 mb-2">${cards}</div>`;
+            return `<h6 class="mt-2">${title}</h6><div class="row g-1 mb-1">${cards}</div>`;
         };
 
         modalBody.innerHTML =

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -139,22 +139,26 @@
     /* Summary cards in calculation breakdown modal */
     .summary-card {
         border-radius: 10px;
-        padding: 1rem;
+        padding: 0.5rem;
         text-align: center;
         color: #fff;
-        height: 100%;
         background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%);
     }
 
     .summary-card .summary-value {
-        font-size: 1.1rem;
+        font-size: 0.9rem;
         font-weight: 700;
-        margin-bottom: 4px;
+        margin-bottom: 2px;
     }
 
     .summary-card .summary-label {
-        font-size: 0.8rem;
+        font-size: 0.7rem;
         font-weight: 500;
+    }
+
+    #calculationBreakdownModal .modal-body {
+        max-height: none;
+        overflow-y: visible;
     }
 
     .bg-purple {
@@ -1156,7 +1160,7 @@
 
 <!-- Calculation Breakdown Modal -->
 <div class="modal fade" id="calculationBreakdownModal" tabindex="-1" aria-labelledby="calculationBreakdownLabel" aria-hidden="true">
-    <div class="modal-dialog modal-fullscreen modal-dialog-scrollable">
+    <div class="modal-dialog modal-fullscreen">
         <div class="modal-content">
             <div class="modal-header" id="calculationBreakdownHeader" data-currency="GBP" style="background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%); color: white;">
                 <h5 class="modal-title" id="calculationBreakdownLabel"></h5>


### PR DESCRIPTION
## Summary
- Reduce summary card padding and font sizes
- Remove scroll from calculation breakdown modal
- Display more summary cards per row for compact layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium'; ModuleNotFoundError: No module named 'flask')*
- `pip install -r Requirements.txt` *(fails: 403 Forbidden for selenium package)*

------
https://chatgpt.com/codex/tasks/task_e_68bac51dc7d0832083e86d1c8f15204d