### PR TITLE
Ensure loan term and end date validations

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -388,7 +388,7 @@ class LoanCalculator:
         gross_amount = Decimal(str(params.get('gross_amount', 0)))
         net_amount = Decimal(str(params.get('net_amount', 0)))
         property_value = Decimal(str(params.get('property_value', 0)))
-        loan_term = int(params.get('loan_term', 12))
+        loan_term = max(1, int(params.get('loan_term', 12)))
         # Get interest rate from either parameter name
         interest_rate = Decimal(str(params.get('annual_rate', params.get('interest_rate', 0))))
         repayment_option = params.get('repayment_option', 'none')
@@ -434,6 +434,9 @@ class LoanCalculator:
 
         if end_date_str:
             end_date = datetime.strptime(end_date_str, '%Y-%m-%d') if isinstance(end_date_str, str) else end_date_str
+            if end_date < start_date:
+                end_date = start_date
+                end_date_str = end_date.strftime('%Y-%m-%d')
             loan_term_days = (end_date - start_date).days + 1
             try:
                 rd = relativedelta(end_date + timedelta(days=1), start_date)
@@ -816,7 +819,7 @@ class LoanCalculator:
         gross_amount = Decimal(str(params.get('gross_amount', 0)))
         net_amount = Decimal(str(params.get('net_amount', 0)))
         property_value = Decimal(str(params.get('property_value', 0)))
-        loan_term = int(params.get('loan_term', 12))
+        loan_term = max(1, int(params.get('loan_term', 12)))
         # Get interest rate from either parameter name
         interest_rate = Decimal(str(params.get('annual_rate', params.get('interest_rate', 0))))
         repayment_option = params.get('repayment_option', 'service_only')
@@ -848,6 +851,9 @@ class LoanCalculator:
 
         if end_date_str:
             end_date = datetime.strptime(end_date_str, '%Y-%m-%d') if isinstance(end_date_str, str) else end_date_str
+            if end_date < start_date:
+                end_date = start_date
+                end_date_str = end_date.strftime('%Y-%m-%d')
             loan_term_days = (end_date - start_date).days + 1
             try:
                 rd = relativedelta(end_date + timedelta(days=1), start_date)
@@ -1079,13 +1085,16 @@ class LoanCalculator:
         
         start_date_str = params.get('start_date', '2025-07-24')
         end_date_str = params.get('end_date')
-        loan_term = int(params.get('loan_term', 18))
+        loan_term = max(1, int(params.get('loan_term', 18)))
 
         # Parse start date
         start_date = datetime.strptime(start_date_str, '%Y-%m-%d') if isinstance(start_date_str, str) else start_date_str
 
         if end_date_str:
             end_date = datetime.strptime(end_date_str, "%Y-%m-%d")
+            if end_date < start_date:
+                end_date = start_date
+                end_date_str = end_date.strftime('%Y-%m-%d')
             actual_days = (end_date - start_date).days + 1
             rd = relativedelta(end_date + timedelta(days=1), start_date)
             total_term_months = rd.years * 12 + rd.months + (1 if rd.days > 0 else 0)
@@ -1338,7 +1347,7 @@ class LoanCalculator:
         
         # Calculate other values for frontend
         property_value = float(params.get('property_value', 2000000))
-        loan_term = int(params.get('loan_term', 18))
+        loan_term = max(1, int(params.get('loan_term', 18)))
         loan_term_days = int(params.get("loan_term_days", 0))
         ltv = (gross_amount_solution / property_value * 100) if property_value > 0 else 0
 
@@ -1535,7 +1544,7 @@ class LoanCalculator:
         currency = params.get('currency', 'GBP')
         net_amount = Decimal(str(params.get('net_amount', 0)))
         property_value = Decimal(str(params.get('property_value', 0)))
-        loan_term = int(params.get('loan_term', 12))
+        loan_term = max(1, int(params.get('loan_term', 12)))
         # Get interest rate from various possible parameter names
         annual_rate = Decimal(str(params.get('annual_rate', params.get('interest_rate', 0))))
         repayment_option = params.get('repayment_option', 'none')  # Default to retained interest
@@ -3589,7 +3598,7 @@ class LoanCalculator:
             from datetime import datetime, timedelta
             from dateutil.relativedelta import relativedelta
             
-            loan_term = int(params.get('loan_term', 0))
+            loan_term = max(1, int(params.get('loan_term', 0)))
             start_date_str = params.get('start_date', '')
             end_date_str = params.get('end_date', '')
             
