### PR TITLE
Store scenario comparison server-side to keep session small

### DIFF
--- a/test_scenario_comparison_session_size.py
+++ b/test_scenario_comparison_session_size.py
@@ -1,0 +1,29 @@
+import pytest
+from app import app
+
+
+def test_scenario_comparison_session_size():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        payload = {
+            "scenarios": [
+                {
+                    "name": "Scenario 1",
+                    "parameters": {
+                        "loan_type": "bridge",
+                        "gross_amount": 100000,
+                        "loan_term": 12,
+                        "interest_rate": 0.05
+                    }
+                }
+            ]
+        }
+        response = client.post('/api/scenario-comparison/create', json=payload)
+        assert response.status_code == 200
+        with client.session_transaction() as sess:
+            assert 'scenario_comparison_id' in sess
+            assert 'scenario_comparison' not in sess
+        cookie_name = app.config.get('SESSION_COOKIE_NAME', 'session')
+        cookie = next((c for c in client.cookie_jar if c.name == cookie_name), None)
+        assert cookie is not None
+        assert len(cookie.value) < 4093


### PR DESCRIPTION
## Summary
- keep scenario comparison data server-side and store only an ID in the session
- update export endpoint to look up comparison data by ID
- add regression test ensuring scenario comparison doesn't bloat session cookies

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install --quiet .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bafb510a9483209ab08121ada0a484