### PR TITLE
Include selected loan notes in DOCX summaries

### DIFF
--- a/pdf_quote_generator.py
+++ b/pdf_quote_generator.py
@@ -532,6 +532,10 @@ def generate_loan_summary_docx(loan, extra_fields=None):
         ),
     ]
 
+    loan_notes = extra_fields.get('loan_notes', [])
+    if loan_notes:
+        sections.insert(1, ("Additional Conditions", loan_notes))
+
     for heading, bullets in sections:
         hp = doc.add_heading(heading, level=1)
         for run in hp.runs:

--- a/routes.py
+++ b/routes.py
@@ -2212,6 +2212,14 @@ def download_loan_summary_docx(loan_id):
         rf = ReportFields.query.filter_by(loan_id=loan_id).first()
         extra_fields = rf.to_dict() if rf else {}
 
+    # Include loan note texts marked for inclusion
+    loan_notes = (
+        LoanNote.query.filter_by(add_flag=True, deleted_at=None)
+        .order_by(LoanNote.group, LoanNote.id)
+        .all()
+    )
+    extra_fields['loan_notes'] = [note.name for note in loan_notes]
+
     docx_content = generate_loan_summary_docx(loan, extra_fields)
     if not docx_content:
         app.logger.error('Loan summary DOCX generation failed - missing python-docx dependency')


### PR DESCRIPTION
## Summary
- Pass loan notes flagged for inclusion to the DOCX generator
- Insert additional conditions section with loan notes in generated summary

## Testing
- `pytest` *(fails: No chrome executable found on PATH; AttributeError in scenario comparison test)*

------
https://chatgpt.com/codex/tasks/task_e_68bee0f6dd68832097843c9ca2f6c21d