### PR TITLE
Handle missing reportlab dependency for DOCX export

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -181,15 +181,15 @@ print_status "Installing Python dependencies..."
 if [ -f "deploy_requirements.txt" ]; then
     pip install -r deploy_requirements.txt
     # Ensure critical libraries not listed are installed
-    pip install "requests>=2.32.4" "scipy>=1.15.3" "webdriver-manager>=4.0.2"
+    pip install "requests>=2.32.4" "scipy>=1.15.3" "webdriver-manager>=4.0.2" "python-docx>=1.2.0"
 elif [ -f "requirements.txt" ]; then
     pip install -r requirements.txt
     # Ensure critical libraries not listed are installed
-    pip install "requests>=2.32.4" "scipy>=1.15.3" "webdriver-manager>=4.0.2"
+    pip install "requests>=2.32.4" "scipy>=1.15.3" "webdriver-manager>=4.0.2" "python-docx>=1.2.0"
 elif [ -f "Requirements.txt" ]; then
     pip install -r Requirements.txt
     # Ensure critical libraries not listed are installed
-    pip install "requests>=2.32.4" "scipy>=1.15.3" "webdriver-manager>=4.0.2"
+    pip install "requests>=2.32.4" "scipy>=1.15.3" "webdriver-manager>=4.0.2" "python-docx>=1.2.0"
 else
     # Install core dependencies with specific versions for compatibility
     pip install \

--- a/routes.py
+++ b/routes.py
@@ -1228,12 +1228,16 @@ def generate_quote_document(id):
         
         # Generate quote document as PDF
         pdf_content = generate_quote_pdf(loan_data, borrower_data)
-        
+        if not pdf_content:
+            app.logger.error('PDF generation failed - missing reportlab dependency')
+            flash('PDF generation failed: reportlab dependency is not installed', 'error')
+            return redirect(url_for('quote_detail', id=id))
+
         # Create response
         response = make_response(pdf_content)
         response.headers['Content-Type'] = 'application/pdf'
         response.headers['Content-Disposition'] = f'attachment; filename=quote_{quote.id}.pdf'
-        
+
         return response
         
     except Exception as e:
@@ -1274,12 +1278,15 @@ def api_generate_pdf_quote():
         
         # Generate PDF
         pdf_content = generate_quote_pdf(quote_data, application_data)
-        
+        if not pdf_content:
+            app.logger.error('PDF generation failed - missing reportlab dependency')
+            return jsonify({'error': 'PDF generation failed: reportlab dependency is not installed'}), 500
+
         # Create response
         response = make_response(pdf_content)
         response.headers['Content-Type'] = 'application/pdf'
         response.headers['Content-Disposition'] = f'attachment; filename=novellus_quote_{quote_data["id"]}.pdf'
-        
+
         return response
         
     except Exception as e:
@@ -1403,12 +1410,16 @@ def download_quote_pdf(id):
         
         # Generate PDF
         pdf_content = generate_quote_pdf(quote_data, application_data)
-        
+        if not pdf_content:
+            app.logger.error('PDF generation failed - missing reportlab dependency')
+            flash('PDF generation failed: reportlab dependency is not installed', 'error')
+            return redirect(url_for('quote_detail', id=id))
+
         # Create response
         response = make_response(pdf_content)
         response.headers['Content-Type'] = 'application/pdf'
         response.headers['Content-Disposition'] = f'attachment; filename=novellus_quote_{quote.id}.pdf'
-        
+
         return response
         
     except Exception as e:
@@ -1782,10 +1793,10 @@ def download_pdf_quote():
         
         # Generate PDF with charts
         pdf_content = generate_quote_pdf(quote_data, application_data)
-        
+
         if not pdf_content:
-            app.logger.error('PDF generation returned empty content')
-            return jsonify({'error': 'PDF generation failed - empty content'}), 500
+            app.logger.error('PDF generation failed - missing reportlab dependency')
+            return jsonify({'error': 'PDF generation failed: reportlab dependency is not installed'}), 500
         
         # Create response with proper headers
         response = make_response(pdf_content)


### PR DESCRIPTION
## Summary
- Import `reportlab` lazily in `pdf_quote_generator` and gate PDF generation behind availability check
- Add graceful error handling in routes when PDF generation is requested without `reportlab`
- Ensure `install.sh` explicitly installs `python-docx` when using any requirements file

## Testing
- `python -m pip install -r Requirements.txt` *(failed: Could not connect to proxy / no matching distribution for selenium>=4.34.2)*
- `pytest` *(failed: ModuleNotFoundError: No module named 'selenium'; No module named 'flask')*
- `python - <<'PY'` to import `docx` *(failed: No module named 'docx')*


------
https://chatgpt.com/codex/tasks/task_e_68bdc032139883208cac9972e9e9d14a