### PR TITLE
Fix missing report icon in loan calculator

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -923,7 +923,7 @@
 <th class="px-3" style="color: #000 !important; border-right: 1px solid #000;"></th>
 <th class="px-3 text-end" style="color: #000 !important; border-right: 1px solid #000;"></th>
 <th class="px-3 text-end" style="color: #000 !important;">
-    <a id="openLoanReport" href="#" style="display:none;" target="_blank" title="Open Loan Report" class="me-2"><i class="fas fa-chart-bar"></i></a>
+    <a id="openLoanReport" href="#" style="display:none;" target="_blank" title="Open Loan Report" class="me-2"><i class="fas fa-chart-column"></i></a>
     <a id="downloadSummaryDocx" href="#" style="display:none;" title="Download Loan Summary"><i class="bi bi-download"></i></a>
 </th>
 </tr>
@@ -1792,7 +1792,7 @@ async function loadPowerBIReports() {
                 'main': {
                     name: 'Loan Summary Report',
                     baseUrl: 'https://app.powerbi.com/groups/71153f62-9f44-47cd-b6d5-c3e56e8977ba/rdlreports/3bcd8dd2-4773-4372-9a19-1174c108aee5?ctid=16f1922b-4a40-4f3f-8c40-afbd1d4a0e21',
-                    icon: 'fas fa-chart-bar'
+                    icon: 'fas fa-chart-column'
                 }
             };
         }
@@ -1802,7 +1802,7 @@ async function loadPowerBIReports() {
             'main': {
                 name: 'Loan Summary Report',
                 baseUrl: 'https://app.powerbi.com/groups/71153f62-9f44-47cd-b6d5-c3e56e8977ba/rdlreports/3bcd8dd2-4773-4372-9a19-1174c108aee5?ctid=16f1922b-4a40-4f3f-8c40-afbd1d4a0e21',
-                icon: 'fas fa-chart-bar'
+                icon: 'fas fa-chart-column'
             }
         };
     }
@@ -2354,7 +2354,7 @@ function displayDatabaseInfo(data) {
                 <div class="col-12">
                     <div class="card">
                         <div class="card-header">
-                            <h6 class="mb-0"><i class="fas fa-chart-bar me-2"></i>Record Counts</h6>
+                            <h6 class="mb-0"><i class="fas fa-chart-column me-2"></i>Record Counts</h6>
                         </div>
                         <div class="card-body">
                             <div class="row">


### PR DESCRIPTION
## Summary
- Replace outdated Font Awesome icon with current chart column icon for loan report link
- Use same icon in default Power BI report configuration and related UI

## Testing
- `pytest -q` *(fails: No module named 'selenium', 'flask')*
- `pip install -q -r Requirements.txt flask` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8efda2b08320be8ffba7703edf6b