### PR TITLE
Ensure loan edit sends full parameters

### DIFF
--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -873,8 +873,14 @@ class LoanHistoryManager {
                 return;
             }
 
-            // Navigate to calculator with loan ID; details loaded from server
-            window.location.href = `/calculator?edit=true&loanId=${this.currentLoanId}&loanName=${encodeURIComponent(loan.loan_name)}`;
+            // Build full parameter list so calculator page can populate fields
+            const params = this.buildEditParams(loan);
+            params.edit = 'true';
+            params.loanId = this.currentLoanId;
+            params.loanName = loan.loan_name;
+
+            const query = new URLSearchParams(params).toString();
+            window.location.href = `/calculator?${query}`;
 
         } catch (error) {
             console.error('Edit loan error:', error);


### PR DESCRIPTION
## Summary
- Restore building of full query params when editing a loan
- Allow calculator page to pre-populate fields by using buildEditParams

## Testing
- `pytest -q test_loan_history_edit_params.py::test_build_edit_params_includes_development2_tranches test_loan_history_edit_params.py::test_build_edit_params_rounds_interest_rate`

------
https://chatgpt.com/codex/tasks/task_e_68c12d6594908320890bba8ef0733cdc