### PR TITLE
Add Loan Notes management page

### DIFF
--- a/database_init.py
+++ b/database_init.py
@@ -34,8 +34,16 @@ def init_database():
                 logger.info("Models imported successfully")
                 
                 # Verify critical loan calculator models are available
-                from models import LoanSummary, PaymentSchedule, User, Application
-                logger.info("Loan calculator storage models verified: LoanSummary, PaymentSchedule")
+                from models import (
+                    LoanSummary,
+                    PaymentSchedule,
+                    User,
+                    Application,
+                    LoanNote,
+                )
+                logger.info(
+                    "Loan calculator storage models verified: LoanSummary, PaymentSchedule"
+                )
                 
             except ImportError as e:
                 logger.warning(f"Could not import models: {e}")
@@ -44,6 +52,90 @@ def init_database():
             # Create all tables
             db.create_all()
             logger.info("Database tables created")
+
+            # Seed LoanNote data if empty
+            if 'loan_notes' in db.inspect(db.engine).get_table_names():
+                if LoanNote.query.count() == 0:
+                    logger.info("Seeding Loan Notes table")
+                    loan_notes_data = [
+                        {"group": "Salient Points", "name": "Legal Costs / Fees (including Title Insurance and site visit, if applicable) are estimated at this stage. The final net advance figures will need to be adjusted accordingly to reflect final costs including any other (as yet unquoted) deductions.", "add_flag": True},
+                        {"group": "Salient Points", "name": "[if applicable] [Broker fees to be paid directly by the Borrower or can be added to the Arrangement Fee (tbc).]", "add_flag": True},
+                        {"group": "Salient Points", "name": "The arrangement fee is €4,000.00 i.e. 2.00% of the gross loan of which 50% is paid to the broker (of which 50% is paid to Broker, Broker1).", "add_flag": True},
+                        {"group": "Salient Points", "name": "The loan Term is 13 months in total (the \u201cTerm\u201d).", "add_flag": True},
+                        {"group": "Salient Points", "name": "Day 1 Net Advance of €166,691.40 to fund the purchase of/form part of the development tranche of the Property.", "add_flag": True},
+                        {"group": "Salient Points", "name": "Breach of value condition, loan not to exceed 70.00% LTV (gross) throughout the Term.", "add_flag": True},
+                        {"group": "Salient Points", "name": "There is a 2.00% exit fee in the sum of €4,000.00 that is payable upon the redemption of this loan. This is in addition to the fee referred to at clause [facility fee clause number] below.", "add_flag": True},
+                        {"group": "Salient Points", "name": "[If Term Loan] The following exit fees apply to the loan: (a) a 3.00% exit fee (in the sum of €[\u2022]) that applies if the loan redeems at any time in year 1 of the Term (subject always to the minimum interest period); (b) 2.00% exit fee (in the sum of €[\u2022]) that applies if the loan redeems at any time in year 2 of the Term; and (c) a 1.00% exit fee (in the sum of €[\u2022]) that applies if the loan redeems at any time thereafter.", "add_flag": True},
+                        {"group": "Salient Points", "name": "For the avoidance of doubt, the exit fee is payable in addition to the fee referred to at clause [facility fee clause number] below.", "add_flag": True},
+                        {"group": "Salient Points", "name": "A commitment fee of €40,000.00 is payable upon signing Novellus' non-binding offer letter. This fee shall only be refunded to the Borrower if the loan completes within 6 weeks from the date of Novellus\u2019 NBOL.", "add_flag": True},
+                        {"group": "Salient Points", "name": "Facility Fee: 2.00% of the loan which will be payable by the Borrower if either (1) the loan is not repaid in full on or before the repayment date (as defined in the Facility Agreement ) or (2) an event of default pursuant to the Facility Agreement occurs (and has not been waived by Novellus). This is in addition to any exit fee.", "add_flag": True},
+                        {"group": "Salient Points", "name": "The minimum interest period is [\u2022] months.", "add_flag": True},
+                        {"group": "Salient Points", "name": "[The retained] Interest is estimated, based on a drawing of €[\u2022] per month during months [\u2022]-[\u2022] of the Term, [in addition to the Day 1 Net Advance].", "add_flag": True},
+                        {"group": "Salient Points", "name": "No Early Repayment Charges (ERCs) save for a minimum notice period of 28 days to repay (or interest equivalent).", "add_flag": True},
+                        {"group": "Salient Points", "name": "Interest to be serviced monthly in advance/arrears.", "add_flag": True},
+                        {"group": "Salient Points", "name": "The loan will be subject to interest and capital repayments throughout the Term. The minimum monthly payment shall be €[\u2022] (to be applied as interest first with the balance applied to the loan as capital reduction(s)) and is payable monthly in arrears.", "add_flag": True},
+                        {"group": "Salient Points", "name": "Net advance includes the first month interest deduction of €0.00.", "add_flag": True},
+                        {"group": "Salient Points", "name": "The interest rate is fixed at 12.00% p.a. for the Term.", "add_flag": True},
+                        {"group": "Salient Points", "name": "An application fee of €495.00 is payable upon the acceptance of these terms.", "add_flag": True},
+
+                        {"group": "Standard AML Pre-Conditions", "name": "Satisfactory proof that the source of any introduced funds is legitimate (together with any supporting documentation required by Novellus to evidence this).", "add_flag": True},
+                        {"group": "Standard AML Pre-Conditions", "name": "Full satisfactory KYC for the Borrower [and Personal / Corporate Guarantor].", "add_flag": True},
+                        {"group": "Standard AML Pre-Conditions", "name": "Guarantor(s) Personal Public Service (PPS) number (evidenced by way of documentation duly certified by solicitor) and contact details as required by the Central Credit Register.", "add_flag": True},
+                        {"group": "Standard AML Pre-Conditions", "name": "[Documentary evidence of PPSN for the Personal Guarantor(s) certified as true copies by the Borrower\u2019s / Personal Guarantor(s)\u2019 solicitors.]", "add_flag": True},
+                        {"group": "Standard AML Pre-Conditions", "name": "Two proof of address documents for all individuals involved in the transaction (no older than 3 months prior to the date of drawdown) to be certified as true copies by the Borrower's solicitors. Valid photo ID(s) (for all individuals involved in the transaction) to be certified as true copies by the Borrower's solicitors.", "add_flag": True},
+                        {"group": "Standard AML Pre-Conditions", "name": "[if applicable] Certified structure chart of the Borrower [and Corporate Guarantor].", "add_flag": True},
+
+                        {"group": "Standard Financial Pre-Conditions", "name": "Any existing director / shareholder loans and / or equity introduced into the Borrower (prior to and/or at any time during the Term) shall be fully subordinated to Novellus\u2019 loan by way of intercreditor deed(s) signed between all relevant parties and Novellus.", "add_flag": True},
+                        {"group": "Standard Financial Pre-Conditions", "name": "[Approval from a tax advisor appointed by Novellus (the costs of which shall be borne by the Borrower), to the satisfaction of Novellus, of the proposed structure of the transaction and refinancing of the director\u2019s loan(s).]", "add_flag": True},
+                        {"group": "Standard Financial Pre-Conditions", "name": "Last 3 months bank statements of the Borrower and [Personal / Corporate Guarantor] to be provided by their respective accountants.", "add_flag": True},
+                        {"group": "Standard Financial Pre-Conditions", "name": "[If required by Novellus, Corporate Guarantor\u2019s latest audited and filed accounts (including financial statements).]", "add_flag": True},
+                        {"group": "Standard Financial Pre-Conditions", "name": "Borrower\u2019s most recent management accounts for the last three years, up to [\u2022] (to be certified by the Borrower\u2019s accountant).", "add_flag": True},
+                        {"group": "Standard Financial Pre-Conditions", "name": "Written confirmation from the Borrower\u2019s and [Personal / Corporate Guarantor\u2019s] accountants that all tax affairs of the Borrower and [Personal / Corporate Guarantor] are up to date and in order or up to date tax clearance certificates for the Borrower and [Personal / Corporate Guarantor].", "add_flag": True},
+                        {"group": "Standard Financial Pre-Conditions", "name": "Borrower to evidence to Novellus\u2019 satisfaction that it has the funds to cover the balance of funds required for completion of the development at the Property (including, but not limited to, all fees, taxes and ongoing costs).", "add_flag": True},
+                        {"group": "Standard Financial Pre-Conditions", "name": "Asset & Liability statements from the Borrower(s) and [Corporate Guarantor] to be provided and certified by the Borrower\u2019s accountants.", "add_flag": True},
+                        {"group": "Standard Financial Pre-Conditions", "name": "Subject to the sale agreement being reviewed by Novellus, to its satisfaction, evidencing the purchase price of [\u2022] and the Borrower evidencing it has the funds to cover the balance of funds required for the purchase together with all fees, taxes and ongoing costs.", "add_flag": True},
+                        {"group": "Standard Financial Pre-Conditions", "name": "[if applicable][Details and background as to the arrangement concerning the director\u2019s loan balance (including, but not limited to, a redemption statement(s))].", "add_flag": True},
+                        {"group": "Standard Financial Pre-Conditions", "name": "[Novellus to be satisfied with current/projected trading performance of the Property (including, but not limited to, management accounts up to [\u2022] (certified by the Borrower\u2019s accountants).]", "add_flag": True},
+
+                        {"group": "Standard General Conditions", "name": "Certificate(s) of Title (in PSL format) or Report(s) on Title in connection with the Property to be provided to the satisfaction of Novellus.", "add_flag": True},
+                        {"group": "Standard General Conditions", "name": "Novellus to be satisfied with any commercial leases in place at the Property.", "add_flag": True},
+                        {"group": "Standard General Conditions", "name": "The Borrower or Guarantor(s) shall not reside in the Property (or any part of it) and shall procure that none of the members of its family reside in the Property (or any part of it).", "add_flag": True},
+                        {"group": "Standard General Conditions", "name": "The directors / officers and shareholders of the Borrower entity [and / or the Corporate Guarantor entity] shall not reside in the Property(ies) (or any part of it/them).", "add_flag": True},
+                        {"group": "Standard General Conditions", "name": "[The Personal Guarantor shall not reside in the Property(ies) (or any part of it)/them and shall procure that none of the members of their family reside in the Property(ies) (or any part of it)/them].", "add_flag": True},
+                        {"group": "Standard General Conditions", "name": "The Borrower [and the Corporate Guarantor] shall procure that none of the members of the families of any director / officer or shareholder of the Borrower entity [and / or the Corporate Guarantor entity] shall reside in the Property(ies) (or any part of it/them).", "add_flag": True},
+                        {"group": "Standard General Conditions", "name": "Novellus will undertake an inspection of the Property periodically.", "add_flag": True},
+                        {"group": "Standard General Conditions", "name": "The loan is subject to a full disclosure and details to be provided in relation to the background to the transaction and relationship(s) between relevant parties, to Novellus\u2019 full satisfaction.", "add_flag": True},
+                        {"group": "Standard General Conditions", "name": "Loan will be subject to (a) red-book valuation of the Property, addressed to Novellus, supporting the values presented [\u2022] (including the \u201cas is\u201d value and the GDV), on a [90]-day, VP basis. The valuer is to be appointed by Novellus and paid for by the Borrower (TBD).", "add_flag": True},
+                        {"group": "Standard General Conditions", "name": "Novellus Limited to be noted as first loss payee above €50,000 on the insurance policy covering the assets within this transaction.", "add_flag": True},
+                        {"group": "Standard General Conditions", "name": "The Borrower\u2019s firm of solicitors must have a minimum of 2 partners.", "add_flag": True},
+
+                        {"group": "Development Conditions", "name": "Borrower to evidence to Novellus\u2019 satisfaction that it has the resources available to cover the balance of funds required for completion of the development at the Property (including, but not limited to, all fees, taxes and ongoing costs).", "add_flag": True},
+                        {"group": "Development Conditions", "name": "Cost of works (including contingencies) to be provided on each drawdown (after the Day 1 Net Advance) to a maximum amount of €[\u2022] in total (to Novellus\u2019 satisfaction).", "add_flag": True},
+                        {"group": "Development Conditions", "name": "Loan will be subject to a structural engineer's review of the Property to Novellus\u2019 satisfaction and a structural engineer\u2019s report for the Property is to be provided / procured (on which Novellus will have reliance). If required, a structural engineer is to be appointed by Novellus and paid for by the Borrower (TBD).", "add_flag": True},
+                        {"group": "Development Conditions", "name": "Loan will be subject to a planning review of the Property and a planning report for the Property is to be provided / procured (on which Novellus will have reliance). If required, a planning consultant is to be appointed by Novellus and paid for by the Borrower (TBD).", "add_flag": True},
+                        {"group": "Development Conditions", "name": "Gross Development Value (GDV) of the Property to be appraised and approved by the Lender\u2019s QS in advance of any funds being released.", "add_flag": True},
+                        {"group": "Development Conditions", "name": "The Borrower shall provide a detailed schedule of proposed works with estimated costs (including contingencies), to be appraised and approved by Novellus' Quantity Surveyor (QS) in advance of any funds being released.", "add_flag": True},
+                        {"group": "Development Conditions", "name": "[The Borrower\u2019s QS and/or project manager will report monthly or at each drawdown request, with reports being provided to Novellus\u2019 satisfaction. Novellus will appoint its own QS and conduct inspections of the Property every month (or as otherwise reasonably required), with all associated costs (including Novellus\u2019 internal monitoring costs) to be paid and deducted in the manner set out above. The Borrower\u2019s QS and/or project manager must also confirm total expenditure and compliance with planning requirements in conjunction with site visits.", "add_flag": True},
+                        {"group": "Development Conditions", "name": "Subject to the development of the Property being completed by no later than month [\u2022] of the Term (with all necessary certifications, sign offs and requisite approvals) and the Property put up for sale by no later than the end of month [\u2022]of the Term with a reputable local agent, to Novellus\u2019 satisfaction.", "add_flag": True},
+
+                        {"group": "Financial Covenants", "name": "Maximum LTV 70.00%", "add_flag": True},
+                        {"group": "Financial Covenants", "name": "Minimum Debt Service Cover Ratio \u2013 minimum of [\u2022] based on [\u2022].", "add_flag": True},
+                        {"group": "Financial Covenants", "name": "Covenant compliance certificate confirming the financial covenants for the Borrower to be provided within one month of each Interest Payment Date (as defined in the Facility Agreement) during the Term. Quarterly management profit & loss statements for the Borrower to be received with each covenant compliance certificate.", "add_flag": True},
+                        {"group": "Financial Covenants", "name": "Draft year-end financial statements for the Borrower to be provided annually, within 3 months of the company\u2019s year-end, with full audited statements to be received not less than 120 days following the company\u2019s financial year end.", "add_flag": True},
+
+                        {"group": "Repayment Conditions", "name": "A reputable agent must be appointed by the Borrower within [\u2022] weeks of drawdown of the loan to market the Property for sale, with the Property to be sold within the Term. The agent is to be appointed and paid for by the Borrower and approved by Novellus.", "add_flag": True},
+                        {"group": "Repayment Conditions", "name": "Subject to the development of the Property being completed by no later than month [\u2022] of the Term (with all necessary certifications, sign offs and requisite approvals) and the Property put up for sale by no later than the end of month [\u2022] of the Term with a reputable local agent, to Novellus\u2019 satisfaction.", "add_flag": True},
+                        {"group": "Repayment Conditions", "name": "All net proceeds from the sale of the Property to be paid to Novellus in repayment of the loan. Borrower to provide regular sales updates in connection with the intended sale of the Property as part of an exit strategy for the loan.", "add_flag": True},
+                        {"group": "Repayment Conditions", "name": "The Borrower shall, within [\u2022] months of the drawdown date, enter into agreement(s) to lease the Property and provide evidence of the same (in the form of exchanged agreements) to Novellus\u2019 satisfaction. Any such agreement(s) shall be subject to Novellus\u2019 prior written approval.", "add_flag": True},
+                        {"group": "Repayment Conditions", "name": "The Borrower will demonstrate to the satisfaction of Novellus, no later than 90 days prior to the end of the Term, its ability to repay the  loan at the end of the Term. In the event of a refinance, this will include: No later than 90 days prior to the end of the Term, the Borrower will provide Novellus with evidence of having secured refinance heads of terms, demonstrating sufficient funding available to discharge the Borrower\u2019s liability to Novellus in full by the end of the Term; and No later than 45 days prior to the end of the Term, the Borrower will provide Novellus with evidence of having a signed facility letter reflecting the above-referenced refinance heads of terms, demonstrating sufficient funding available to discharge the Borrower\u2019s liability to Novellus in full by the end of the Term.", "add_flag": True},
+
+                        {"group": "Other Conditions", "name": "Subject to an evidenced clear path to exit.", "add_flag": True},
+                        {"group": "Other Conditions", "name": "This quote will expire within 7 days of this email.", "add_flag": True},
+                        {"group": "Other Conditions", "name": "[If the above is of interest to your client, please fill out the application form attached and arrange to pay the €495, bank details also attached. Should you have any questions, don't hesitate to contact us.]", "add_flag": True},
+                    ]
+                    for note in loan_notes_data:
+                        db.session.add(LoanNote(**note))
+                    db.session.commit()
             
             # Verify tables were created
             inspector = db.inspect(db.engine)

