### PR TITLE
style: restyle refresh button

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -52,9 +52,9 @@
                 {% block nav_heading %}{% endblock %}
             </div>
             <div class="d-flex ms-auto gap-2">
-                <a class="btn text-white" style="background-color: black;" href="#" onclick="window.location.reload(); return false;">
+                <button type="button" class="btn btn-sm btn-light" onclick="window.location.reload();">
                     <i class="fas fa-sync-alt me-1"></i>Refresh
-                </a>
+                </button>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
## Summary
- restyle refresh button to match 'View Details' style while keeping refresh icon

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68bad0589e48832090a094bbc9d68f9b