### PR TITLE
Remove obsolete feature from landing page

### DIFF
--- a/templates/landing.html
+++ b/templates/landing.html
@@ -196,14 +196,6 @@
                 {% endfor %}
             </div>
 
-            <div class="features-section">
-                <div class="feature-list">
-                    <div class="feature-item">
-                        <i class="fas fa-check-circle"></i>
-                        <span>Bridging loan financing in the UK from 500000 to 50m .</span>
-                    </div>
-                </div>
-            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- remove Bridging loan financing feature section from landing page

## Testing
- `pytest` *(fails: No chrome executable found on PATH; AttributeError: 'FlaskClient' object has no attribute 'cookie_jar')*


------
https://chatgpt.com/codex/tasks/task_e_68c09c7d4e2883209c3190cdade29972