### PR TITLE
Avoid mapping loan term from edited end date

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1303,12 +1303,7 @@ function calculateEndDate() {
                 window.loanCalculator.update360DayVisibility();
             }
 
-            let monthsDiff = (ey - sy) * 12 + (em - sm);
-            if (ed < sd) {
-                monthsDiff -= 1;
-            }
-            const loanTerm = Math.max(1, monthsDiff);
-            loanTermEl.value = loanTerm;
+            // Do not map end date back to a loan term to avoid incorrect month calculations
             triggerCalculationUpdate();
         }
     }

--- a/templates/calculator_w.html
+++ b/templates/calculator_w.html
@@ -1070,17 +1070,8 @@ function recalculateLoanTerm() {
             window.loanCalculator.update360DayVisibility();
         }
 
-        let monthsDiff = (end.getFullYear() - start.getFullYear()) * 12 +
-                         (end.getMonth() - start.getMonth());
-        if (end.getDate() < start.getDate()) {
-            monthsDiff -= 1;
-        }
-        const loanTerm = Math.max(1, monthsDiff);
-
-        document.getElementById('loanTerm').value = loanTerm;
-        console.log(`Set loan term to ${loanTerm} months based on ${daysDiff} days`);
-
-        // Trigger calculation update if calculator instance exists and form has data
+        // Avoid mapping the manual end date back to the loan term months
+        // to prevent incorrect values during editing
         triggerCalculationUpdate();
     }
 }

--- a/templates/scenario_comparison.html
+++ b/templates/scenario_comparison.html
@@ -1790,16 +1790,8 @@
                     endDateEl.value = end.toISOString().split('T')[0];
                 }
             } else {
-                const endDate = endDateEl.value;
-                if (startDate && endDate) {
-                    const start = new Date(startDate);
-                    const end = new Date(endDate);
-                    let monthsDiff = (end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth());
-                    if (end.getDate() < start.getDate()) {
-                        monthsDiff -= 1;
-                    }
-                    loanTermEl.value = Math.max(1, monthsDiff);
-                }
+                // In end date mode, avoid deriving a loan term from the end date
+                // to prevent incorrect month mappings during editing.
             }
         }
     </script>


### PR DESCRIPTION
## Summary
- prevent mapping of end date to loan term months when editing the calculator
- drop reverse loan term mapping for scenario comparison and wizard pages

## Testing
- `pytest test_database_url.py -q`
- `pytest test_calculator_term_end_date_toggle.py::test_toggle_preserves_values -q` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install selenium chromedriver-autoinstaller -q` *(fails: Could not find a version that satisfies the requirement selenium)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2564aa4483209e11c73982b303ed