### PR TITLE
Fix EUR calculator toggle button color

### DIFF
--- a/static/css/currency-themes.css
+++ b/static/css/currency-themes.css
@@ -402,8 +402,8 @@ body[data-currency="EUR"] .btn-success {
 
 [data-currency="EUR"] .btn-group .btn-outline-secondary,
 [data-currency="EUR"] .btn-group .btn-outline-primary {
-    border-color: #42B89A !important;
-    color: #42B89A !important;
+    border-color: #509664 !important;
+    color: #509664 !important;
 }
 
 [data-currency="EUR"] .btn-group .btn-outline-secondary:hover,
@@ -412,8 +412,8 @@ body[data-currency="EUR"] .btn-success {
 [data-currency="EUR"] .btn-group .btn-outline-primary.active,
 [data-currency="EUR"] .btn-group .btn-check:checked + .btn-outline-secondary,
 [data-currency="EUR"] .btn-group .btn-check:checked + .btn-outline-primary {
-    background-color: #42B89A !important;
-    border-color: #42B89A !important;
+    background-color: #509664 !important;
+    border-color: #509664 !important;
     color: white !important;
 }
   
@@ -438,15 +438,15 @@ body[data-currency="EUR"] .btn-success {
 }
 
 [data-currency="EUR"] .btn-outline-secondary {
-    border-color: #42B89A !important;
-    color: #42B89A !important;
+    border-color: #509664 !important;
+    color: #509664 !important;
 }
 
 [data-currency="EUR"] .btn-outline-secondary:hover,
 [data-currency="EUR"] .btn-outline-secondary.active,
 [data-currency="EUR"] .btn-check:checked + .btn-outline-secondary {
-    background-color: #42B89A !important;
-    border-color: #42B89A !important;
+    background-color: #509664 !important;
+    border-color: #509664 !important;
     color: white !important;
 }
 
@@ -458,8 +458,8 @@ body[data-currency="EUR"] .btn-success {
 }
 
 .currency-eur-btn {
-    background-color: #42B89A !important;
-    border-color: #42B89A !important;
+    background-color: #509664 !important;
+    border-color: #509664 !important;
     color: white !important;
 }
 


### PR DESCRIPTION
## Summary
- Ensure EUR currency toggles and buttons use green `#509664` instead of lighter teal

## Testing
- `pip install selenium -q` *(failed: proxy 403)*
- `pytest test_calculator_page.py::test_development_loan_disables_gross_amount -q` *(missing selenium)*
- `pytest test_database_url.py -q` *(skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bad2b0be3083209265b5517811b85c