### PR TITLE
Fix report fields link after calculation

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -1982,7 +1982,6 @@ async function fetchReportFields() {
 
 async function handleReportFieldsClick(e) {
     e.preventDefault();
-    if (!window.editMode || !window.editMode.loanId) return;
     const data = await fetchReportFields();
     document.getElementById('docxClientName').value = data.client_name || '';
     document.getElementById('docxPropertyAddress').value = data.property_address || '';
@@ -2093,7 +2092,12 @@ document.addEventListener('DOMContentLoaded', async function() {
     const saveFieldsBtn = document.getElementById('saveReportFields');
     if (saveFieldsBtn) {
         saveFieldsBtn.addEventListener('click', async function() {
-            if (!window.editMode || !window.editMode.loanId) return;
+            if (!window.editMode || !window.editMode.loanId) {
+                if (Novellus?.utils?.showToast) {
+                    Novellus.utils.showToast('Save the loan before editing report fields', 'warning');
+                }
+                return;
+            }
             const selectedNoteIds = Array.from(
                 document.querySelectorAll('#loanNotesAccordion input[type="checkbox"]:checked')
             )


### PR DESCRIPTION
## Summary
- Allow report fields icon to open even when loan isn't saved
- Warn users to save the loan before saving report field changes

## Testing
- `pytest -q` *(fails: No chrome executable found on PATH; FlaskClient has no attribute 'cookie_jar')*


------
https://chatgpt.com/codex/tasks/task_e_68c09fd34e7483208a35abbca52a29e6