### PR TITLE
Fix misaligned summary header

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -893,12 +893,14 @@
 <div id="calculationResultsSection">
 <!-- Summary Table (Loan Summary Format) -->
 <div class="card">
-<div class="card-header d-flex align-items-center bg-primary text-white fw-bold border border-dark" data-currency="GBP">
-                    <span class="flex-grow-1 text-center">Loan Summary</span>
-                    <button type="button" class="btn btn-sm btn-primary ms-2" id="viewBreakdownBtn" data-bs-toggle="modal" data-bs-target="#calculationBreakdownModal">View Details</button>
-                    <div class="dropdown ms-2">
-                        <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="openReportsBtn" data-bs-toggle="dropdown" aria-expanded="false" disabled>Reports</button>
-                        <ul class="dropdown-menu" aria-labelledby="openReportsBtn" id="reportDropdownMenu"></ul>
+<div class="card-header bg-primary text-white fw-bold border border-dark position-relative text-center" data-currency="GBP">
+                    Loan Summary
+                    <div class="position-absolute top-50 end-0 translate-middle-y d-flex">
+                        <button type="button" class="btn btn-sm btn-primary me-2" id="viewBreakdownBtn" data-bs-toggle="modal" data-bs-target="#calculationBreakdownModal">View Details</button>
+                        <div class="dropdown">
+                            <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="openReportsBtn" data-bs-toggle="dropdown" aria-expanded="false" disabled>Reports</button>
+                            <ul class="dropdown-menu" aria-labelledby="openReportsBtn" id="reportDropdownMenu"></ul>
+                        </div>
                     </div>
                 </div>
 <div class="card-body p-0">


### PR DESCRIPTION
## Summary
- restore centered `Loan Summary` header with actions aligned right

## Testing
- `pytest` *(fails: No module named 'selenium', No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68bac8df39b883209af09acf4b40a533