### PR TITLE
fix: allow entry of partial decimals

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -1756,20 +1756,18 @@ class LoanCalculator {
         const numberInputs = this.form.querySelectorAll('input[type="number"]');
         numberInputs.forEach(input => {
             input.addEventListener('input', () => {
-                    const minAttr = parseFloat(input.getAttribute('min'));
-                    const min = isNaN(minAttr) ? 0 : minAttr;
-                    const val = parseFloat(input.value);
-                    if (!isNaN(val) && val < min) {
-                        input.value = '';
-                        if (window.notifications && window.notifications.error) {
-                            const label = this.form.querySelector(`label[for="${input.id}"]`);
-                            const fieldName = label ? label.textContent.trim() : input.name || input.id;
-                            window.notifications.error(`${fieldName} cannot be negative`);
-                        }
+                const val = parseFloat(input.value);
+                if (!isNaN(val) && val < 0) {
+                    input.value = '';
+                    if (window.notifications && window.notifications.error) {
+                        const label = this.form.querySelector(`label[for="${input.id}"]`);
+                        const fieldName = label ? label.textContent.trim() : input.name || input.id;
+                        window.notifications.error(`${fieldName} cannot be negative`);
                     }
-                });
+                }
             });
-        }
+        });
+    }
 
     safeFormatInputValue(input) {
         const originalValue = input.value;


### PR DESCRIPTION
## Summary
- relax negative input prevention to allow decimals like 0.23 in Title Insurance field

## Testing
- `pytest` *(fails: No chrome executable found on PATH; ValueError)*

------
https://chatgpt.com/codex/tasks/task_e_68c02b5738b08320b6bf37b50e532701