### PR TITLE
Remove Loan Notes header section

### DIFF
--- a/templates/loan_notes.html
+++ b/templates/loan_notes.html
@@ -7,9 +7,6 @@
 {% endblock %}
 {% block content %}
 <div class="card">
-    <div class="card-header bg-primary text-white fw-bold">
-        Loan Notes
-    </div>
     <div class="card-body p-0">
         <form method="get" class="p-3">
             <div class="row">


### PR DESCRIPTION
## Summary
- remove header card section from Loan Notes template

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68c09b0713c48320ab926427a2b14c07