### PR TITLE
Ensure report fields icon always visible

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1904,14 +1904,15 @@ function updateSummaryDocxIcon() {
     const link = document.getElementById('downloadSummaryDocx');
     const configLink = document.getElementById('openReportFields');
     if (!link || !configLink) return;
+    // Always show the report fields icon, even if the loan hasn't been saved
+    configLink.style.display = 'inline';
+
     if (isLoanSaved && window.editMode && window.editMode.loanId) {
         link.style.display = 'inline';
         link.href = `/loan/${window.editMode.loanId}/summary-docx`;
-        configLink.style.display = 'inline';
     } else {
         link.style.display = 'none';
         link.removeAttribute('href');
-        configLink.style.display = 'none';
     }
 }
 


### PR DESCRIPTION
## Summary
- Show report fields icon even when a loan hasn't been saved
- Keep report field editor bound so the modal opens on icon click

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r Requirements.txt` *(fails: Could not find a version that satisfies the requirement selenium>=4.34.2)*

------
https://chatgpt.com/codex/tasks/task_e_68be18c389e48320bbeba5af47b0bd09