### PR TITLE
Fix loan term validation when using end date

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1339,8 +1339,22 @@ function calculateEndDate() {
 
 function toggleLoanEndInputs() {
     const mode = document.querySelector('input[name="loan_end_type"]:checked').value;
-    document.getElementById('loanTermContainer').style.display = mode === 'term' ? '' : 'none';
-    document.getElementById('endDateContainer').style.display = mode === 'term' ? 'none' : '';
+    const loanTermContainer = document.getElementById('loanTermContainer');
+    const endDateContainer = document.getElementById('endDateContainer');
+    const loanTermInput = document.getElementById('loanTerm');
+    const endDateInput = document.getElementById('endDate');
+
+    if (mode === 'term') {
+        loanTermContainer.style.display = '';
+        endDateContainer.style.display = 'none';
+        if (loanTermInput) loanTermInput.required = true;
+        if (endDateInput) endDateInput.required = false;
+    } else {
+        loanTermContainer.style.display = 'none';
+        endDateContainer.style.display = '';
+        if (loanTermInput) loanTermInput.required = false;
+        if (endDateInput) endDateInput.required = true;
+    }
 }
 
 // Helper function to trigger calculation update when dates change

--- a/templates/scenario_comparison.html
+++ b/templates/scenario_comparison.html
@@ -1763,14 +1763,23 @@
             const loanTermContainer = document.getElementById('loanTermContainer');
             const endDateContainer = document.getElementById('endDateContainer');
             const endDate = document.getElementById('endDate');
+            const loanTerm = document.getElementById('loanTerm');
             if (mode === 'term') {
                 loanTermContainer.style.display = '';
                 endDateContainer.style.display = 'none';
-                if (endDate) endDate.setAttribute('readonly', '');
+                if (endDate) {
+                    endDate.setAttribute('readonly', '');
+                    endDate.required = false;
+                }
+                if (loanTerm) loanTerm.required = true;
             } else {
                 loanTermContainer.style.display = 'none';
                 endDateContainer.style.display = '';
-                if (endDate) endDate.removeAttribute('readonly');
+                if (endDate) {
+                    endDate.removeAttribute('readonly');
+                    endDate.required = true;
+                }
+                if (loanTerm) loanTerm.required = false;
             }
         }
 


### PR DESCRIPTION
## Summary
- allow calculator to accept end-date based loans without triggering loan term validation
- ensure scenario comparison toggles required attributes between term months and end date

## Testing
- `pytest test_calculator_term_end_date_toggle.py::test_toggle_preserves_values -q` *(fails: No module named 'flask_jwt_extended')*

------
https://chatgpt.com/codex/tasks/task_e_68beb7d741848320a0c01c567b77e71a