### PR TITLE
Align Snowflake config buttons with calculator style

### DIFF
--- a/static/css/novellus-theme.css
+++ b/static/css/novellus-theme.css
@@ -363,9 +363,12 @@
     color: var(--novellus-navy);
 }
 
-.btn-outline-secondary:hover {
+.btn-outline-secondary:hover,
+.btn-outline-secondary:focus {
     background-color: var(--novellus-navy);
     border-color: var(--novellus-navy);
+    color: white;
+    box-shadow: none;
 }
 
 /* Alert styling */
@@ -435,6 +438,7 @@ canvas {
     background: linear-gradient(135deg, var(--novellus-gold) 0%, var(--novellus-gold-dark) 100%);
     border-color: var(--novellus-gold);
     color: white;
+    box-shadow: none;
 }
 
 /* Prevent form layout shift when content changes */
@@ -506,10 +510,12 @@ button[type="submit"] {
     color: var(--novellus-navy);
 }
 
-.btn-outline-secondary:hover {
+.btn-outline-secondary:hover,
+.btn-outline-secondary:focus {
     background-color: var(--novellus-navy);
     border-color: var(--novellus-navy);
     color: white;
+    box-shadow: none;
 }
 
 .btn-outline-secondary.active {

--- a/templates/snowflake_config.html
+++ b/templates/snowflake_config.html
@@ -9,7 +9,7 @@
 {% block content %}
 <div class="container py-4">
     <div class="d-flex justify-content-end align-items-start mb-3">
-        <button id="openModalBtn" class="btn btn-outline-secondary btn-sm" data-bs-toggle="modal" data-bs-target="#snowflakeModal">
+        <button id="openModalBtn" class="btn btn-outline-secondary" data-bs-toggle="modal" data-bs-target="#snowflakeModal">
             <i class="fas fa-cog me-1"></i>Configure
         </button>
     </div>
@@ -18,11 +18,11 @@
             <div id="savedConfig" style="display:none;">
                 <ul id="savedDetails" class="list-group list-group-flush mb-3"></ul>
                 <div class="d-flex gap-2">
-                    <button type="button" class="btn btn-sm btn-primary" onclick="editConfig()">Edit</button>
-                    <button type="button" class="btn btn-sm btn-info text-white" onclick="testConnection()" title="Test Connection">
+                    <button type="button" class="btn btn-primary" onclick="editConfig()">Edit</button>
+                    <button type="button" class="btn btn-info text-white" onclick="testConnection()" title="Test Connection">
                         <i class="fas fa-vial"></i>
                     </button>
-                    <button type="button" class="btn btn-sm btn-danger" onclick="deleteConfig()">Delete</button>
+                    <button type="button" class="btn btn-danger" onclick="deleteConfig()">Delete</button>
                 </div>
             </div>
             <div id="noConfig" class="text-muted">No Snowflake configuration saved.</div>


### PR DESCRIPTION
## Summary
- Remove small sizing classes from Snowflake config buttons
- Add hover and focus styling for secondary buttons in theme CSS
- Remove focus ring from primary buttons for consistent appearance

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r Requirements.txt` *(fails: Could not find a version that satisfies the requirement selenium>=4.34.2)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3ce266c88320bc596370de6f50cb