### PR TITLE
Normalize leading decimal inputs

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -1756,6 +1756,11 @@ class LoanCalculator {
         const numberInputs = this.form.querySelectorAll('input[type="number"]');
         numberInputs.forEach(input => {
             input.addEventListener('input', () => {
+                // Ensure values like ".23" are normalised to "0.23" before validation
+                if (input.value.startsWith('.')) {
+                    input.value = '0' + input.value;
+                }
+
                 const val = parseFloat(input.value);
                 if (!isNaN(val) && val < 0) {
                     input.value = '';
@@ -1797,7 +1802,8 @@ class LoanCalculator {
                 minimumFractionDigits: 0,
                 maximumFractionDigits: 4
             });
-            input.value = formattedValue;
+            // Prefix a leading zero if locale formatting drops it (e.g. .23)
+            input.value = formattedValue.startsWith('.') ? `0${formattedValue}` : formattedValue;
         } catch (error) {
             // If formatting fails, keep original value
             console.warn('Number formatting failed:', error);


### PR DESCRIPTION
## Summary
- normalize number inputs by prefixing leading zero when user enters values like `.23`
- ensure formatted values retain leading zero for decimals

## Testing
- `pytest` *(fails: No chrome executable found on PATH; 13 failed, 179 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68c02ecc78a083209e6a616a311c5b4b