### PR TITLE
Use Brother font in DOCX reports

### DIFF
--- a/fonts/README.txt
+++ b/fonts/README.txt
@@ -1,2 +1,3 @@
 This directory contains the Brother 1816 Light font used across the application.
-The provided brother-1816-light.otf file is served for web pages and referenced by the Excel generator.
+The provided brother-1816-light.otf file is served for web pages, referenced by
+the Excel generator, and used for DOCX report generation.

--- a/pdf_quote_generator.py
+++ b/pdf_quote_generator.py
@@ -11,6 +11,24 @@ from reportlab.lib.enums import TA_CENTER, TA_LEFT, TA_RIGHT
 import tempfile
 from datetime import datetime
 
+
+BROTHER_FONT = "Brother 1816 Light"
+BROTHER_STYLES = ["Normal", "Heading 1", "Heading 2", "Heading 3", "Title", "List Bullet"]
+
+
+def _apply_brother_font(doc):
+    """Apply the Brother font to common Word styles."""
+    from docx.oxml.ns import qn
+
+    for style_name in BROTHER_STYLES:
+        try:
+            style = doc.styles[style_name]
+        except KeyError:
+            continue
+        font = style.font
+        font.name = BROTHER_FONT
+        style._element.rPr.rFonts.set(qn("w:eastAsia"), BROTHER_FONT)
+
 def generate_quote_pdf(quote_data, application_data=None):
     """Generate PDF quote document"""
     # Create temporary file
@@ -88,6 +106,7 @@ def generate_professional_quote_docx(quote_data, application_data=None):
     from docx.enum.text import WD_ALIGN_PARAGRAPH
 
     doc = Document()
+    _apply_brother_font(doc)
 
     # Determine currency-specific logo
     currency = quote_data.get('currency', 'GBP')
@@ -162,6 +181,7 @@ def generate_loan_summary_docx(loan):
     import tempfile
 
     doc = Document()
+    _apply_brother_font(doc)
 
     # Determine currency-specific logo
     currency = getattr(loan, 'currency', 'GBP')


### PR DESCRIPTION
## Summary
- Apply Brother 1816 Light font to common Word styles
- Update DOCX generators to use Brother font for quote and loan summary reports
- Document Brother font usage for DOCX report generation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'selenium'; No module named 'flask')*
- `pip install flask selenium` *(fails: Could not find a version that satisfies the requirement flask due to proxy; No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbccaa09c83208e55cb9b85ca432f