### PR TITLE
Support snake_case repayment option

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -2061,7 +2061,7 @@ def save_loan():
                 data.get('startDate', datetime.now().strftime('%Y-%m-%d')), '%Y-%m-%d'
             ).date() if data.get('startDate') else datetime.now().date()
             loan_summary.end_date = end_date
-            loan_summary.repayment_option = data.get('repaymentOption', 'none')
+            loan_summary.repayment_option = data.get('repaymentOption') or data.get('repayment_option', 'none')
             loan_summary.payment_timing = data.get('paymentTiming') or data.get('payment_timing', 'advance')
             loan_summary.payment_frequency = data.get('paymentFrequency') or data.get('payment_frequency', 'monthly')
             # Support both camelCase and snake_case field names from the form
@@ -2119,7 +2119,7 @@ def save_loan():
                     data.get('startDate', datetime.now().strftime('%Y-%m-%d')), '%Y-%m-%d'
                 ).date() if data.get('startDate') else datetime.now().date(),
                 end_date=end_date,
-                repayment_option=data.get('repaymentOption', 'none'),
+                repayment_option=data.get('repaymentOption') or data.get('repayment_option', 'none'),
                 payment_timing=data.get('paymentTiming') or data.get('payment_timing', 'advance'),
                 payment_frequency=data.get('paymentFrequency') or data.get('payment_frequency', 'monthly'),
                 # Support both camelCase and snake_case field names from the form


### PR DESCRIPTION
## Summary
- Allow route saving to read `repayment_option` in addition to `repaymentOption` for both updates and creations

## Testing
- `pytest` *(fails: No module named 'flask')*
- `grep -n "selenium" /tmp/unit.log | head -n 5`
- `grep -n "docx" /tmp/unit.log | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68c02bb041e88320bf6053a9df511299