### PR TITLE
Use SVG favicon

### DIFF
--- a/templates/403.html
+++ b/templates/403.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Access Denied - Novellus</title>
-    <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='novellus_logo.png') }}">
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='tabicon.svg') }}">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <style>

--- a/templates/404.html
+++ b/templates/404.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Page Not Found - Novellus</title>
-    <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='novellus_logo.png') }}">
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='tabicon.svg') }}">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <style>

--- a/templates/500.html
+++ b/templates/500.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Server Error - Novellus</title>
-    <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='novellus_logo.png') }}">
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='tabicon.svg') }}">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
     <style>

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,7 +6,7 @@
     <title>{% block title %}Novellus Loan Management{% endblock %}</title>
     
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='novellus_logo.png') }}">
+    <link rel="icon" type="image/svg+xml" href="{{ url_for('static', filename='tabicon.svg') }}">
     
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- switch favicon links to use crisp `tabicon.svg`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68bb62d3be348320b7fc4e23f7d97984