### PR TITLE
Fix missing repayment sections on loan edit

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1563,6 +1563,8 @@ function handleEditMode() {
                     window.loanCalculator.toggleGrossAmountInputs();
                     window.loanCalculator.toggleRateInputs();
                     window.loanCalculator.toggleTrancheMode();
+                    // Ensure repayment-specific sections are visible when editing
+                    window.loanCalculator.updateRepaymentOptions();
                     window.loanCalculator.updateAdditionalParams();
                     // Automatically recalculate to reflect loaded values
                     if (typeof window.loanCalculator.calculateLoan === 'function') {


### PR DESCRIPTION
## Summary
- Ensure calculator shows repayment-specific fields when editing a loan by updating repayment options before applying additional parameter toggles

## Testing
- `pytest test_loan_history_edit_params.py -q`
- `pytest test_calculator_editing_fields.py::test_editing_shows_capital_repayment_section -q` *(fails: skipped; tests require browser setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bb570ec67c8320ab4fefc91e0e67e2