### PR TITLE
Load loan inputs from history using loan_summary

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -2341,10 +2341,17 @@ def get_loan_details(loan_id):
         except Exception as e:
             app.logger.warning(f"Could not parse loan tranches_data: {e}")
             loan_data['tranches'] = []
-        
+        # Include original user input data for editing
+        try:
+            input_data = json.loads(loan.input_data) if getattr(loan, 'input_data', None) else {}
+        except Exception as e:
+            app.logger.warning(f"Could not parse loan input_data: {e}")
+            input_data = {}
+
         return jsonify({
             'success': True,
-            'loan': loan_data
+            'loan': loan_data,
+            'input_data': input_data
         })
         
     except Exception as e:

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1553,27 +1553,46 @@ function handleEditMode() {
                 console.log('Set loan name field to:', decodeURIComponent(loanName));
             }
 
-            // Populate form with URL parameters
+            // Populate form with URL parameters (fallback)
             populateFormFromParams(urlParams);
 
-            // Ensure toggle-dependent sections reflect loaded values
-            if (window.loanCalculator) {
-                try {
-                    window.loanCalculator.toggleAmountInputSections();
-                    window.loanCalculator.toggleGrossAmountInputs();
-                    window.loanCalculator.toggleRateInputs();
-                    window.loanCalculator.toggleTrancheMode();
-                    // Ensure repayment-specific sections are visible when editing
-                    window.loanCalculator.updateRepaymentOptions();
-                    window.loanCalculator.updateAdditionalParams();
-                    // Automatically recalculate to reflect loaded values
-                    if (typeof window.loanCalculator.calculateLoan === 'function') {
-                        window.loanCalculator.calculateLoan(true);
+            // Fetch full loan details from server and populate form
+            fetch(`/api/loan/${loanId}`)
+                .then(response => response.json())
+                .then(data => {
+                    if (data && data.success && data.input_data) {
+                        const paramsFromData = new URLSearchParams();
+                        for (const [key, value] of Object.entries(data.input_data)) {
+                            if (value !== null && value !== undefined) {
+                                paramsFromData.set(key, value);
+                            }
+                        }
+                        populateFormFromParams(paramsFromData);
                     }
-                } catch (err) {
-                    console.error('Error toggling sections in edit mode:', err);
-                }
-            }
+                })
+                .catch(err => {
+                    console.error('Error loading loan data:', err);
+                })
+                .finally(() => {
+                    // Ensure toggle-dependent sections reflect loaded values
+                    if (window.loanCalculator) {
+                        try {
+                            window.loanCalculator.toggleAmountInputSections();
+                            window.loanCalculator.toggleGrossAmountInputs();
+                            window.loanCalculator.toggleRateInputs();
+                            window.loanCalculator.toggleTrancheMode();
+                            // Ensure repayment-specific sections are visible when editing
+                            window.loanCalculator.updateRepaymentOptions();
+                            window.loanCalculator.updateAdditionalParams();
+                            // Automatically recalculate to reflect loaded values
+                            if (typeof window.loanCalculator.calculateLoan === 'function') {
+                                window.loanCalculator.calculateLoan(true);
+                            }
+                        } catch (err) {
+                            console.error('Error toggling sections in edit mode:', err);
+                        }
+                    }
+                });
         }
     }
 }

--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -768,10 +768,8 @@ class LoanHistoryManager {
                 return;
             }
 
-            // Navigate to calculator with loan data for editing
-            const params = this.buildEditParams(loan);
-            const queryString = new URLSearchParams(params).toString();
-            window.location.href = `/calculator?edit=true&loanId=${this.currentLoanId}&loanName=${encodeURIComponent(loan.loan_name)}&${queryString}`;
+            // Navigate to calculator with loan ID; details loaded from server
+            window.location.href = `/calculator?edit=true&loanId=${this.currentLoanId}&loanName=${encodeURIComponent(loan.loan_name)}`;
 
         } catch (error) {
             console.error('Edit loan error:', error);


### PR DESCRIPTION
## Summary
- Provide input_data via `/api/loan/<id>` endpoint
- When editing from history, navigate with loan ID only
- Calculator fetches saved loan input data to populate fields

## Testing
- `pytest` *(fails: No module named 'flask')*
- `pip install -r Requirements.txt` *(fails: Could not find a version that satisfies the requirement selenium>=4.34.2)*

------
https://chatgpt.com/codex/tasks/task_e_68bb640cf6808320a68f8006b21f8845