### PR TITLE
Fix report dropdown placement

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -893,14 +893,12 @@
 <div id="calculationResultsSection">
 <!-- Summary Table (Loan Summary Format) -->
 <div class="card">
-<div class="card-header bg-primary text-white fw-bold border border-dark position-relative text-center" data-currency="GBP">
-                    Loan Summary
-                    <div class="position-absolute top-50 end-0 translate-middle-y d-flex">
-                        <button type="button" class="btn btn-sm btn-primary me-2" id="viewBreakdownBtn" data-bs-toggle="modal" data-bs-target="#calculationBreakdownModal">View Details</button>
-                        <div class="dropdown">
-                            <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="openReportsBtn" data-bs-toggle="dropdown" aria-expanded="false" disabled>Reports</button>
-                            <ul class="dropdown-menu" aria-labelledby="openReportsBtn" id="reportDropdownMenu"></ul>
-                        </div>
+<div class="card-header d-flex align-items-center bg-primary text-white fw-bold border border-dark" data-currency="GBP">
+                    <span class="flex-grow-1 text-center">Loan Summary</span>
+                    <button type="button" class="btn btn-sm btn-primary ms-2" id="viewBreakdownBtn" data-bs-toggle="modal" data-bs-target="#calculationBreakdownModal">View Details</button>
+                    <div class="dropdown ms-2">
+                        <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="openReportsBtn" data-bs-toggle="dropdown" aria-expanded="false" disabled>Reports</button>
+                        <ul class="dropdown-menu" aria-labelledby="openReportsBtn" id="reportDropdownMenu"></ul>
                     </div>
                 </div>
 <div class="card-body p-0">


### PR DESCRIPTION
## Summary
- Restore flex layout for calculator summary header
- Keep View Details as a button and align Reports dropdown inside header

## Testing
- `pytest -q` *(fails: No module named 'selenium'; No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68bacb750bd083209f590fa38b9fd59e