### PR TITLE
Hide docx report icon until loan update and adjust save button style

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -564,3 +564,17 @@ footer {
         transition-duration: 0.01ms !important;
     }
 }
+
+/* Save/Update Loan button styling */
+#saveLoanBtn {
+    background-color: #fff !important;
+    color: #000 !important;
+    border: 1px solid #000 !important;
+}
+
+#saveLoanBtn:hover,
+#saveLoanBtn:focus,
+#saveLoanBtn:disabled {
+    background-color: #fff !important;
+    color: #000 !important;
+}

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -908,7 +908,7 @@
                     <div class="position-absolute top-50 end-0 translate-middle-y d-flex">
                         <a id="openReportFields" href="#" class="btn btn-sm btn-light me-2 report-fields-link" style="display:none;" title="Edit Report Fields"><i class="fas fa-list"></i></a>
                         <a id="openLoanReport" class="btn btn-sm btn-light me-2" href="#" style="display:none;" target="_blank" title="Open Loan Report">
-                            <i class="fas fa-chart-column"></i>
+                            <i class="fas fa-file-word"></i>
                         </a>
                         <button type="button" class="btn btn-sm btn-light me-2" id="viewBreakdownBtn" data-bs-toggle="modal" data-bs-target="#calculationBreakdownModal" title="View Details"><i class="fas fa-eye"></i></button>
                         <button class="btn btn-sm btn-light" data-currency="GBP" disabled id="saveLoanBtn" type="button"><i class="fas fa-save me-2"></i><span id="saveLoanText">Save Loan</span></button>
@@ -2124,6 +2124,8 @@ document.addEventListener('DOMContentLoaded', async function() {
                 if (modalInstance) modalInstance.hide();
                 const saveBtn = document.getElementById('saveLoanBtn');
                 if (saveBtn) saveBtn.disabled = false;
+                isLoanSaved = false;
+                updateLoanReportLink();
                 return;
             }
             try {
@@ -2141,6 +2143,8 @@ document.addEventListener('DOMContentLoaded', async function() {
                     if (modalInstance) modalInstance.hide();
                     const saveBtn = document.getElementById('saveLoanBtn');
                     if (saveBtn) saveBtn.disabled = false;
+                    isLoanSaved = false;
+                    updateLoanReportLink();
                 } else {
                     Novellus.utils.showToast(result.error || 'Failed to save report fields', 'danger');
                 }

--- a/templates/calculator_w.html
+++ b/templates/calculator_w.html
@@ -763,7 +763,7 @@
 <button class="btn btn-primary btn-lg calculate-button" data-currency="GBP" type="submit">
 <i class="fas fa-calculator me-2"></i>Calculate
                     </button>
-<button class="btn btn-success" data-currency="GBP" disabled="" id="saveLoanBtn" type="button">
+<button class="btn btn-light" data-currency="GBP" disabled id="saveLoanBtn" type="button">
 <i class="fas fa-save me-2"></i><span id="saveLoanText">Save Loan</span>
 </button>
 <button class="btn btn-outline-secondary" id="cancelEditBtn" style="display: none;" type="button">


### PR DESCRIPTION
## Summary
- change open report icon to Word icon
- hide loan report icon after saving report fields until loan is updated
- set Save/Update Loan button to white background with black text

## Testing
- `pytest` *(fails: No chrome executable found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ab28b6c08320ad99f8dea64614e7