### PR TITLE
Show only interest accrued line in balance chart

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -3679,21 +3679,13 @@ class LoanCalculator {
             return 0;
         };
 
-        // Build running sums for interest accrued and retained
+        // Build running sum for interest accrued
         let cumulativeAccrued = 0;
         const interestAccruedData = schedule.map(entry => {
             const raw = entry.interest_accrued_raw ?? entry.interest_accrued ?? entry.interest_amount ?? entry.interest;
             const val = parseValue(raw);
             cumulativeAccrued += val;
             return cumulativeAccrued;
-        });
-
-        let cumulativeRetained = 0;
-        const interestRetainedData = schedule.map(entry => {
-            const raw = entry.interest_retained_raw ?? entry.interest_retained;
-            const val = parseValue(raw);
-            cumulativeRetained += val;
-            return cumulativeRetained;
         });
 
         const data = {
@@ -3724,21 +3716,6 @@ class LoanCalculator {
                     pointRadius: 3,
                     pointHoverRadius: 6,
                     pointBackgroundColor: 'rgba(70, 130, 180, 1)',
-                    pointBorderColor: '#fff',
-                    pointBorderWidth: 2,
-                    yAxisID: 'y1'
-                },
-                {
-                    label: 'Interest Retained',
-                    data: interestRetainedData,
-                    borderColor: 'rgba(220, 53, 69, 1)',
-                    backgroundColor: 'rgba(220, 53, 69, 0.1)',
-                    borderWidth: 2,
-                    fill: false,
-                    tension: 0.1,
-                    pointRadius: 3,
-                    pointHoverRadius: 6,
-                    pointBackgroundColor: 'rgba(220, 53, 69, 1)',
                     pointBorderColor: '#fff',
                     pointBorderWidth: 2,
                     yAxisID: 'y1'

--- a/static/js/charts.js
+++ b/static/js/charts.js
@@ -202,18 +202,12 @@ class ChartManager {
             }
             return val || 0;
         };
-        // Build running sums for interest accrued and retained
+        // Build running sum for interest accrued
         let cumulativeAccrued = 0;
-        let cumulativeRetained = 0;
         const interestAccruedData = schedule.map(payment => {
             const val = parseValue(payment.interest_accrued_raw ?? payment.interest_accrued);
             cumulativeAccrued += val;
             return cumulativeAccrued;
-        });
-        const interestRetainedData = schedule.map(payment => {
-            const val = parseValue(payment.interest_retained_raw ?? payment.interest_retained);
-            cumulativeRetained += val;
-            return cumulativeRetained;
         });
 
         const config = {
@@ -243,20 +237,6 @@ class ChartManager {
                         fill: false,
                         tension: 0.4,
                         pointBackgroundColor: this.defaultColors.secondary,
-                        pointBorderColor: '#fff',
-                        pointBorderWidth: 2,
-                        pointRadius: 4,
-                        yAxisID: 'y1'
-                    },
-                    {
-                        label: 'Interest Retained',
-                        data: interestRetainedData,
-                        backgroundColor: this.addTransparency(this.defaultColors.warning, 0.1),
-                        borderColor: this.defaultColors.warning,
-                        borderWidth: 3,
-                        fill: false,
-                        tension: 0.4,
-                        pointBackgroundColor: this.defaultColors.warning,
                         pointBorderColor: '#fff',
                         pointBorderWidth: 2,
                         pointRadius: 4,


### PR DESCRIPTION
## Summary
- Remove interest retained dataset from balance over time chart, leaving only interest accrued alongside remaining balance.
- Simplify chart data preparation to track accrued interest only.

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7e3bfc988320969a06967a40763b