### PR TITLE
Style loan note action buttons

### DIFF
--- a/static/css/novellus-theme.css
+++ b/static/css/novellus-theme.css
@@ -1073,3 +1073,17 @@ h4, h5, h6 {
     background-color: #fff !important;
     color: #000 !important;
 }
+
+/* Loan note action buttons */
+.loan-note-actions .btn {
+    background-color: #fff;
+    color: #000;
+    border-color: #000;
+}
+
+.loan-note-actions .btn:hover,
+.loan-note-actions .btn:focus {
+    background-color: #fff;
+    color: #000;
+    border-color: #000;
+}

--- a/templates/loan_notes.html
+++ b/templates/loan_notes.html
@@ -25,10 +25,12 @@
                     <td class="px-3" style="color:#000!important; border-right:1px solid #000;">{{ note.group }}</td>
                     <td class="px-3" style="color:#000!important; border-right:1px solid #000;">{{ note.name }}</td>
                     <td class="px-3 text-center">
-                        <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#editNote{{note.id}}">Edit</button>
-                        <form method="post" action="{{ url_for('delete_loan_note', note_id=note.id) }}" style="display:inline;" onsubmit="return confirm('Delete this note?');">
-                            <button type="submit" class="btn btn-sm btn-danger">Delete</button>
-                        </form>
+                        <div class="loan-note-actions">
+                            <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#editNote{{note.id}}">Edit</button>
+                            <form method="post" action="{{ url_for('delete_loan_note', note_id=note.id) }}" style="display:inline;" onsubmit="return confirm('Delete this note?');">
+                                <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                            </form>
+                        </div>
                     </td>
                 </tr>
                 <div class="modal fade" id="editNote{{note.id}}" tabindex="-1">


### PR DESCRIPTION
## Summary
- style loan note action buttons with white background and black text/border
- wrap edit and delete buttons to apply scoped action styles

## Testing
- `pytest` *(fails: No chrome executable found on PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68bee060456c832094f3d33426b2df20