### PR TITLE
Invert 360-day toggle visibility

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -1668,11 +1668,11 @@ class LoanCalculator {
             const threshold = includesLeapDay(start, end) ? 366 : 365;
 
             if (daysDiff > threshold) {
-                use360DaysSection.style.display = 'block';
-            } else {
                 use360DaysSection.style.display = 'none';
                 const checkbox = document.getElementById('use360Days');
                 if (checkbox) checkbox.checked = false;
+            } else {
+                use360DaysSection.style.display = 'block';
             }
         } catch (error) {
             console.error('Error in update360DayVisibility:', error);


### PR DESCRIPTION
## Summary
- Hide 360-day interest option for loans longer than 12 months and show it for shorter terms
- Clear the 360-day checkbox whenever the section is hidden

## Testing
- `pytest test_calculator_term_end_date_toggle.py` *(fails: No module named 'selenium')*
- Manual DOM simulation for loan terms below and above 12 months

------
https://chatgpt.com/codex/tasks/task_e_68badd4caef483208de1d69bb7999393