### PR TITLE
Include loan_summary_id in loan notes placeholders

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -3027,7 +3027,6 @@ def loan_notes():
     placeholder_options = [
         f"loan_data.{col.name}"
         for col in LoanData.__table__.columns
-        if col.name != 'loan_summary_id'
     ]
     return render_template(
         "loan_notes.html",

--- a/test_loan_notes_placeholder_option.py
+++ b/test_loan_notes_placeholder_option.py
@@ -1,0 +1,6 @@
+import routes
+
+
+def test_placeholder_options_includes_loan_summary_id():
+    placeholder_options = [f"loan_data.{col.name}" for col in routes.LoanData.__table__.columns]
+    assert "loan_data.loan_summary_id" in placeholder_options


### PR DESCRIPTION
## Summary
- allow `loan_summary_id` in loan notes placeholder options
- add regression test for loan note placeholders

## Testing
- `pytest test_loan_notes_placeholder_option.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0010c23808320821f5e4608c999f8