### PR TITLE
Ensure report fields modal renders full screen

### DIFF
--- a/static/css/layout-hotfix.css
+++ b/static/css/layout-hotfix.css
@@ -17,3 +17,22 @@
 .chart-container canvas {
     min-height: 200px;
 }
+
+/* Fullscreen modal compatibility for Bootstrap 5.1 */
+
+.modal-fullscreen {
+    width: 100vw;
+    max-width: none;
+    height: 100%;
+    margin: 0;
+}
+
+.modal-fullscreen .modal-content {
+    height: 100%;
+    border: 0;
+    border-radius: 0;
+}
+
+.modal-fullscreen .modal-body {
+    overflow-y: auto;
+}


### PR DESCRIPTION
## Summary
- add custom CSS to support full-screen report fields modal with Bootstrap 5.1

## Testing
- `pytest test_report_fields_length.py test_report_fields_numeric.py test_report_fields_updates_loan_data.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1257d583483209578c08b0dfaaf18