### PR TITLE
Make Report Fields modal full screen

### DIFF
--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -2433,7 +2433,7 @@ function retryLoanSave() {
 </style>
 <!-- Report Fields Modal -->
 <div class="modal fade" id="loanSummaryFieldsModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog modal-fullscreen">
+  <div class="modal-dialog modal-dialog-scrollable modal-fullscreen">
     <div class="modal-content">
       <div class="modal-header bg-primary text-white justify-content-center position-relative" id="loanSummaryFieldsHeader" data-currency="GBP">
         <h5 class="modal-title text-white w-100 text-center">Report Fields</h5>


### PR DESCRIPTION
## Summary
- ensure Report Fields modal on calculator page uses Bootstrap's fullscreen modal class
- allow scrolling within the fullscreen modal

## Testing
- `pytest` *(fails: ValueError: No chrome executable found on PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68c0af4697048320b6c36b0ff03a95a6