### PR TITLE
Show report field edit icon after loan save

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -909,6 +909,7 @@
 <div class="card-header d-flex justify-content-center align-items-center position-relative bg-primary text-white fw-bold border border-dark" data-currency="GBP">
                     <span>Loan Summary</span>
                     <div class="position-absolute top-50 end-0 translate-middle-y d-flex">
+                        <a id="openReportFields" href="#" class="btn btn-sm btn-light me-2 report-fields-link" style="display:none;" title="Edit Report Fields"><i class="fas fa-list"></i></a>
                         <a id="openLoanReport" class="btn btn-sm btn-light me-2" href="#" style="display:none;" target="_blank" title="Open Loan Report">
                             <i class="fas fa-chart-column"></i>
                         </a>
@@ -922,16 +923,15 @@
 <div class="card-body p-0">
 <table class="table" style="border: 1px solid #000; border-collapse: collapse;">
 <thead>
-<tr style="border: 1px solid #000; background: #f8f9fa;">
-<th class="px-3" style="color: #000 !important; border-right: 1px solid #000;"></th>
-<th class="px-3 text-end" style="color: #000 !important; border-right: 1px solid #000;"></th>
-<th class="px-3 text-end" style="color: #000 !important;">
-    <a id="openReportFields" href="#" class="me-2 report-fields-link" title="Edit Report Fields"><i class="fas fa-list"></i></a>
-    <a id="downloadSummaryDocx" href="#" style="display:none;" title="Download Loan Summary"><i class="fas fa-file-word"></i></a>
-</th>
-</tr>
-</thead>
-<tbody>
+                            <tr style="border: 1px solid #000; background: #f8f9fa;">
+                                <th class="px-3" style="color: #000 !important; border-right: 1px solid #000;"></th>
+                                <th class="px-3 text-end" style="color: #000 !important; border-right: 1px solid #000;"></th>
+                                <th class="px-3 text-end" style="color: #000 !important;">
+                                    <a id="downloadSummaryDocx" href="#" style="display:none;" title="Download Loan Summary"><i class="fas fa-file-word"></i></a>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
 <tr style="border: 1px solid #000;">
 <td class="px-3" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;">Valuation</td>
 <td class="text-end px-3 currency-symbol" style="color: #000 !important; border-right: 1px solid #000; background: #f8f9fa;">£</td>
@@ -1903,13 +1903,13 @@ function updateSummaryDocxIcon() {
     const link = document.getElementById('downloadSummaryDocx');
     const configLink = document.getElementById('openReportFields');
     if (!link || !configLink) return;
-    // Always show the report fields icon, even if the loan hasn't been saved
-    configLink.style.display = 'inline';
 
     if (isLoanSaved && window.editMode && window.editMode.loanId) {
+        configLink.style.display = 'inline';
         link.style.display = 'inline';
         link.href = `/loan/${window.editMode.loanId}/summary-docx`;
     } else {
+        configLink.style.display = 'none';
         link.style.display = 'none';
         link.removeAttribute('href');
     }


### PR DESCRIPTION
## Summary
- Move report field editor button into Loan Summary card header
- Only display report field editor and DOCX export when loan is saved

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68be823fe3f083208aa270522b66af02