### PR TITLE
refactor: standardize toast notifications

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -107,7 +107,7 @@ Novellus.utils = {
     },
 
     // Show toast notification
-    showToast: function(message, type = 'info') {
+    showToast: function(message, type = 'info', options = {}) {
         // Create toast container if it doesn't exist
         let toastContainer = document.querySelector('.toast-container');
         if (!toastContainer) {
@@ -115,12 +115,24 @@ Novellus.utils = {
             toastContainer.className = 'toast-container position-fixed top-0 end-0 p-3';
             document.body.appendChild(toastContainer);
         }
-        
+
+        // Setup options
+        const { autohide = true, delay = 5000, id } = options;
+
         // Create toast element
-        const toastId = 'toast-' + Date.now();
+        const toastId = id || 'toast-' + Date.now();
         const toast = document.createElement('div');
         toast.id = toastId;
-        toast.className = `toast align-items-center text-white bg-${type} border-0`;
+        toast.className = 'toast align-items-center text-white border-0';
+
+        const typeColors = {
+            success: '#198754', // green
+            warning: '#fd7e14', // orange
+            danger: '#dc3545',  // red
+            info: '#0d6efd'
+        };
+        toast.style.backgroundColor = typeColors[type] || typeColors.info;
+
         toast.setAttribute('role', 'alert');
         toast.innerHTML = `
             <div class="d-flex">
@@ -128,20 +140,22 @@ Novellus.utils = {
                 <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"></button>
             </div>
         `;
-        
+
         toastContainer.appendChild(toast);
-        
+
         // Initialize and show toast
         const bsToast = new bootstrap.Toast(toast, {
-            autohide: true,
-            delay: 5000
+            autohide: autohide,
+            delay: delay
         });
         bsToast.show();
-        
+
         // Remove toast element after it's hidden
         toast.addEventListener('hidden.bs.toast', () => {
             toast.remove();
         });
+
+        return toast;
     },
 
     // Validate email format

--- a/static/js/notifications.js
+++ b/static/js/notifications.js
@@ -1,166 +1,41 @@
 /**
- * Novellus Notification System - Golden Theme
- * Creates beautiful golden notifications with white text throughout the application
+ * Unified notification wrappers using Bootstrap toasts
  */
-class NotificationSystem {
-    constructor() {
-        this.createNotificationContainer();
-    }
-
-    createNotificationContainer() {
-        let container = document.getElementById('notification-container');
-        if (!container) {
-            container = document.createElement('div');
-            container.id = 'notification-container';
-            container.style.cssText = `
-                position: fixed;
-                top: 20px;
-                right: 20px;
-                z-index: 10001;
-                max-width: 450px;
-                pointer-events: none;
-            `;
-            document.body.appendChild(container);
+(function() {
+    function mapType(type) {
+        switch(type) {
+            case 'error':
+            case 'danger':
+            case 'fail':
+            case 'failure':
+                return 'danger';
+            case 'warning':
+                return 'warning';
+            case 'success':
+                return 'success';
+            default:
+                return 'info';
         }
-        this.container = container;
     }
 
-    show(message, type = 'info', duration = 8000) {
-        const notification = document.createElement('div');
-        notification.className = `notification notification-${type}`;
-        
-        // Golden theme styling
-        notification.style.cssText = `
-            background: linear-gradient(135deg, #B8860B 0%, #DAA520 100%);
-            border: 2px solid #FFD700;
-            border-left: 6px solid #FFF;
-            color: #FFFFFF;
-            font-weight: 500;
-            text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3);
-            box-shadow: 0 6px 20px rgba(184, 134, 11, 0.4);
-            border-radius: 8px;
-            margin-bottom: 12px;
-            pointer-events: all;
-            transform: translateX(100%);
-            opacity: 0;
-            transition: all 0.3s ease-in-out;
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            position: relative;
-        `;
-        
-        const icons = {
-            success: 'fas fa-check-circle',
-            error: 'fas fa-exclamation-circle', 
-            warning: 'fas fa-exclamation-triangle',
-            info: 'fas fa-info-circle'
-        };
-
-        notification.innerHTML = `
-            <div style="display: flex; align-items: center; padding: 16px 20px;">
-                <i class="${icons[type] || icons.info}" style="
-                    color: #FFF;
-                    font-size: 18px;
-                    margin-right: 12px;
-                    flex-shrink: 0;
-                "></i>
-                <div style="
-                    flex-grow: 1;
-                    color: #FFF;
-                    font-weight: 500;
-                    line-height: 1.4;
-                ">${message}</div>
-                <button onclick="this.parentElement.parentElement.remove()" style="
-                    background: none;
-                    border: none;
-                    color: #FFF;
-                    font-size: 16px;
-                    cursor: pointer;
-                    margin-left: 12px;
-                    padding: 4px;
-                    border-radius: 50%;
-                    width: 24px;
-                    height: 24px;
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                    transition: background-color 0.2s;
-                " onmouseover="this.style.backgroundColor='rgba(255,255,255,0.2)'" 
-                   onmouseout="this.style.backgroundColor='transparent'">
-                    <i class="fas fa-times"></i>
-                </button>
-            </div>
-        `;
-
-        this.container.appendChild(notification);
-
-        // Show with animation
-        setTimeout(() => {
-            notification.style.transform = 'translateX(0)';
-            notification.style.opacity = '1';
-        }, 100);
-
-        // Auto-remove
-        if (duration > 0) {
-            setTimeout(() => {
-                if (notification.parentElement) {
-                    notification.style.transform = 'translateX(100%)';
-                    notification.style.opacity = '0';
-                    setTimeout(() => {
-                        if (notification.parentElement) {
-                            notification.remove();
-                        }
-                    }, 300);
-                }
-            }, duration);
+    function showNotification(message, type = 'info', duration = 5000) {
+        if (Novellus?.utils?.showToast) {
+            Novellus.utils.showToast(message, mapType(type), { delay: duration });
         }
-
-        return notification;
     }
 
-    success(message, duration) {
-        return this.show(message, 'success', duration);
-    }
+    const notifications = {
+        show: showNotification,
+        success: (msg, duration) => showNotification(msg, 'success', duration),
+        error: (msg, duration) => showNotification(msg, 'danger', duration),
+        warning: (msg, duration) => showNotification(msg, 'warning', duration),
+        info: (msg, duration) => showNotification(msg, 'info', duration)
+    };
 
-    error(message, duration) {
-        return this.show(message, 'error', duration);
-    }
-
-    warning(message, duration) {
-        return this.show(message, 'warning', duration);
-    }
-
-    info(message, duration) {
-        return this.show(message, 'info', duration);
-    }
-}
-
-// Global notification instance
-const notifications = new NotificationSystem();
-// Expose notification system globally for pages checking window.notifications
-window.notifications = notifications;
-
-// Global functions for easy access
-function showNotification(message, type = 'info', duration = 8000) {
-    return notifications.show(message, type, duration);
-}
-
-function showSuccess(message, duration) {
-    return notifications.success(message, duration);
-}
-
-function showError(message, duration) {
-    return notifications.error(message, duration);
-}
-
-function showWarning(message, duration) {
-    return notifications.warning(message, duration);
-}
-
-function showInfo(message, duration) {
-    return notifications.info(message, duration);
-}
-
-// Test notification function
-function testNotification() {
-    showSuccess('Golden notification system is working!', 5000);
-}
+    window.notifications = notifications;
+    window.showNotification = showNotification;
+    window.showSuccess = notifications.success;
+    window.showError = notifications.error;
+    window.showWarning = notifications.warning;
+    window.showInfo = notifications.info;
+})();

--- a/templates/base.html
+++ b/templates/base.html
@@ -143,37 +143,29 @@
     
     <!-- Rollback functionality -->
     <script>
-    // Rollback confirmation function
     function confirmRollback() {
-        if (window.notifications) {
-            // Create a custom confirmation notification
+        if (Novellus?.utils?.showToast) {
+            const toastId = 'rollback-toast';
             const confirmMessage = `
                 <div style="margin-top: 8px;">
                     <button class="btn btn-sm btn-warning me-2" onclick="performRollback()" style="font-size: 0.8rem;">Yes, Rollback</button>
-                    <button class="btn btn-sm btn-secondary" onclick="this.closest('.notification').remove()" style="font-size: 0.8rem;">Cancel</button>
+                    <button class="btn btn-sm btn-secondary" onclick="document.getElementById('${toastId}').remove()" style="font-size:0.8rem;">Cancel</button>
                 </div>
             `;
-            window.notifications.show(
-                'Are you sure you want to rollback? This will undo recent changes.' + confirmMessage,
-                'warning',
-                15000
-            );
-        } else {
-            if (confirm('Are you sure you want to rollback? This will undo recent changes.')) {
-                performRollback();
-            }
+            Novellus.utils.showToast('Are you sure you want to rollback? This will undo recent changes.' + confirmMessage, 'warning', { autohide: false, id: toastId });
+        } else if (confirm('Are you sure you want to rollback? This will undo recent changes.')) {
+            performRollback();
         }
     }
-    
+
     function performRollback() {
-        // Close any open notifications
-        const notifications = document.querySelectorAll('.notification');
-        notifications.forEach(n => n.remove());
-        
+        const toasts = document.querySelectorAll('.toast');
+        toasts.forEach(t => t.remove());
+
         window.history.back();
-        if (window.notifications) {
+        if (Novellus?.utils?.showToast) {
             setTimeout(() => {
-                window.notifications.info('Navigated back to previous page');
+                Novellus.utils.showToast('Navigated back to previous page', 'info');
             }, 500);
         }
     }

--- a/templates/loan_notes.html
+++ b/templates/loan_notes.html
@@ -131,31 +131,14 @@
     {% endfor %}
 </datalist>
 
-  <!-- Toast notifications -->
-<div class="toast-container position-fixed top-0 end-0 p-3">
-    <div id="notificationToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
-        <div class="toast-header">
-            <strong class="me-auto">Notification</strong>
-            <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
-        </div>
-        <div class="toast-body" id="toastMessage"></div>
-    </div>
-</div>
 {% endblock %}
 
 {% block scripts %}
 <script>
-function showNotification(message) {
-    const toast = document.getElementById('notificationToast');
-    const toastMessage = document.getElementById('toastMessage');
-    toastMessage.textContent = message;
-    const bsToast = new bootstrap.Toast(toast);
-    bsToast.show();
-}
 document.addEventListener('DOMContentLoaded', () => {
     const message = {{ request.args.get('toast')|tojson }};
-    if (message) {
-        showNotification(message);
+    if (message && Novellus?.utils?.showToast) {
+        Novellus.utils.showToast(message, 'success');
     }
     initPlaceholderMaps();
     initRowEditing();

--- a/templates/powerbi_config.html
+++ b/templates/powerbi_config.html
@@ -690,52 +690,9 @@ class PowerBIConfigManager {
     }
 
     showNotification(message, type = 'info') {
-        // Create golden notification with white text
-        const notification = document.createElement('div');
-        notification.className = `alert alert-${this.getBootstrapType(type)} alert-dismissible fade show position-fixed`;
-        notification.style.cssText = `
-            top: 20px;
-            right: 20px;
-            z-index: 10001;
-            max-width: 450px;
-            min-width: 350px;
-            background: linear-gradient(135deg, #B8860B 0%, #DAA520 100%) !important;
-            border: 2px solid #FFD700 !important;
-            border-left: 6px solid #FFF !important;
-            color: #FFFFFF !important;
-            font-weight: 500 !important;
-            text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.3) !important;
-            box-shadow: 0 6px 20px rgba(184, 134, 11, 0.4) !important;
-            border-radius: 8px;
-        `;
-        
-        notification.innerHTML = `
-            <div class="d-flex align-items-center">
-                <i class="fas ${this.getNotificationIcon(type)} me-2" style="color: #FFF; font-size: 18px;"></i>
-                <div class="flex-grow-1" style="color: #FFF; font-weight: 500;">${message}</div>
-                <button type="button" class="btn-close btn-close-white" onclick="this.parentElement.parentElement.remove()" style="filter: brightness(100%) saturate(100%) invert(1);"></button>
-            </div>
-        `;
-        
-        document.body.appendChild(notification);
-        
-        // Add animation class
-        setTimeout(() => {
-            notification.style.transform = 'translateX(0)';
-        }, 100);
-        
-        // Auto-remove after 10 seconds
-        setTimeout(() => {
-            if (notification.parentNode) {
-                notification.style.transform = 'translateX(100%)';
-                notification.style.opacity = '0';
-                setTimeout(() => {
-                    if (notification.parentNode) {
-                        notification.remove();
-                    }
-                }, 300);
-            }
-        }, 10000);
+        if (Novellus?.utils?.showToast) {
+            Novellus.utils.showToast(message, this.getBootstrapType(type));
+        }
     }
     
     getBootstrapType(type) {
@@ -748,15 +705,6 @@ class PowerBIConfigManager {
         }
     }
 
-    getNotificationIcon(type) {
-        switch(type) {
-            case 'success': return 'fa-check-circle';
-            case 'error': return 'fa-exclamation-triangle';
-            case 'warning': return 'fa-exclamation-circle';
-            case 'info': 
-            default: return 'fa-info-circle';
-        }
-    }
 }
 
 // Initialize the manager
@@ -2244,23 +2192,9 @@ function updateRefreshHistory(newStatus) {
 
 // Show notification
 function showNotification(message, type = 'info') {
-    // Create notification element
-    const notification = document.createElement('div');
-    notification.className = `alert alert-${type === 'error' ? 'danger' : type === 'success' ? 'success' : 'info'} alert-dismissible fade show position-fixed`;
-    notification.style.cssText = 'top: 20px; right: 20px; z-index: 1050; min-width: 300px;';
-    notification.innerHTML = `
-        ${message}
-        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-    `;
-    
-    document.body.appendChild(notification);
-    
-    // Auto-remove after 5 seconds
-    setTimeout(() => {
-        if (notification.parentNode) {
-            notification.remove();
-        }
-    }, 5000);
+    if (Novellus?.utils?.showToast) {
+        Novellus.utils.showToast(message, type === 'error' ? 'danger' : type);
+    }
 }
 
 // This function was moved to the enhanced DOMContentLoaded below

--- a/templates/scenario_comparison.html
+++ b/templates/scenario_comparison.html
@@ -65,12 +65,6 @@
             border: none;
         }
 
-        .notification-toast {
-            position: fixed;
-            top: 20px;
-            right: 20px;
-            z-index: 1050;
-        }
     </style>
 {% endblock %}
 
@@ -400,20 +394,6 @@
                     </div>
                 </div>
     </div>
-<!-- Notification Toast -->
-    <div class="toast-container position-fixed top-0 end-0 p-3">
-        <div id="notificationToast" class="toast" role="alert">
-            <div class="toast-header">
-                <i class="fas fa-bell text-primary me-2"></i>
-                <strong class="me-auto">Notification</strong>
-                <button type="button" class="btn-close" data-bs-dismiss="toast"></button>
-            </div>
-            <div class="toast-body" id="toastMessage">
-                <!-- Notification message will be inserted here -->
-            </div>
-        </div>
-    </div>
-
     <!-- Interest Rate Comparison Modal -->
     <div class="modal fade" id="interestRateModal" tabindex="-1">
         <div class="modal-dialog">
@@ -745,15 +725,6 @@
             document.getElementById('loadingSpinner').style.display = 'none';
         }
 
-        function showNotification(message, type = 'info') {
-            const toast = document.getElementById('notificationToast');
-            const toastMessage = document.getElementById('toastMessage');
-            toastMessage.textContent = message;
-            
-            const bsToast = new bootstrap.Toast(toast);
-            bsToast.show();
-        }
-
         function getBaseParameters() {
             // Get parameters from URL first (if navigated from calculator)
             const urlParams = new URLSearchParams(window.location.search);
@@ -914,7 +885,7 @@
                 
             } catch (error) {
                 console.error('Template generation failed:', error);
-                showNotification('Failed to generate template: ' + error.message, 'error');
+                showNotification('Failed to generate template: ' + error.message, 'danger');
             } finally {
                 hideLoading();
             }
@@ -942,7 +913,7 @@
                 
             } catch (error) {
                 console.error('Scenario comparison failed:', error);
-                showNotification('Failed to create comparison: ' + error.message, 'error');
+                showNotification('Failed to create comparison: ' + error.message, 'danger');
             }
         }
 
@@ -1095,7 +1066,7 @@
                 
             } catch (error) {
                 console.error('Export failed:', error);
-                showNotification('Failed to export comparison: ' + error.message, 'error');
+                showNotification('Failed to export comparison: ' + error.message, 'danger');
             }
         }
 
@@ -1663,7 +1634,7 @@
                 
             } catch (error) {
                 console.error('Custom scenario generation failed:', error);
-                showNotification('Failed to generate custom scenarios: ' + error.message, 'error');
+                showNotification('Failed to generate custom scenarios: ' + error.message, 'danger');
             } finally {
                 hideLoading();
             }


### PR DESCRIPTION
## Summary
- unify toast notifications and color mapping for success, warning, and failure
- replace custom notification system with wrapper around unified toast
- update templates to use shared toast helper

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask', selenium, docx)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aeb252fc832090a0419812332469