### PR TITLE
Update View Details modal to respect currency theme

### DIFF
--- a/static/css/currency-themes.css
+++ b/static/css/currency-themes.css
@@ -138,7 +138,7 @@
 [data-currency="GBP"] .table thead th,
 [data-currency="GBP"] .card-header,
 [data-currency="GBP"] .bg-primary {
-    background-color: #AD965F !important;
+    background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%) !important;
     border: 2px solid #000000 !important;
     color: white !important;
 }
@@ -146,7 +146,7 @@
 [data-currency="EUR"] .table thead th,
 [data-currency="EUR"] .card-header,
 [data-currency="EUR"] .bg-primary {
-    background-color: #509664 !important;
+    background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%) !important;
     border: 2px solid #000000 !important;
     color: white !important;
 }

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -893,9 +893,9 @@
 <div id="calculationResultsSection">
 <!-- Summary Table (Loan Summary Format) -->
 <div class="card">
-<div class="card-header d-flex align-items-center" data-currency="GBP" style="background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%); color: white; font-weight: bold; border: 1px solid #000;">
+<div class="card-header d-flex align-items-center bg-primary text-white fw-bold border border-dark" data-currency="GBP">
                     <span class="flex-grow-1 text-center">Loan Summary</span>
-                    <button type="button" class="btn btn-sm btn-light ms-2" id="viewBreakdownBtn" data-bs-toggle="modal" data-bs-target="#calculationBreakdownModal">View Details</button>
+                    <button type="button" class="btn btn-sm btn-primary ms-2" id="viewBreakdownBtn" data-bs-toggle="modal" data-bs-target="#calculationBreakdownModal">View Details</button>
                     <div class="dropdown ms-2">
                         <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="openReportsBtn" data-bs-toggle="dropdown" aria-expanded="false" disabled>Reports</button>
                         <ul class="dropdown-menu" aria-labelledby="openReportsBtn" id="reportDropdownMenu"></ul>
@@ -1162,7 +1162,7 @@
 <div class="modal fade" id="calculationBreakdownModal" tabindex="-1" aria-labelledby="calculationBreakdownLabel" aria-hidden="true">
     <div class="modal-dialog modal-fullscreen">
         <div class="modal-content">
-            <div class="modal-header" id="calculationBreakdownHeader" data-currency="GBP" style="background: linear-gradient(135deg, var(--primary-color) 0%, var(--secondary-color) 100%); color: white;">
+            <div class="modal-header bg-primary text-white" id="calculationBreakdownHeader" data-currency="GBP">
                 <h5 class="modal-title" id="calculationBreakdownLabel"></h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>


### PR DESCRIPTION
## Summary
- Style Loan Summary header and View Details button with theme-aware classes
- Apply currency-based gradient styling for headers and modal

## Testing
- `pytest` *(fails: No module named 'selenium', No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68bac6b92cf48320a5261e92d847f82a