### PR TITLE
feat: support silent form validation

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -182,7 +182,7 @@ class LoanCalculator {
         // Live validation to toggle calculate button
         const requiredFields = this.form.querySelectorAll('[required]');
         const toggleCalculate = () => {
-            const valid = Novellus.forms.validate(this.form);
+            const valid = Novellus.forms.validate(this.form, false);
             if (calcBtn) {
                 calcBtn.disabled = !valid;
             }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -204,7 +204,7 @@ Novellus.forms = {
     },
 
     // Validate form
-    validate: function(form) {
+    validate: function(form, showToast = true) {
         let isValid = true;
         const invalidFields = [];
         const requiredFields = form.querySelectorAll('[required]');
@@ -273,7 +273,7 @@ Novellus.forms = {
             }
         });
 
-        if (!isValid) {
+        if (!isValid && showToast) {
             const message = 'Please correct: ' + invalidFields.join(', ');
             if (window.notifications) {
                 window.notifications.error(message);


### PR DESCRIPTION
## Summary
- add `showToast` option to `Novellus.forms.validate`
- use silent validation for calculator inputs

## Testing
- `pytest` *(fails: No chrome executable found on PATH; AttributeError: 'FlaskClient' object has no attribute 'cookie_jar')*


------
https://chatgpt.com/codex/tasks/task_e_68beba4531548320a0e3f9c954b05534