### PR TITLE
Disable browser autofill on calculator form

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -503,13 +503,13 @@
 <!-- Calculator Form -->
 <div class="col-lg-4 user-input-col">
 <div class="calculator-section">
-<form id="calculatorForm">
+<form id="calculatorForm" autocomplete="off">
 <!-- Loan Name -->
 <div class="">
 <label class="form-label" for="loanName">
 <i class="fas me-1"></i>Loan Name <span class="text-danger">*</span>
 </label>
-<input class="form-control" id="loanName" maxlength="200" name="loanName" placeholder="Enter loan name (e.g., Client Name - Property Address)" required="" style="min-height: 38px; font-size: 1rem;" type="text"/>
+<input class="form-control" id="loanName" maxlength="200" name="loanName" placeholder="Enter loan name (e.g., Client Name - Property Address)" required="" style="min-height: 38px; font-size: 1rem;" type="text" autocomplete="off"/>
 </div>
 <!-- Loan Type Selection -->
 <div class="">


### PR DESCRIPTION
## Summary
- disable browser autofill suggestions on the calculator form
- explicitly disable autofill for the Loan Name field

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask_sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68c00b24cf008320923256a191c9a205