### PR TITLE
Fix interest rate precision when editing loans

### DIFF
--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -781,6 +781,17 @@ class LoanHistoryManager {
     }
 
     buildEditParams(loan) {
+        const formatRate = (rate) => {
+            if (rate === undefined || rate === null || rate === '') return '';
+            let num = parseFloat(rate);
+            if (isNaN(num)) return '';
+            num = parseFloat(num.toFixed(4));
+            if (Math.abs(num - Math.round(num)) < 0.0005) {
+                num = Math.round(num);
+            }
+            return num.toString();
+        };
+
         const params = {
             // Core loan parameters
             loan_type: loan.loan_type ?? 'bridge',
@@ -791,8 +802,8 @@ class LoanHistoryManager {
             net_amount: loan.netAmount ?? loan.net_amount ?? '',
             gross_amount_percentage: loan.grossAmountPercentage ?? loan.gross_amount_percentage ?? '',
             property_value: loan.propertyValue ?? loan.property_value ?? '',
-            annual_rate: loan.interestRate ?? loan.interest_rate ?? '',
-            monthly_rate: loan.monthlyRate ?? loan.monthly_rate ?? '',
+            annual_rate: formatRate(loan.interestRate ?? loan.interest_rate ?? ''),
+            monthly_rate: formatRate(loan.monthlyRate ?? loan.monthly_rate ?? ''),
             loan_term: loan.loanTerm ?? loan.loan_term ?? '',
             start_date: loan.startDate ?? loan.start_date ?? '',
             end_date: loan.endDate ?? loan.end_date ?? '',
@@ -822,7 +833,7 @@ class LoanHistoryManager {
         if (!params.monthly_rate && params.annual_rate) {
             const annual = parseFloat(params.annual_rate);
             if (!isNaN(annual)) {
-                params.monthly_rate = (annual / 12).toFixed(4);
+                params.monthly_rate = formatRate(annual / 12);
             }
         }
 

--- a/test_loan_history_edit_params.py
+++ b/test_loan_history_edit_params.py
@@ -36,3 +36,11 @@ def test_build_edit_params_includes_development2_tranches():
     assert result['tranche_dates[1]'] == '2024-06-01'
     assert result['tranche_rates[1]'] == '11'
     assert result['tranche_descriptions[1]'] == 'Phase 2'
+
+
+def test_build_edit_params_rounds_interest_rate():
+    loan_obj = {
+        'interest_rate': 9.9996
+    }
+    result = _run_build_edit_params(loan_obj)
+    assert result['annual_rate'] == '10'


### PR DESCRIPTION
## Summary
- Round interest and monthly rates when building edit params to remove floating-point errors
- Add regression test ensuring interest rate rounds to expected value

## Testing
- `pytest test_loan_history_edit_params.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium')*
- `pip install flask selenium -q` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4a5ab7208320801b8fcf5af551d5