### PR TITLE
Populate calculator edit form from saved loan data

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1560,13 +1560,33 @@ function handleEditMode() {
             fetch(`/api/loan/${loanId}`)
                 .then(response => response.json())
                 .then(data => {
-                    if (data && data.success && data.input_data) {
+                    if (data && data.success) {
                         const paramsFromData = new URLSearchParams();
-                        for (const [key, value] of Object.entries(data.input_data)) {
-                            if (value !== null && value !== undefined) {
-                                paramsFromData.set(key, value);
+                        // Prefer original input_data but fall back to loan summary data
+                        const source = (data.input_data && Object.keys(data.input_data).length > 0)
+                            ? data.input_data
+                            : (data.loan || {});
+
+                        for (const [key, value] of Object.entries(source)) {
+                            if (value === null || value === undefined) continue;
+
+                            // Handle tranche arrays separately
+                            if (key === 'tranches' && Array.isArray(value)) {
+                                value.forEach((tranche, index) => {
+                                    paramsFromData.set(`tranche_amounts[${index}]`, tranche.amount ?? '');
+                                    paramsFromData.set(`tranche_dates[${index}]`, tranche.date ?? '');
+                                    paramsFromData.set(`tranche_rates[${index}]`, tranche.rate ?? '');
+                                    paramsFromData.set(`tranche_descriptions[${index}]`, tranche.description ?? '');
+                                });
+                                continue; // skip setting 'tranches' key directly
                             }
+
+                            const formatted = typeof value === 'boolean'
+                                ? value.toString().toLowerCase()
+                                : value;
+                            paramsFromData.set(key, formatted);
                         }
+
                         populateFormFromParams(paramsFromData);
                     }
                 })


### PR DESCRIPTION
## Summary
- Ensure calculator edit mode loads saved loan details when opened from loan history
- Populate all toggles and tranches by converting saved loan data into form parameters

## Testing
- `pytest test_loan_history_edit_params.py test_calculator_editing_fields.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb691fa030832098702296d4bc09f8