### PR TITLE
Ensure landing page cards have uniform size

### DIFF
--- a/templates/landing.html
+++ b/templates/landing.html
@@ -54,12 +54,12 @@
         }
         .navigation-cards {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
             gap: 2rem;
             max-width: 1200px;
             margin: 0 auto;
             padding: 0 1rem;
-            justify-items: center;
+            grid-auto-rows: 1fr;
         }
         .nav-card {
             background: rgba(255, 255, 255, 0.95);
@@ -73,6 +73,8 @@
             flex-direction: column;
             align-items: center;
             border: 2px solid #AD965F;
+            width: 100%;
+            height: 100%;
         }
         .nav-card:hover {
             transform: translateY(-10px);


### PR DESCRIPTION
## Summary
- adjust landing page grid and card styles so navigation cards fill equal-sized cells

## Testing
- `pytest -q` *(fails: No chrome executable found on PATH and `test_scenario_comparison_session_size` AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_68c09c24d9e48320abf724a3270e9dd4