### PR TITLE
style: white bold header text

### DIFF
--- a/templates/loan_notes.html
+++ b/templates/loan_notes.html
@@ -27,10 +27,10 @@
         <table class="table" style="border: 1px solid #000; border-collapse: collapse;">
             <thead>
                 <tr style="border: 1px solid #000; background: #f8f9fa;">
-                    <th class="px-3" style="color:#000!important; border-right:1px solid #000;">Group</th>
-                    <th class="px-3" style="color:#000!important; border-right:1px solid #000;">Name</th>
-                    <th class="px-3" style="color:#000!important; border-right:1px solid #000; width:500px;">Placeholder Map</th>
-                    <th class="px-3 text-center" style="color:#000!important;">Actions</th>
+                    <th class="px-3" style="color:#fff!important; font-weight:bold; border-right:1px solid #000;">Group</th>
+                    <th class="px-3" style="color:#fff!important; font-weight:bold; border-right:1px solid #000;">Name</th>
+                    <th class="px-3" style="color:#fff!important; font-weight:bold; border-right:1px solid #000; width:500px;">Placeholder Map</th>
+                    <th class="px-3 text-center" style="color:#fff!important; font-weight:bold;">Actions</th>
                 </tr>
             </thead>
             <tbody>


### PR DESCRIPTION
## Summary
- make loan notes table header text white and bold

## Testing
- `pytest` *(fails: No chrome executable found on PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68c09b3d411c8320922755d355f8e52f