### PR TITLE
Support start_date fallback in loan summary

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -2058,8 +2058,9 @@ def save_loan():
             loan_summary.loan_term = max(1, safe_int(data.get('loanTerm'), 12))
             loan_summary.loan_term_days = fresh_calculation.get('loanTermDays', 365)
             loan_summary.start_date = datetime.strptime(
-                data.get('startDate', datetime.now().strftime('%Y-%m-%d')), '%Y-%m-%d'
-            ).date() if data.get('startDate') else datetime.now().date()
+                data.get('startDate') or data.get('start_date') or datetime.now().strftime('%Y-%m-%d'),
+                '%Y-%m-%d'
+            ).date()
             loan_summary.end_date = end_date
             loan_summary.repayment_option = data.get('repaymentOption', 'none')
             loan_summary.payment_timing = data.get('paymentTiming') or data.get('payment_timing', 'advance')
@@ -2116,8 +2117,9 @@ def save_loan():
                 loan_term=data.get('loanTerm', 12),
                 loan_term_days=fresh_calculation.get('loanTermDays', 365),
                 start_date=datetime.strptime(
-                    data.get('startDate', datetime.now().strftime('%Y-%m-%d')), '%Y-%m-%d'
-                ).date() if data.get('startDate') else datetime.now().date(),
+                    data.get('startDate') or data.get('start_date') or datetime.now().strftime('%Y-%m-%d'),
+                    '%Y-%m-%d'
+                ).date(),
                 end_date=end_date,
                 repayment_option=data.get('repaymentOption', 'none'),
                 payment_timing=data.get('paymentTiming') or data.get('payment_timing', 'advance'),


### PR DESCRIPTION
## Summary
- handle both `startDate` and `start_date` when saving loan summaries
- only fallback to current date when neither key is provided

## Testing
- `pytest` *(fails: No chrome executable found on PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68c02ba63b648320bcfa5c98d85fad21