### PR TITLE
Switch calculator report link to DOCX summary

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1906,16 +1906,13 @@ function updateSummaryDocxIcon() {
 function updateLoanReportLink() {
     const link = document.getElementById('openLoanReport');
     if (!link) return;
-    if (isLoanSaved) {
-        const loan = getLoanForReport();
-        if (loan) {
-            link.style.display = 'inline';
-            link.href = generatePowerBIUrl(loan, 'standard', 'main');
-            return;
-        }
+    if (isLoanSaved && window.editMode && window.editMode.loanId) {
+        link.style.display = 'inline';
+        link.href = `/loan/${window.editMode.loanId}/summary-docx`;
+    } else {
+        link.style.display = 'none';
+        link.removeAttribute('href');
     }
-    link.style.display = 'none';
-    link.removeAttribute('href');
 }
 
 function updateReportsButton(loan) {


### PR DESCRIPTION
## Summary
- Direct the calculator's report button to the server-generated DOCX summary instead of Power BI

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb0059a10832087459b3ca5828dd1