### PR TITLE
Fix loan edit field population and tranche loading

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1564,6 +1564,10 @@ function handleEditMode() {
                     window.loanCalculator.toggleRateInputs();
                     window.loanCalculator.toggleTrancheMode();
                     window.loanCalculator.updateAdditionalParams();
+                    // Automatically recalculate to reflect loaded values
+                    if (typeof window.loanCalculator.calculateLoan === 'function') {
+                        window.loanCalculator.calculateLoan(true);
+                    }
                 } catch (err) {
                     console.error('Error toggling sections in edit mode:', err);
                 }
@@ -1668,7 +1672,7 @@ function populateTrancheData(params) {
     }
     
     // Extract tranche parameters
-    const trancheContainer = document.getElementById('trancheContainer');
+    const trancheContainer = document.getElementById('tranchesContainer');
     if (!trancheContainer) {
         console.warn('Tranche container not found');
         return;
@@ -1685,16 +1689,18 @@ function populateTrancheData(params) {
         const description = params.get(`tranche_descriptions[${trancheIndex}]`);
         
         if (amount) {
-            // Add tranche if not first one (first one should exist)
+            // Add tranche if not first one (first row exists by default)
             if (trancheIndex > 0) {
-                addTranche();
+                if (window.loanCalculator && typeof window.loanCalculator.increaseTranches === 'function') {
+                    window.loanCalculator.increaseTranches();
+                }
             }
-            
+
             // Populate tranche fields
-            const amountField = document.querySelector(`#trancheContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheAmount"]`);
-            const dateField = document.querySelector(`#trancheContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheDate"]`);
-            const rateField = document.querySelector(`#trancheContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheRate"]`);
-            const descField = document.querySelector(`#trancheContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheDescription"]`);
+            const amountField = document.querySelector(`#tranchesContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheAmount"]`);
+            const dateField = document.querySelector(`#tranchesContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheDate"]`);
+            const rateField = document.querySelector(`#tranchesContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheRate"]`);
+            const descField = document.querySelector(`#tranchesContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheDescription"]`);
             
             if (amountField) amountField.value = amount;
             if (dateField) dateField.value = date;

--- a/templates/calculator_w.html
+++ b/templates/calculator_w.html
@@ -1314,6 +1314,22 @@ function handleEditMode() {
             
             // Populate form with URL parameters
             populateFormFromParams(urlParams);
+
+            // Ensure toggle-dependent sections reflect loaded values
+            if (window.loanCalculator) {
+                try {
+                    window.loanCalculator.toggleAmountInputSections();
+                    window.loanCalculator.toggleGrossAmountInputs();
+                    window.loanCalculator.toggleRateInputs();
+                    window.loanCalculator.toggleTrancheMode();
+                    window.loanCalculator.updateAdditionalParams();
+                    if (typeof window.loanCalculator.calculateLoan === 'function') {
+                        window.loanCalculator.calculateLoan(true);
+                    }
+                } catch (err) {
+                    console.error('Error toggling sections in edit mode:', err);
+                }
+            }
         }
     }
 }
@@ -1373,7 +1389,7 @@ function populateTrancheData(params) {
     }
     
     // Extract tranche parameters
-    const trancheContainer = document.getElementById('trancheContainer');
+    const trancheContainer = document.getElementById('tranchesContainer');
     if (!trancheContainer) {
         console.warn('Tranche container not found');
         return;
@@ -1390,16 +1406,18 @@ function populateTrancheData(params) {
         const description = params.get(`tranche_descriptions[${trancheIndex}]`);
         
         if (amount) {
-            // Add tranche if not first one (first one should exist)
+            // Add tranche if not first one (first row exists by default)
             if (trancheIndex > 0) {
-                addTranche();
+                if (window.loanCalculator && typeof window.loanCalculator.increaseTranches === 'function') {
+                    window.loanCalculator.increaseTranches();
+                }
             }
-            
+
             // Populate tranche fields
-            const amountField = document.querySelector(`#trancheContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheAmount"]`);
-            const dateField = document.querySelector(`#trancheContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheDate"]`);
-            const rateField = document.querySelector(`#trancheContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheRate"]`);
-            const descField = document.querySelector(`#trancheContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheDescription"]`);
+            const amountField = document.querySelector(`#tranchesContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheAmount"]`);
+            const dateField = document.querySelector(`#tranchesContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheDate"]`);
+            const rateField = document.querySelector(`#tranchesContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheRate"]`);
+            const descField = document.querySelector(`#tranchesContainer .tranche-item:nth-child(${trancheIndex + 1}) input[id*="trancheDescription"]`);
             
             if (amountField) amountField.value = amount;
             if (dateField) dateField.value = date;

--- a/test_calculator_editing_fields.py
+++ b/test_calculator_editing_fields.py
@@ -90,9 +90,9 @@ def test_editing_populates_tranches(live_server):
         driver.get(url)
 
         WebDriverWait(driver, 10).until(
-            lambda d: len(d.find_elements(By.CSS_SELECTOR, "#trancheContainer .tranche-item")) == 2
+            lambda d: len(d.find_elements(By.CSS_SELECTOR, "#tranchesContainer .tranche-item")) == 2
         )
-        items = driver.find_elements(By.CSS_SELECTOR, "#trancheContainer .tranche-item")
+        items = driver.find_elements(By.CSS_SELECTOR, "#tranchesContainer .tranche-item")
         first = items[0]
         second = items[1]
         assert first.find_element(By.CSS_SELECTOR, 'input[id*="trancheAmount"]').get_attribute("value") == "10000"
@@ -127,6 +127,7 @@ def test_editing_shows_capital_repayment_section(live_server):
             lambda d: d.find_element(By.ID, "capitalRepaymentSection").is_displayed()
         )
         assert driver.find_element(By.ID, "capitalRepaymentSection").is_displayed()
+        assert driver.find_element(By.ID, "capitalRepayment").get_attribute("value") == "750"
         assert not driver.find_element(By.ID, "flexiblePaymentSection").is_displayed()
     finally:
         driver.quit()
@@ -152,6 +153,32 @@ def test_editing_shows_flexible_payment_section(live_server):
             lambda d: d.find_element(By.ID, "flexiblePaymentSection").is_displayed()
         )
         assert driver.find_element(By.ID, "flexiblePaymentSection").is_displayed()
+        assert driver.find_element(By.ID, "flexiblePayment").get_attribute("value") == "1000"
         assert not driver.find_element(By.ID, "capitalRepaymentSection").is_displayed()
+    finally:
+        driver.quit()
+
+
+def test_editing_populates_capital_payment_only(live_server):
+    driver = _get_chrome_driver()
+    try:
+        params = {
+            "edit": "true",
+            "loanId": "5",
+            "loanName": "Cap Only",
+            "loan_type": "bridge",
+            "repayment_option": "capital_payment_only",
+            "capital_repayment": "1500",
+            "payment_timing": "arrears",
+            "payment_frequency": "monthly",
+        }
+        url = f"{live_server}/calculator?{urlencode(params)}"
+        driver.get(url)
+
+        WebDriverWait(driver, 10).until(
+            lambda d: d.find_element(By.ID, "capitalRepaymentSection").is_displayed()
+        )
+        assert driver.find_element(By.ID, "capitalRepaymentSection").is_displayed()
+        assert driver.find_element(By.ID, "capitalRepayment").get_attribute("value") == "1500"
     finally:
         driver.quit()


### PR DESCRIPTION
## Summary
- Recalculate loan automatically when loading edit parameters
- Correct tranche population on edit by using the proper container and dynamic row creation
- Expand Selenium edit tests to cover capital, flexible, and capital-only repayment fields

## Testing
- `pytest test_calculator_editing_fields.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb44a6502883208cce0d3700d92d5f