### PR TITLE
Handle commit errors in manage_report_fields

### DIFF
--- a/test_report_fields_length.py
+++ b/test_report_fields_length.py
@@ -1,0 +1,32 @@
+import pytest
+
+pytest.importorskip("flask")
+pytest.importorskip("app")
+
+from app import app, db
+from models import LoanSummary, ReportFields
+
+
+def _create_loan():
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+        loan = LoanSummary(loan_name="Test", loan_type="bridge")
+        db.session.add(loan)
+        db.session.commit()
+        return loan.id
+
+
+def test_broker_name_length_limit():
+    loan_id = _create_loan()
+    client = app.test_client()
+    long_name = "a" * 201
+    payload = {"broker_name": long_name, "brokerage": "ok"}
+
+    res = client.post(f"/loan/{loan_id}/report-fields", json=payload)
+    assert res.status_code == 400
+    assert "error" in res.get_json()
+
+    with app.app_context():
+        rf = ReportFields.query.filter_by(loan_id=loan_id).first()
+        assert rf is None


### PR DESCRIPTION
## Summary
- ensure tables exist and validate broker fields length before saving report fields
- expose commit exceptions in error response for easier debugging
- add test covering broker name length validation

## Testing
- `DATABASE_URL=sqlite:///:memory: pytest test_report_fields_numeric.py test_report_fields_length.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be969ed1348320b5bbd2470a66366e