### PR TITLE
Handle interest_rate snake case

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -2054,7 +2054,9 @@ def save_loan():
             loan_summary.gross_amount = fresh_calculation.get('grossAmount', 0)
             loan_summary.net_amount = fresh_calculation.get('netAmount', 0)
             loan_summary.property_value = fresh_calculation.get('propertyValue', 0)
-            loan_summary.interest_rate = data.get('interestRate', 0)
+            loan_summary.interest_rate = safe_float(
+                data.get('interestRate') or data.get('interest_rate'), 0
+            )
             loan_summary.loan_term = max(1, safe_int(data.get('loanTerm'), 12))
             loan_summary.loan_term_days = fresh_calculation.get('loanTermDays', 365)
             loan_summary.start_date = datetime.strptime(
@@ -2112,7 +2114,9 @@ def save_loan():
                 gross_amount=fresh_calculation.get('grossAmount', 0),
                 net_amount=fresh_calculation.get('netAmount', 0),
                 property_value=fresh_calculation.get('propertyValue', 0),
-                interest_rate=data.get('interestRate', 0),
+                interest_rate=safe_float(
+                    data.get('interestRate') or data.get('interest_rate'), 0
+                ),
                 loan_term=data.get('loanTerm', 12),
                 loan_term_days=fresh_calculation.get('loanTermDays', 365),
                 start_date=datetime.strptime(


### PR DESCRIPTION
## Summary
- handle both camelCase and snake_case interest rate fields in loan summary update and creation
- parse interest rate using safe_float for consistency

## Testing
- `pytest` *(fails: test_scenario_comparison_session_size - AttributeError: 'FlaskClient' object has no attribute 'context_provider')*

------
https://chatgpt.com/codex/tasks/task_e_68c02ba7a440832095026d57b0d5d925