@@ -3938,7 +3947,7 @@ class LoanCalculator:
         
         repayment_option = quote_data.get('repaymentOption', quote_data.get('repayment_option', 'none'))
         gross_amount = Decimal(str(quote_data.get('grossAmount', quote_data.get('gross_amount', 0))))
-        loan_term = int(quote_data.get('loanTerm', quote_data.get('loan_term', 12)))
+        loan_term = max(1, int(quote_data.get('loanTerm', quote_data.get('loan_term', 12))))
         # Accept both legacy and new field names for interest rate
         annual_rate = Decimal(
             str(
@@ -4238,7 +4247,7 @@ class LoanCalculator:
         repayment_option = params.get('repayment_option', 'none')
         # Try multiple field names for gross_amount
         gross_amount = Decimal(str(calculation.get('grossAmount', calculation.get('gross_amount', params.get('gross_amount', 0)))))
-        loan_term = int(calculation.get('loanTerm', calculation.get('loan_term', params.get('loan_term', 12))))
+        loan_term = max(1, int(calculation.get('loanTerm', calculation.get('loan_term', params.get('loan_term', 12)))))
         annual_rate = Decimal(str(params.get('annual_rate', params.get('interest_rate', 0))))
         property_value = Decimal(str(params.get('property_value', params.get('propertyValue', 0))))
         
@@ -4999,7 +5008,7 @@ class LoanCalculator:
         
         repayment_option = quote_data.get('repaymentOption', quote_data.get('repayment_option', 'service_only'))
         gross_amount = Decimal(str(quote_data.get('grossAmount', 0)))
-        loan_term = int(quote_data.get('loanTerm', 18))  # Default to 18 months for development loans
+        loan_term = max(1, int(quote_data.get('loanTerm', 18)))  # Default to 18 months for development loans
         annual_rate = Decimal(str(quote_data.get('interestRate', 0)))
         monthly_payment = Decimal(str(quote_data.get('monthlyPayment', 0)))
         
@@ -5139,7 +5148,7 @@ class LoanCalculator:
         gross_amount = Decimal(str(calculation.get('grossAmount', calculation.get('gross_amount', params.get('gross_amount', 0)))))
         # Get 360-day parameter
         use_360_days = params.get('use_360_days', False)
-        loan_term = int(params.get('loan_term', 18))
+        loan_term = max(1, int(params.get('loan_term', 18)))
         annual_rate = Decimal(str(params.get('annual_rate', params.get('interest_rate', 0))))
         loan_term_days_param = params.get('loan_term_days')
         property_value = Decimal(str(params.get('property_value', params.get('propertyValue', 0))))
@@ -6808,7 +6817,7 @@ class LoanCalculator:
         
         repayment_option = quote_data.get('repaymentOption', quote_data.get('repayment_option', 'service_only'))
         gross_amount = Decimal(str(quote_data.get('grossAmount', 0)))
-        loan_term = int(quote_data.get('loanTerm', 18))  # Default to 18 months for development loans
+        loan_term = max(1, int(quote_data.get('loanTerm', 18)))  # Default to 18 months for development loans
         annual_rate = Decimal(str(quote_data.get('interestRate', 0)))
         monthly_payment = Decimal(str(quote_data.get('monthlyPayment', 0)))
         tranches = quote_data.get('tranches', [])

--- a/routes.py
+++ b/routes.py
@@ -369,7 +369,7 @@ def api_calculate():
         logging.info(f"Routes - Interest rate extraction: rate_input_type={rate_input_type}, annual_rate={annual_rate}, monthly_rate={monthly_rate}")
         
         # Other parameters - using safe conversion
-        loan_term = safe_int(data.get('loan_term'), 12)
+        loan_term = max(1, safe_int(data.get('loan_term'), 12))
         start_date_str = data.get('start_date', datetime.now().strftime('%Y-%m-%d'))
         start_date = datetime.strptime(start_date_str, '%Y-%m-%d')
 
@@ -379,6 +379,9 @@ def api_calculate():
         if end_date_str and end_date_str.strip():
             try:
                 end_date = datetime.strptime(end_date_str, '%Y-%m-%d')
+                if end_date < start_date:
+                    end_date = start_date
+                    end_date_str = end_date.strftime('%Y-%m-%d')
                 rd = relativedelta(end_date + timedelta(days=1), start_date)
                 loan_term = max(1, rd.years * 12 + rd.months)
                 loan_term_days = (end_date + timedelta(days=1) - start_date).days
@@ -730,7 +733,7 @@ def monthly_breakdown():
         params = {
             'loan_type': 'development',
             'annual_rate': float(data.get('annual_rate', 12.0)),
-            'loan_term': int(data.get('loan_term', 18)),
+            'loan_term': max(1, int(data.get('loan_term', 18))),
             'start_date': data.get('start_date', '2025-07-16'),
             'day1_advance': float(data.get('day1_advance', 100000)),
             'net_amount': float(data.get('net_amount', 0))
@@ -763,7 +766,7 @@ def excel_style_breakdown():
         
         # Extract parameters
         annual_rate = float(data.get('annual_rate', 12.0))
-        loan_term = int(data.get('loan_term', 18))
+        loan_term = max(1, int(data.get('loan_term', 18)))
         start_date_str = data.get('start_date', '2025-07-16')
         day1_advance = float(data.get('day1_advance', 100000))
         net_amount = float(data.get('net_amount', 0))
@@ -1472,7 +1475,7 @@ def perform_fresh_calculation_for_download(form_data):
             annual_rate = monthly_rate * 12
         
         # Other parameters
-        loan_term = int(form_data.get('loan_term', 12))
+        loan_term = max(1, int(form_data.get('loan_term', 12)))
         start_date_str = form_data.get('start_date', datetime.now().strftime('%Y-%m-%d'))
         
         # Fees
@@ -1871,7 +1874,7 @@ def save_loan():
             loan_summary.net_amount = fresh_calculation.get('netAmount', 0)
             loan_summary.property_value = fresh_calculation.get('propertyValue', 0)
             loan_summary.interest_rate = data.get('interestRate', 0)
-            loan_summary.loan_term = data.get('loanTerm', 12)
+            loan_summary.loan_term = max(1, safe_int(data.get('loanTerm'), 12))
             loan_summary.loan_term_days = fresh_calculation.get('loanTermDays', 365)
             loan_summary.start_date = datetime.strptime(data.get('startDate', datetime.now().strftime('%Y-%m-%d')), '%Y-%m-%d').date() if data.get('startDate') else datetime.now().date()
             loan_summary.end_date = datetime.strptime(data.get('endDate', (datetime.now() + timedelta(days=365)).strftime('%Y-%m-%d')), '%Y-%m-%d').date() if data.get('endDate') else (datetime.now() + timedelta(days=365)).date()

--- a/test_start_end_validation.py
+++ b/test_start_end_validation.py
@@ -1,0 +1,33 @@
+from calculations import LoanCalculator
+from datetime import datetime
+
+def test_end_date_before_start_adjusts():
+    calc = LoanCalculator()
+    params = {
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 12,
+        'repayment_option': 'service_and_capital',
+        'start_date': '2025-09-01',
+        'end_date': '2025-08-01'
+    }
+    res = calc.calculate_bridge_loan(params)
+    assert res['loanTerm'] == 1
+    assert res['loanTermDays'] == 1
+    assert res['end_date'] == '2025-09-01'
+
+
+def test_zero_loan_term_defaults_to_one():
+    calc = LoanCalculator()
+    params = {
+        'gross_amount': 100000,
+        'annual_rate': 12,
+        'loan_term': 0,
+        'repayment_option': 'service_and_capital',
+        'start_date': '2025-09-01'
+    }
+    res = calc.calculate_bridge_loan(params)
+    assert res['loanTerm'] == 1
+    start = datetime.strptime('2025-09-01', '%Y-%m-%d')
+    end = datetime.strptime(res['end_date'], '%Y-%m-%d')
+    assert (end - start).days + 1 == res['loanTermDays'] == 30

--- a/utils.py
+++ b/utils.py
@@ -85,8 +85,8 @@ def validate_loan_application_data(data: Dict[str, Any]) -> List[str]:
     if 'loan_term' in data:
         try:
             value = int(data['loan_term'])
-            if value < 3:
-                errors.append("Loan term must be at least 3 months")
+            if value < 1:
+                errors.append("Loan term must be at least 1 month")
             if value > 600:
                 errors.append("Loan term cannot exceed 600 months")
         except (ValueError, TypeError):


### PR DESCRIPTION
## Summary
- prevent loan end date from preceding the start date and enforce minimum one-month term across routes
- relax application validation to allow one-month loans and sanitize term inputs
- align loan calculation internals and add regression tests for edge cases

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68bb20177c7083209f6d483564a4edeb