### PR TITLE
Remove Quick Start Templates card header

### DIFF
--- a/templates/scenario_comparison.html
+++ b/templates/scenario_comparison.html
@@ -326,9 +326,6 @@
                 <!-- Scenario Tools and Results -->
                 <div class="col-lg-8">
                     <div class="card mb-4">
-                        <div class="card-header">
-                            <h3 class="mb-0"><i class="fas fa-template me-2"></i>Quick Start Templates</h3>
-                        </div>
                         <div class="card-body">
                             <p class="text-muted">Click a template to customize and generate comparison scenarios:</p>
                             <div class="d-grid gap-2">


### PR DESCRIPTION
## Summary
- remove Quick Start Templates card header from scenario comparison page

## Testing
- `pytest` *(fails: No chrome executable found on PATH, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c09739dfa88320b2d96ff642c40eb4