--- a/models.py
+++ b/models.py
@@ -367,3 +367,19 @@ class ReportFields(db.Model):
 
     def __repr__(self):
         return f'<ReportFields for Loan {self.loan_id}>'
+
+
+class LoanNote(db.Model):
+    """Stores standard loan notes grouped by category."""
+
+    __tablename__ = 'loan_notes'
+
+    id = db.Column(db.Integer, primary_key=True)
+    group = db.Column('group', db.String(100), nullable=False)
+    name = db.Column(db.Text, nullable=False)
+    add_flag = db.Column(db.Boolean, default=False)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    deleted_at = db.Column(db.DateTime)
+
+    def __repr__(self) -> str:
+        return f'<LoanNote {self.group}: {self.name[:20]}>'

--- a/templates/loan_notes.html
+++ b/templates/loan_notes.html
@@ -1,0 +1,96 @@
+{% extends "base.html" %}
+{% block title %}Loan Notes - Novellus Financial{% endblock %}
+{% block body_attr %}class="gold-nav"{% endblock %}
+{% block nav_heading %}<span class="navbar-text text-white text-center fw-bold">Loan Notes</span>{% endblock %}
+{% block head %}
+<link href="{{ url_for('static', filename='css/novellus-theme.css') }}" rel="stylesheet"/>
+{% endblock %}
+{% block content %}
+<div class="card">
+    <div class="card-header bg-primary text-white fw-bold">
+        Loan Notes
+    </div>
+    <div class="card-body p-0">
+        <table class="table" style="border: 1px solid #000; border-collapse: collapse;">
+            <thead>
+                <tr style="border: 1px solid #000; background: #f8f9fa;">
+                    <th class="px-3" style="color:#000!important; border-right:1px solid #000;">Group</th>
+                    <th class="px-3" style="color:#000!important; border-right:1px solid #000;">Name</th>
+                    <th class="px-3 text-center" style="color:#000!important;">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for note in notes %}
+                <tr style="border:1px solid #000;">
+                    <td class="px-3" style="color:#000!important; border-right:1px solid #000;">{{ note.group }}</td>
+                    <td class="px-3" style="color:#000!important; border-right:1px solid #000;">{{ note.name }}</td>
+                    <td class="px-3 text-center">
+                        <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#editNote{{note.id}}">Edit</button>
+                        <form method="post" action="{{ url_for('delete_loan_note', note_id=note.id) }}" style="display:inline;" onsubmit="return confirm('Delete this note?');">
+                            <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                        </form>
+                    </td>
+                </tr>
+                <div class="modal fade" id="editNote{{note.id}}" tabindex="-1">
+                    <div class="modal-dialog">
+                        <form class="modal-content" method="post" action="{{ url_for('update_loan_note', note_id=note.id) }}">
+                            <div class="modal-header">
+                                <h5 class="modal-title">Edit Note</h5>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                            </div>
+                            <div class="modal-body">
+                                <div class="mb-3">
+                                    <label class="form-label">Group</label>
+                                    <input type="text" class="form-control" name="group" value="{{ note.group }}" required>
+                                </div>
+                                <div class="mb-3">
+                                    <label class="form-label">Name</label>
+                                    <textarea class="form-control" name="name" rows="4" required>{{ note.name }}</textarea>
+                                </div>
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" name="add_flag" id="addFlag{{note.id}}" {% if note.add_flag %}checked{% endif %}>
+                                    <label class="form-check-label" for="addFlag{{note.id}}">Add Flag</label>
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                <button type="submit" class="btn btn-primary">Save</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="card mt-4">
+    <div class="card-header bg-secondary text-white">Add Loan Note</div>
+    <div class="card-body">
+        <form method="post" action="{{ url_for('add_loan_note') }}">
+            <div class="row">
+                <div class="col-md-3">
+                    <div class="mb-3">
+                        <label class="form-label">Group</label>
+                        <input type="text" class="form-control" name="group" required>
+                    </div>
+                </div>
+                <div class="col-md-7">
+                    <div class="mb-3">
+                        <label class="form-label">Name</label>
+                        <textarea class="form-control" name="name" rows="2" required></textarea>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="form-check mt-4">
+                        <input class="form-check-input" type="checkbox" name="add_flag" id="newAddFlag">
+                        <label class="form-check-label" for="newAddFlag">Add Flag</label>
+                    </div>
+                    <button type="submit" class="btn btn-primary mt-3">Add</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `LoanNote` model and seed default notes
- create administration page to view, add, edit, and remove loan notes
- link Loan Notes page in sidebar navigation

## Testing
- `pip install -r Requirements.txt`
- `pip install python-dotenv`
- `pip install flask_sqlalchemy`
- `pip install flask_login`
- `pip install flask_jwt_extended`
- `pip install flask_cors`
- `pip install openpyxl`
- `pytest` *(fails: No chrome executable found)*

------
https://chatgpt.com/codex/tasks/task_e_68beda85933c8320ba8a1a3fa011ce80