### PR TITLE
Add tooltip validation and disable calculate until form valid

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -179,6 +179,19 @@ class LoanCalculator {
             });
         }
 
+        // Live validation to toggle calculate button
+        const requiredFields = this.form.querySelectorAll('[required]');
+        const toggleCalculate = () => {
+            const valid = Novellus.forms.validate(this.form);
+            if (calcBtn) {
+                calcBtn.disabled = !valid;
+            }
+        };
+        requiredFields.forEach(field => {
+            field.addEventListener('input', toggleCalculate);
+            field.addEventListener('change', toggleCalculate);
+        });
+
         // Loan type and repayment option changes with error handling
         document.getElementById('loanType').addEventListener('change', () => {
             try {

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -209,14 +209,29 @@ Novellus.forms = {
         const invalidFields = [];
         const requiredFields = form.querySelectorAll('[required]');
 
+        // Helper to remove tooltip
+        const removeTooltip = (field) => {
+            const tooltip = bootstrap.Tooltip.getInstance(field);
+            if (tooltip) tooltip.dispose();
+            field.removeAttribute('data-bs-toggle');
+            field.removeAttribute('title');
+        };
+
         requiredFields.forEach(field => {
+            const label = form.querySelector(`label[for="${field.id}"]`);
+            const labelText = label ? label.textContent.trim() : field.name || field.id;
             if (!field.value.trim()) {
                 field.classList.add('is-invalid');
+                field.dataset.bsToggle = 'tooltip';
+                field.title = `${labelText} is required`;
+                if (!bootstrap.Tooltip.getInstance(field)) {
+                    new bootstrap.Tooltip(field);
+                }
                 isValid = false;
-                const label = form.querySelector(`label[for="${field.id}"]`);
-                invalidFields.push(label ? label.textContent.trim() : field.name || field.id);
+                invalidFields.push(labelText);
             } else {
                 field.classList.remove('is-invalid');
+                removeTooltip(field);
             }
         });
 
@@ -225,9 +240,17 @@ Novellus.forms = {
         emailFields.forEach(field => {
             if (field.value && !Novellus.utils.validateEmail(field.value)) {
                 field.classList.add('is-invalid');
+                field.dataset.bsToggle = 'tooltip';
+                field.title = 'Invalid email address';
+                if (!bootstrap.Tooltip.getInstance(field)) {
+                    new bootstrap.Tooltip(field);
+                }
                 isValid = false;
                 const label = form.querySelector(`label[for="${field.id}"]`);
                 invalidFields.push(label ? label.textContent.trim() : field.name || field.id);
+            } else {
+                field.classList.remove('is-invalid');
+                removeTooltip(field);
             }
         });
 
@@ -236,9 +259,17 @@ Novellus.forms = {
         phoneFields.forEach(field => {
             if (field.value && !Novellus.utils.validatePhone(field.value)) {
                 field.classList.add('is-invalid');
+                field.dataset.bsToggle = 'tooltip';
+                field.title = 'Invalid phone number';
+                if (!bootstrap.Tooltip.getInstance(field)) {
+                    new bootstrap.Tooltip(field);
+                }
                 isValid = false;
                 const label = form.querySelector(`label[for="${field.id}"]`);
                 invalidFields.push(label ? label.textContent.trim() : field.name || field.id);
+            } else {
+                field.classList.remove('is-invalid');
+                removeTooltip(field);
             }
         });
 
@@ -259,6 +290,10 @@ Novellus.forms = {
         const invalidFields = form.querySelectorAll('.is-invalid');
         invalidFields.forEach(field => {
             field.classList.remove('is-invalid');
+            const tooltip = bootstrap.Tooltip.getInstance(field);
+            if (tooltip) tooltip.dispose();
+            field.removeAttribute('data-bs-toggle');
+            field.removeAttribute('title');
         });
     }
 };

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -877,8 +877,8 @@
 </div>
 <!-- Calculate Button -->
 <div class="d-grid gap-2">
-<button class="btn btn-primary btn-lg calculate-button" data-currency="GBP" type="submit">
-<i class="fas fa-calculator me-2"></i>Calculate
+<button class="btn btn-primary btn-lg calculate-button" data-currency="GBP" type="submit" disabled>
+    <i class="fas fa-calculator me-2"></i>Calculate
                     </button>
 <button class="btn btn-success" data-currency="GBP" disabled="" id="saveLoanBtn" type="button">
 <i class="fas fa-save me-2"></i><span id="saveLoanText">Save Loan</span>


### PR DESCRIPTION
## Summary
- show Bootstrap tooltips with descriptive messages for required, email, and phone validation
- live-validate form fields and enable the Calculate button only when the form passes validation
- disable Calculate button by default in the calculator template

## Testing
- `pytest -q` *(fails: No chrome executable found on PATH; FlaskClient has no attribute cookie_jar)*

------
https://chatgpt.com/codex/tasks/task_e_68beb6a0e8c88320b12f5753ea7d0087