### PR TITLE
Serialize dict values before Snowflake sync

### DIFF
--- a/test_snowflake_variant_insertion.py
+++ b/test_snowflake_variant_insertion.py
@@ -42,6 +42,6 @@ def test_sync_data_to_snowflake_parses_json(monkeypatch):
     data = {"input_data": json.dumps({"a": 1}), "value": 2}
     snowflake_utils.sync_data_to_snowflake("tbl", data)
 
-    assert executed[0][0] == {"a": 1}
+    assert executed[0][0] == json.dumps({"a": 1})
     assert executed[0][1] == 2
 


### PR DESCRIPTION
## Summary
- Avoid passing dict/list values directly to the Snowflake connector
- Update Snowflake sync test to expect JSON strings

## Testing
- `pytest test_snowflake_variant_insertion.py test_snowflake_config_persistence.py` *(skipped: Flask not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb6b7f5088320a898b69965fb7c3b