### PR TITLE
Use locally hosted Brother 1816 Light font

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import os
 import logging
-from flask import Flask
+from flask import Flask, send_from_directory
 from dotenv import load_dotenv
 
 # Load environment variables from .env file
@@ -69,6 +69,11 @@ def load_user(user_id):
 with app.app_context():
     db.create_all()
     logging.info("Database tables created")
+
+# Serve font files from the fonts directory
+@app.route('/fonts/<path:filename>')
+def serve_font(filename):
+    return send_from_directory('fonts', filename)
 
 # Import routes to ensure they are registered when running the app directly
 import routes  # noqa: F401

--- a/excel_generator.py
+++ b/excel_generator.py
@@ -14,7 +14,7 @@ from pathlib import Path
 # font installed can locate it. OpenPyXL does not embed fonts, but setting the
 # default font helps signal the intended typeface.
 BROTHER_FONT_NAME = "Brother 1816"
-FONT_FILE = Path(__file__).with_name("fonts").joinpath("Brother-1816-Regular.ttf")
+FONT_FILE = Path(__file__).with_name("fonts").joinpath("brother-1816-light.otf")
 if FONT_FILE.exists():
     try:
         from openpyxl.styles import fonts as openpyxl_fonts

--- a/fonts/README.txt
+++ b/fonts/README.txt
@@ -1,3 +1,2 @@
-This directory should contain the Brother 1816 font file required for Excel output.
-The current Brother-1816-Regular.ttf is a placeholder due to environment limitations.
-Replace it with the actual TTF file to ensure correct rendering in Excel.
+This directory contains the Brother 1816 Light font used across the application.
+The provided brother-1816-light.otf file is served for web pages and referenced by the Excel generator.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,18 +1,10 @@
 /* Novellus Loan Management System - Custom Styles */
 
-/* Import Brother 1816 font from OnlineWebFonts CDN */
-@import url(https://db.onlinewebfonts.com/c/e869c6b775bf55c06d009bbe92d03583?family=Brother+1816);
-
-/* Font-face declaration for Brother 1816 as backup */
+/* Font-face declaration for locally hosted Brother 1816 Light */
 @font-face {
     font-family: "Brother 1816";
-    src: url("https://db.onlinewebfonts.com/t/e869c6b775bf55c06d009bbe92d03583.eot");
-    src: url("https://db.onlinewebfonts.com/t/e869c6b775bf55c06d009bbe92d03583.eot?#iefix") format("embedded-opentype"),
-         url("https://db.onlinewebfonts.com/t/e869c6b775bf55c06d009bbe92d03583.woff2") format("woff2"),
-         url("https://db.onlinewebfonts.com/t/e869c6b775bf55c06d009bbe92d03583.woff") format("woff"),
-         url("https://db.onlinewebfonts.com/t/e869c6b775bf55c06d009bbe92d03583.ttf") format("truetype"),
-         url("https://db.onlinewebfonts.com/t/e869c6b775bf55c06d009bbe92d03583.svg#Brother1816") format("svg");
-    font-weight: normal;
+    src: url("/fonts/brother-1816-light.otf") format("opentype");
+    font-weight: 300;
     font-style: normal;
     font-display: swap;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,8 +14,8 @@
     <!-- Font Awesome -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
     
-    <!-- Brother 1816 Font -->
-    <link href="https://db.onlinewebfonts.com/c/e869c6b775bf55c06d009bbe92d03583?family=Brother+1816" rel="stylesheet">
+    <!-- Preload Brother 1816 Light font -->
+    <link rel="preload" href="{{ url_for('serve_font', filename='brother-1816-light.otf') }}" as="font" type="font/otf">
     
     <!-- Chart.js for visualizations -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.js"></script>


### PR DESCRIPTION
## Summary
- serve font files from new `/fonts/<filename>` route
- preload and use locally hosted Brother 1816 Light font in templates and styles
- reference Brother 1816 Light font for Excel generation and update documentation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5c52c7bc832085672d4fef917415