### PR TITLE
Align loan summary header buttons

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -893,12 +893,14 @@
 <div id="calculationResultsSection">
 <!-- Summary Table (Loan Summary Format) -->
 <div class="card">
-<div class="card-header d-flex align-items-center bg-primary text-white fw-bold border border-dark" data-currency="GBP">
-                    <span class="flex-grow-1 text-center">Loan Summary</span>
-                    <button type="button" class="btn btn-sm btn-primary ms-2" id="viewBreakdownBtn" data-bs-toggle="modal" data-bs-target="#calculationBreakdownModal">View Details</button>
-                    <div class="dropdown ms-2">
-                        <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="openReportsBtn" data-bs-toggle="dropdown" aria-expanded="false" disabled>Reports</button>
-                        <ul class="dropdown-menu" aria-labelledby="openReportsBtn" id="reportDropdownMenu"></ul>
+<div class="card-header d-flex justify-content-center align-items-center position-relative bg-primary text-white fw-bold border border-dark" data-currency="GBP">
+                    <span>Loan Summary</span>
+                    <div class="position-absolute top-50 end-0 translate-middle-y d-flex">
+                        <button type="button" class="btn btn-sm btn-light me-2" id="viewBreakdownBtn" data-bs-toggle="modal" data-bs-target="#calculationBreakdownModal">View Details</button>
+                        <div class="dropdown">
+                            <button class="btn btn-sm btn-light dropdown-toggle" type="button" id="openReportsBtn" data-bs-toggle="dropdown" aria-expanded="false" disabled>Reports</button>
+                            <ul class="dropdown-menu" aria-labelledby="openReportsBtn" id="reportDropdownMenu"></ul>
+                        </div>
                     </div>
                 </div>
 <div class="card-body p-0">


### PR DESCRIPTION
## Summary
- Recenter Loan Summary table header and place View Details and Reports buttons side by side.
- Style View Details as a light button to match Reports while keeping it enabled before saving.

## Testing
- `pytest test_calculator_page.py test_calculation_breakdown_term_label.py` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium` *(fails: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68bace4b60908320aef46bc1e872c298