### PR TITLE
Fix end-date term calculation and add test

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1331,7 +1331,16 @@ function calculateEndDate() {
                 window.loanCalculator.update360DayVisibility();
             }
 
-            // Do not map end date back to a loan term to avoid incorrect month calculations
+            // Derive loan term (months) from start/end dates
+            const endPlusOne = new Date(endObj);
+            endPlusOne.setUTCDate(endPlusOne.getUTCDate() + 1);
+            let months = (endPlusOne.getUTCFullYear() - startObj.getUTCFullYear()) * 12 +
+                         (endPlusOne.getUTCMonth() - startObj.getUTCMonth());
+            if (endPlusOne.getUTCDate() < startObj.getUTCDate()) {
+                months -= 1;
+            }
+            loanTermEl.value = months > 0 ? months : '';
+
             triggerCalculationUpdate();
         }
     }

--- a/templates/scenario_comparison.html
+++ b/templates/scenario_comparison.html
@@ -1799,8 +1799,23 @@
                     endDateEl.value = end.toISOString().split('T')[0];
                 }
             } else {
-                // In end date mode, avoid deriving a loan term from the end date
-                // to prevent incorrect month mappings during editing.
+                const endDate = endDateEl.value;
+                if (startDate && endDate) {
+                    const startObj = new Date(startDate);
+                    const endObj = new Date(endDate);
+                    if (endObj < startObj) {
+                        endDateEl.value = startDate;
+                        endObj.setTime(startObj.getTime());
+                    }
+                    const endPlusOne = new Date(endObj);
+                    endPlusOne.setUTCDate(endPlusOne.getUTCDate() + 1);
+                    let months = (endPlusOne.getUTCFullYear() - startObj.getUTCFullYear()) * 12 +
+                                 (endPlusOne.getUTCMonth() - startObj.getUTCMonth());
+                    if (endPlusOne.getUTCDate() < startObj.getUTCDate()) {
+                        months -= 1;
+                    }
+                    loanTermEl.value = months > 0 ? months : '';
+                }
             }
         }
     </script>

--- a/test_end_date_populates_term.py
+++ b/test_end_date_populates_term.py
@@ -1,0 +1,22 @@
+import pytest
+from selenium.webdriver.common.by import By
+
+from test_calculator_page import live_server, _get_chrome_driver
+
+
+def test_end_date_populates_term(live_server):
+    driver = _get_chrome_driver()
+    try:
+        driver.get(live_server + "/calculator")
+        start = driver.find_element(By.ID, "startDate")
+        start.clear()
+        start.send_keys("2024-01-01")
+        driver.find_element(By.ID, "loanEndDateOption").click()
+        end = driver.find_element(By.ID, "endDate")
+        end.clear()
+        end.send_keys("2024-12-31")
+        driver.execute_script("calculateEndDate();")
+        term_val = driver.find_element(By.ID, "loanTerm").get_attribute("value")
+        assert term_val == "12"
+    finally:
+        driver.quit()


### PR DESCRIPTION
## Summary
- derive loan term (months) from start/end dates when using end-date mode
- sync scenario comparison end-date mode with term calculation
- cover end-date term derivation with a Selenium test

## Testing
- `pytest test_end_date_populates_term.py -q`
- `pytest test_calculator_term_end_date_toggle.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bebc3d6cd08320a70cef9075a4bf29