### PR TITLE
Fix tranche editing for development loans

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1663,7 +1663,7 @@ function populateFormFromParams(params) {
 function populateTrancheData(params) {
     // Check if this is a development loan
     const loanType = params.get('loan_type');
-    if (loanType !== 'development') {
+    if (!['development', 'development2'].includes(loanType)) {
         return;
     }
     

--- a/templates/calculator_w.html
+++ b/templates/calculator_w.html
@@ -1368,7 +1368,7 @@ function populateFormFromParams(params) {
 function populateTrancheData(params) {
     // Check if this is a development loan
     const loanType = params.get('loan_type');
-    if (loanType !== 'development') {
+    if (!['development', 'development2'].includes(loanType)) {
         return;
     }
     

--- a/test_calculator_editing_fields.py
+++ b/test_calculator_editing_fields.py
@@ -75,7 +75,7 @@ def test_editing_populates_tranches(live_server):
             "edit": "true",
             "loanId": "2",
             "loanName": "Dev Loan",
-            "loan_type": "development",
+            "loan_type": "development2",
             "tranche_mode": "manual",
             "tranche_amounts[0]": "10000",
             "tranche_dates[0]": "2024-01-01",


### PR DESCRIPTION
## Summary
- ensure tranche data is populated when editing development2 loans
- mirror tranche logic fix in wizard calculator template
- adjust Selenium editing test for development2 tranches

## Testing
- `pytest test_loan_history_edit_params.py -q`
- `pytest test_calculator_editing_fields.py -q` *(fails: Skipped: Selenium not available)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3e35b0e88320bf5369d6343b9598