### PR TITLE
Switch loan summary DOCX icon to Font Awesome

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -926,7 +926,7 @@
     <a id="openLoanReport" href="#" style="display:none;" target="_blank" title="Open Loan Report" class="me-2">
         <i class="fas fa-chart-column"></i>
     </a>
-    <a id="downloadSummaryDocx" href="#" style="display:none;" title="Download Loan Summary"><i class="bi bi-download"></i></a>
+    <a id="downloadSummaryDocx" href="#" style="display:none;" title="Download Loan Summary"><i class="fas fa-file-word"></i></a>
 </th>
 </tr>
 </thead>


### PR DESCRIPTION
## Summary
- Replace Bootstrap download icon with a Font Awesome Word icon for the loan summary DOCX export

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9bb8ddd48320a1a0ce11b7db7e60