### PR TITLE
Fix loan edit form rate field population

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1638,7 +1638,12 @@ function handleEditMode() {
                             const formatted = typeof value === 'boolean'
                                 ? value.toString().toLowerCase()
                                 : value;
+                            const snakeKey = key.replace(/[A-Z]/g, letter => '_' + letter.toLowerCase());
+                            paramsFromData.set(snakeKey, formatted);
                             paramsFromData.set(key, formatted);
+                            if (snakeKey === 'interest_rate') {
+                                paramsFromData.set('annual_rate', formatted);
+                            }
                         }
 
                         populateFormFromParams(paramsFromData);
@@ -1677,6 +1682,7 @@ function populateFormFromParams(params) {
         'gross_amount_percentage': 'grossAmountPercentage',
         'property_value': 'propertyValue',
         'annual_rate': 'annualRateValue',
+        'interest_rate': 'annualRateValue',
         'monthly_rate': 'monthlyRateValue',
         'loan_term': 'loanTerm',
         'start_date': 'startDate',


### PR DESCRIPTION
## Summary
- Ensure saved loans populate interest rate fields correctly when editing
- Map interest_rate to annual_rate and convert camelCase keys to snake_case

## Testing
- `pytest test_calculator_editing_fields.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bed84b4d6483209638a938c859b38f