### PR TITLE
feat(ui): highlight next step banner

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -58,6 +58,7 @@
             </div>
         </div>
     </nav>
+    <div id="nextStepBanner" class="text-center bg-dark text-white fw-bold py-2 d-none"></div>
     </header>
 
     <div class="offcanvas offcanvas-start" tabindex="-1" id="sidebarMenu" aria-labelledby="sidebarMenuLabel">

--- a/templates/calculator.html
+++ b/templates/calculator.html
@@ -2089,23 +2089,24 @@ function updateReportsButton(loan) {
 }
 
 // Initialize everything when page loads
-document.addEventListener('DOMContentLoaded', async function() {
-    const navActions = document.querySelector('.navbar .d-flex.ms-auto');
-    if (navActions) {
-        const stepEl = document.createElement('span');
-        stepEl.id = 'workflowStep';
-        stepEl.className = 'text-white me-2';
-        navActions.insertBefore(stepEl, navActions.firstChild);
-    }
-    window.updateNextStep = function(step) {
-        const el = document.getElementById('workflowStep');
-        if (el) {
-            el.textContent = `Next: ${step}`;
+    document.addEventListener('DOMContentLoaded', async function() {
+        const banner = document.getElementById('nextStepBanner');
+        if (banner) {
+            const stepEl = document.createElement('span');
+            stepEl.id = 'workflowStep';
+            stepEl.className = 'badge bg-warning text-dark fs-6 px-3 py-1 me-2';
+            banner.appendChild(stepEl);
+            banner.classList.remove('d-none');
         }
-    };
-    window.updateNextStep('Calculate');
-    await loadPowerBIReports();
-    // Initialize edit mode
+        window.updateNextStep = function(step) {
+            const el = document.getElementById('workflowStep');
+            if (el) {
+                el.innerHTML = `<i class="fas fa-arrow-right me-1"></i>Next: ${step}`;
+            }
+        };
+        window.updateNextStep('Calculate');
+        await loadPowerBIReports();
+        // Initialize edit mode
     initializeEditMode();
     isLoanSaved = !!(window.editMode && window.editMode.loanId);
     if (isLoanSaved) {


### PR DESCRIPTION
## Summary
- Add persistent banner below navbar for upcoming actions
- Style workflow step with attention-grabbing badge and arrow icon

## Testing
- `pytest test_calculator_page.py -q` *(fails: ModuleNotFoundError: No module named 'selenium')*


------
https://chatgpt.com/codex/tasks/task_e_68c12ce7a13c8320b024571fa5079507