### PR TITLE
Add loan note selection support

### DIFF
--- a/models.py
+++ b/models.py
@@ -286,7 +286,13 @@ class LoanSummary(db.Model):
     report_fields = db.relationship(
         'ReportFields', backref='loan', uselist=False, cascade='all, delete-orphan'
     )
-    
+
+    loan_notes = db.relationship(
+        'LoanNote',
+        secondary='loan_summary_notes',
+        backref='loan_summaries',
+    )
+
     def __repr__(self):
         return f'<LoanSummary {self.loan_name} v{self.version}>'
 
@@ -383,3 +389,14 @@ class LoanNote(db.Model):
 
     def __repr__(self) -> str:
         return f'<LoanNote {self.group}: {self.name[:20]}>'
+
+
+class LoanSummaryNote(db.Model):
+    __tablename__ = 'loan_summary_notes'
+
+    loan_summary_id = db.Column(
+        db.Integer, db.ForeignKey('loan_summary.id'), primary_key=True
+    )
+    loan_note_id = db.Column(
+        db.Integer, db.ForeignKey('loan_notes.id'), primary_key=True
+    )

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1985,6 +1985,43 @@ async function handleReportFieldsClick(e) {
     document.getElementById('docxMaxLtv').value = data.max_ltv || '';
     document.getElementById('docxExitFee').value = data.exit_fee_percent || '';
     document.getElementById('docxCommitmentFee').value = data.commitment_fee || '';
+    const notesResp = await fetch('/api/loan-notes');
+    const notesData = await notesResp.json();
+    const accordion = document.getElementById('loanNotesAccordion');
+    accordion.innerHTML = '';
+    let idx = 0;
+    const selectedNotes = data.note_ids || [];
+    for (const [group, notes] of Object.entries(notesData)) {
+        const item = document.createElement('div');
+        item.className = 'accordion-item';
+        const headingId = `loanNotesHeading${idx}`;
+        const collapseId = `loanNotesCollapse${idx}`;
+        item.innerHTML = `
+           <h2 class="accordion-header" id="${headingId}">
+             <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#${collapseId}">
+               ${group}
+             </button>
+           </h2>
+           <div id="${collapseId}" class="accordion-collapse collapse" data-bs-parent="#loanNotesAccordion">
+             <div class="accordion-body"></div>
+           </div>
+        `;
+        const body = item.querySelector('.accordion-body');
+        notes.forEach(note => {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'form-check';
+            wrapper.innerHTML = `
+                <input class="form-check-input" type="checkbox" id="note-${note.id}" data-note-id="${note.id}">
+                <label class="form-check-label" for="note-${note.id}">${note.text}</label>
+            `;
+            if (selectedNotes.includes(note.id)) {
+                wrapper.querySelector('input').checked = true;
+            }
+            body.appendChild(wrapper);
+        });
+        accordion.appendChild(item);
+        idx++;
+    }
     const modal = new bootstrap.Modal(document.getElementById('loanSummaryFieldsModal'));
     modal.show();
 }
@@ -2029,6 +2066,7 @@ document.addEventListener('DOMContentLoaded', async function() {
     if (saveFieldsBtn) {
         saveFieldsBtn.addEventListener('click', async function() {
             if (!window.editMode || !window.editMode.loanId) return;
+            const selectedNoteIds = Array.from(document.querySelectorAll('#loanNotesAccordion input[type="checkbox"]:checked')).map(cb => parseInt(cb.dataset.noteId));
             const data = {
                 client_name: document.getElementById('docxClientName').value,
                 property_address: document.getElementById('docxPropertyAddress').value,
@@ -2038,7 +2076,8 @@ document.addEventListener('DOMContentLoaded', async function() {
                 brokerage: document.getElementById('docxBrokerage').value,
                 max_ltv: document.getElementById('docxMaxLtv').value,
                 exit_fee_percent: document.getElementById('docxExitFee').value,
-                commitment_fee: document.getElementById('docxCommitmentFee').value
+                commitment_fee: document.getElementById('docxCommitmentFee').value,
+                note_ids: selectedNoteIds
             };
             try {
                 const response = await fetch(`/loan/${window.editMode.loanId}/report-fields`, {
@@ -2351,6 +2390,7 @@ function retryLoanSave() {
           <label for="docxCommitmentFee" class="form-label">Commitment Fee</label>
           <input type="number" step="0.01" class="form-control" id="docxCommitmentFee">
         </div>
+        <div id="loanNotesAccordion" class="accordion"></div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>


### PR DESCRIPTION
## Summary
- expose `/api/loan-notes` endpoint for grouped non-deleted loan notes
- link `LoanSummary` and `LoanNote` via `LoanSummaryNote` association
- allow report fields endpoint and UI to manage selected loan notes

## Testing
- `pytest test_report_fields_length.py test_report_fields_numeric.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bee0ea7d0483209cf1fba666e347cd