### PR TITLE
Fix Snowflake insert with VARIANT data

### DIFF
--- a/snowflake_utils.py
+++ b/snowflake_utils.py
@@ -198,7 +198,7 @@ def sync_data_to_snowflake(table: str, rows):
 
     columns = list(rows[0].keys())
     placeholders = ["parse_json(%s)" for _ in columns]
-    insert_stmt = "insert into {0} ({1}) values ({2})".format(
+    insert_stmt = "insert into {0} ({1}) select {2}".format(
         table,
         ", ".join(columns),
         ", ".join(placeholders),

--- a/test_snowflake_variant_insertion.py
+++ b/test_snowflake_variant_insertion.py
@@ -44,7 +44,7 @@ def test_sync_data_to_snowflake_parses_json(monkeypatch):
 
 
     stmt, params = executed[0]
-    assert stmt == "insert into tbl (input_data, value) values (parse_json(%s), parse_json(%s))"
+    assert stmt == "insert into tbl (input_data, value) select parse_json(%s), parse_json(%s)"
     assert params[0] == json.dumps({"a": 1})
     assert params[1] == json.dumps(2)
 


### PR DESCRIPTION
## Summary
- avoid `PARSE_JSON` in INSERT...VALUES by inserting via SELECT
- adjust test for new insert statement

## Testing
- `pytest test_snowflake_variant_insertion.py` *(fails: skipped, missing flask dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbaec5240832087858792e8c08367