### PR TITLE
Enhance loan summary docx with user mapping and styling

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -2112,11 +2112,12 @@ def save_loan():
         return jsonify({'error': f'Failed to save loan: {str(e)}'}), 500
 
 
-@app.route('/loan/<int:loan_id>/summary-docx')
+@app.route('/loan/<int:loan_id>/summary-docx', methods=['GET', 'POST'])
 def download_loan_summary_docx(loan_id):
     """Download saved loan summary as DOCX report."""
     loan = LoanSummary.query.get_or_404(loan_id)
-    docx_content = generate_loan_summary_docx(loan)
+    extra_fields = request.get_json() if request.method == 'POST' else {}
+    docx_content = generate_loan_summary_docx(loan, extra_fields)
     if not docx_content:
         app.logger.error('Loan summary DOCX generation failed - missing python-docx dependency')
         return (

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1942,6 +1942,51 @@ document.addEventListener('DOMContentLoaded', async function() {
     updateSummaryDocxIcon();
     updateLoanReportLink();
 
+    const docxLink = document.getElementById('downloadSummaryDocx');
+    if (docxLink) {
+        docxLink.addEventListener('click', function(e) {
+            e.preventDefault();
+            const modal = new bootstrap.Modal(document.getElementById('loanSummaryFieldsModal'));
+            modal.show();
+        });
+    }
+
+    const generateDocxBtn = document.getElementById('generateSummaryDocx');
+    if (generateDocxBtn) {
+        generateDocxBtn.addEventListener('click', async function() {
+            const data = {
+                property_address: document.getElementById('docxPropertyAddress').value,
+                debenture: document.getElementById('docxDebenture').value,
+                corporate_guarantor: document.getElementById('docxGuarantor').value,
+                broker_name: document.getElementById('docxBrokerName').value,
+                brokerage: document.getElementById('docxBrokerage').value,
+                max_ltv: document.getElementById('docxMaxLtv').value,
+                exit_fee_percent: document.getElementById('docxExitFee').value,
+                commitment_fee: document.getElementById('docxCommitmentFee').value
+            };
+
+            const response = await fetch(`/loan/${window.editMode.loanId}/summary-docx`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+
+            const blob = await response.blob();
+            const url = window.URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `${window.editMode.loanId}_Summary.docx`;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            window.URL.revokeObjectURL(url);
+
+            const modalEl = document.getElementById('loanSummaryFieldsModal');
+            const modalInstance = bootstrap.Modal.getInstance(modalEl);
+            if (modalInstance) modalInstance.hide();
+        });
+    }
+
     // Initialize save loan functionality
     const saveLoanBtn = document.getElementById('saveLoanBtn');
     
@@ -2188,6 +2233,55 @@ function retryLoanSave() {
 }
 </style>
 <!-- Database Info Modal -->
+<div class="modal fade" id="loanSummaryFieldsModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Loan Summary Fields</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div class="mb-3">
+          <label for="docxPropertyAddress" class="form-label">Property Address</label>
+          <input type="text" class="form-control" id="docxPropertyAddress">
+        </div>
+        <div class="mb-3">
+          <label for="docxDebenture" class="form-label">Debenture</label>
+          <input type="text" class="form-control" id="docxDebenture">
+        </div>
+        <div class="mb-3">
+          <label for="docxGuarantor" class="form-label">Corporate Guarantor</label>
+          <input type="text" class="form-control" id="docxGuarantor">
+        </div>
+        <div class="mb-3">
+          <label for="docxBrokerName" class="form-label">Broker Name</label>
+          <input type="text" class="form-control" id="docxBrokerName">
+        </div>
+        <div class="mb-3">
+          <label for="docxBrokerage" class="form-label">Brokerage</label>
+          <input type="text" class="form-control" id="docxBrokerage">
+        </div>
+        <div class="mb-3">
+          <label for="docxMaxLtv" class="form-label">Max LTV (%)</label>
+          <input type="number" step="0.01" class="form-control" id="docxMaxLtv">
+        </div>
+        <div class="mb-3">
+          <label for="docxExitFee" class="form-label">Exit Fee (%)</label>
+          <input type="number" step="0.01" class="form-control" id="docxExitFee">
+        </div>
+        <div class="mb-3">
+          <label for="docxCommitmentFee" class="form-label">Commitment Fee</label>
+          <input type="number" step="0.01" class="form-control" id="docxCommitmentFee">
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="generateSummaryDocx">Generate</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <div aria-hidden="true" aria-labelledby="databaseInfoModalLabel" class="modal fade" id="databaseInfoModal" tabindex="-1">
 <div class="modal-dialog modal-lg">
 <div class="modal-content">


### PR DESCRIPTION
## Summary
- Add dynamic loan-summary heading color and bolded fields in DOCX output
- Map additional user-entered fields (address, debenture, broker, fees, etc.) into generated reports
- Introduce modal form and fetch-based generation flow for loan summary DOCX download

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install flask` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68be060a44888320a8bb307163130944