### PR TITLE
Add loan note select/clear controls

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -2020,6 +2020,25 @@ async function handleReportFieldsClick(e) {
             }
             body.appendChild(wrapper);
         });
+        const controls = document.createElement('div');
+        controls.className = 'mb-2';
+        controls.innerHTML = `
+            <button type="button" class="btn btn-sm btn-link p-0 me-2 select-all">Select All</button>
+            <button type="button" class="btn btn-sm btn-link p-0 clear-all">Clear All</button>
+        `;
+        const selectAllBtn = controls.querySelector('.select-all');
+        const clearAllBtn = controls.querySelector('.clear-all');
+        selectAllBtn.addEventListener('click', () => {
+            body.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+                cb.checked = true;
+            });
+        });
+        clearAllBtn.addEventListener('click', () => {
+            body.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+                cb.checked = false;
+            });
+        });
+        body.insertBefore(controls, body.firstChild);
         accordion.appendChild(item);
         idx++;
     }


### PR DESCRIPTION
## Summary
- Add Select All and Clear All controls to each loan note group in Report Fields modal
- Enable selecting or deselecting all notes within a group without affecting pre-selection

## Testing
- `pytest test_report_fields_length.py -q` *(fails: skipped due to database connection)*

------
https://chatgpt.com/codex/tasks/task_e_68bef73848fc832088259fefac006bc5