### PR TITLE
Handle missing python-docx dependency

### DIFF
--- a/Requirements.txt
+++ b/Requirements.txt
@@ -1,3 +1,5 @@
 # Minimal requirements for running tests in constrained environments
 selenium>=4.34.2
 chromedriver-autoinstaller>=0.6.2
+flask>=3.1.1
+python-docx>=1.2.0

--- a/pdf_quote_generator.py
+++ b/pdf_quote_generator.py
@@ -83,9 +83,15 @@ def generate_quote_pdf(quote_data, application_data=None):
 
 def generate_professional_quote_docx(quote_data, application_data=None):
     """Generate professional DOCX quote document"""
-    from docx import Document
-    from docx.shared import Inches
-    from docx.enum.text import WD_ALIGN_PARAGRAPH
+    try:
+        from docx import Document
+        from docx.shared import Inches
+        from docx.enum.text import WD_ALIGN_PARAGRAPH
+    except ModuleNotFoundError:
+        # Required dependency is missing. Return ``None`` so callers can
+        # provide a helpful error message rather than raising an
+        # unhandled exception which results in a generic 500 response.
+        return None
 
     doc = Document()
 
@@ -156,9 +162,12 @@ def generate_professional_quote_docx(quote_data, application_data=None):
 
 def generate_loan_summary_docx(loan):
     """Generate DOCX loan summary report."""
-    from docx import Document
-    from docx.shared import Inches
-    from docx.enum.text import WD_ALIGN_PARAGRAPH
+    try:
+        from docx import Document
+        from docx.shared import Inches
+        from docx.enum.text import WD_ALIGN_PARAGRAPH
+    except ModuleNotFoundError:
+        return None
     import tempfile
 
     doc = Document()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "mammoth>=1.9.1",
     "python-docx>=1.2.0",
     "openpyxl>=3.1.5",
-    "docx>=0.2.4",
     "flask-cors>=6.0.1",
     "flask-jwt-extended>=4.7.1",
     "reportlab>=4.4.2",

--- a/routes.py
+++ b/routes.py
@@ -1699,10 +1699,17 @@ def download_professional_quote():
         
         # Generate professional DOCX using the fresh calculation results
         docx_content = generate_professional_quote_docx(fresh_calculation)
-        
+
         if not docx_content:
-            app.logger.error('Professional DOCX generation returned empty content')
-            return jsonify({'error': 'Professional DOCX generation failed - empty content'}), 500
+            app.logger.error('Professional DOCX generation failed - missing python-docx dependency')
+            return (
+                jsonify(
+                    {
+                        'error': 'Professional DOCX generation failed: python-docx dependency is not installed'
+                    }
+                ),
+                500,
+            )
 
         # Create response with comprehensive headers
         response = make_response(docx_content)
@@ -1723,8 +1730,8 @@ def download_professional_quote():
         return response
         
     except Exception as e:
-        app.logger.error(f"Professional PDF generation error: {str(e)}")
-        return jsonify({'error': 'Professional PDF generation failed'}), 500
+        app.logger.error(f"Professional DOCX generation error: {str(e)}")
+        return jsonify({'error': 'Professional DOCX generation failed'}), 500
 
 
 
@@ -2099,6 +2106,16 @@ def download_loan_summary_docx(loan_id):
     """Download saved loan summary as DOCX report."""
     loan = LoanSummary.query.get_or_404(loan_id)
     docx_content = generate_loan_summary_docx(loan)
+    if not docx_content:
+        app.logger.error('Loan summary DOCX generation failed - missing python-docx dependency')
+        return (
+            jsonify(
+                {
+                    'error': 'Loan summary DOCX generation failed: python-docx dependency is not installed'
+                }
+            ),
+            500,
+        )
     response = make_response(docx_content)
     response.headers['Content-Type'] = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
     response.headers['Content-Disposition'] = f'attachment; filename="{loan.loan_name}_Summary.docx"'
@@ -2510,7 +2527,14 @@ def generate_saved_quote(loan_id):
         if quote_type == 'professional':
             docx_content = generate_professional_quote_docx(calculation_data)
             if not docx_content:
-                return jsonify({'error': 'Professional quote generation failed'}), 500
+                return (
+                    jsonify(
+                        {
+                            'error': 'Professional quote generation failed: python-docx dependency is not installed'
+                        }
+                    ),
+                    500,
+                )
             
             response = make_response(docx_content)
             response.headers['Content-Type'] = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'


### PR DESCRIPTION
## Summary
- Gracefully handle missing `python-docx` in DOCX generation helpers
- Return clear error messages when DOCX exports are requested without the dependency
- Align dependencies by removing legacy `docx` package and documenting required modules

## Testing
- `pytest` *(fails: No module named 'selenium'; No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68bdbd15469c8320bd80c3df793988aa