### PR TITLE
Handle loan term fields in both naming styles

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -2055,7 +2055,9 @@ def save_loan():
             loan_summary.net_amount = fresh_calculation.get('netAmount', 0)
             loan_summary.property_value = fresh_calculation.get('propertyValue', 0)
             loan_summary.interest_rate = data.get('interestRate', 0)
-            loan_summary.loan_term = max(1, safe_int(data.get('loanTerm'), 12))
+            loan_summary.loan_term = max(
+                1, safe_int(data.get('loanTerm') or data.get('loan_term'), 12)
+            )
             loan_summary.loan_term_days = fresh_calculation.get('loanTermDays', 365)
             loan_summary.start_date = datetime.strptime(
                 data.get('startDate', datetime.now().strftime('%Y-%m-%d')), '%Y-%m-%d'
@@ -2113,7 +2115,9 @@ def save_loan():
                 net_amount=fresh_calculation.get('netAmount', 0),
                 property_value=fresh_calculation.get('propertyValue', 0),
                 interest_rate=data.get('interestRate', 0),
-                loan_term=data.get('loanTerm', 12),
+                loan_term=max(
+                    1, safe_int(data.get('loanTerm') or data.get('loan_term'), 12)
+                ),
                 loan_term_days=fresh_calculation.get('loanTermDays', 365),
                 start_date=datetime.strptime(
                     data.get('startDate', datetime.now().strftime('%Y-%m-%d')), '%Y-%m-%d'


### PR DESCRIPTION
## Summary
- Ensure loan term uses camelCase or snake_case input in update and creation paths

## Testing
- `pytest -q` *(fails: No chrome executable found, 13 failed, 179 passed, 2 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c02ba8f7a08320abaf3ce47de75256