### PR TITLE
Use loan ID for calculator edits

### DIFF
--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -873,13 +873,12 @@ class LoanHistoryManager {
                 return;
             }
 
-            // Build full parameter list so calculator page can populate fields
-            const params = this.buildEditParams(loan);
-            params.edit = 'true';
-            params.loanId = this.currentLoanId;
-            params.loanName = loan.loan_name;
-
-            const query = new URLSearchParams(params).toString();
+            // Only pass basic identifiers; calculator will fetch full details
+            const query = new URLSearchParams({
+                edit: 'true',
+                loanId: this.currentLoanId,
+                loanName: loan.loan_name
+            }).toString();
             window.location.href = `/calculator?${query}`;
 
         } catch (error) {
@@ -893,85 +892,6 @@ class LoanHistoryManager {
     editLoanFromTable(loanId) {
         this.currentLoanId = loanId;
         this.editLoan();
-    }
-
-    buildEditParams(loan) {
-        const formatRate = (rate) => {
-            if (rate === undefined || rate === null || rate === '') return '';
-            let num = parseFloat(rate);
-            if (isNaN(num)) return '';
-            num = parseFloat(num.toFixed(4));
-            if (Math.abs(num - Math.round(num)) < 0.0005) {
-                num = Math.round(num);
-            }
-            return num.toString();
-        };
-
-        const params = {
-            // Core loan parameters
-            loan_type: loan.loan_type ?? 'bridge',
-            amount_input_type: loan.amountInputType ?? loan.amount_input_type ?? 'gross',
-            gross_amount_type: loan.grossAmountType ?? loan.gross_amount_type ?? 'fixed',
-            rate_input_type: loan.rateInputType ?? loan.rate_input_type ?? 'annual',
-            gross_amount: loan.grossAmount ?? loan.gross_amount ?? '',
-            net_amount: loan.netAmount ?? loan.net_amount ?? '',
-            gross_amount_percentage: loan.grossAmountPercentage ?? loan.gross_amount_percentage ?? '',
-            property_value: loan.propertyValue ?? loan.property_value ?? '',
-            annual_rate: formatRate(loan.interestRate ?? loan.interest_rate ?? ''),
-            monthly_rate: formatRate(loan.monthlyRate ?? loan.monthly_rate ?? ''),
-            loan_term: loan.loanTerm ?? loan.loan_term ?? '',
-            start_date: loan.startDate ?? loan.start_date ?? '',
-            end_date: loan.endDate ?? loan.end_date ?? '',
-
-            // Repayment and fee parameters
-            repayment_option: loan.repaymentOption ?? loan.repayment_option ?? 'none',
-            arrangement_fee_percentage: loan.arrangementFeePercentage ?? loan.arrangement_fee_percentage ?? '2',
-            legal_fees: loan.legalFees ?? loan.legal_fees ?? '1500',
-            site_visit_fee: loan.siteVisitFee ?? loan.site_visit_fee ?? '500',
-            title_insurance_rate: loan.titleInsuranceRate ?? loan.title_insurance_rate ?? '0.01',
-
-            // Payment parameters
-            payment_timing: loan.paymentTiming ?? loan.payment_timing ?? 'advance',
-            payment_frequency: loan.paymentFrequency ?? loan.payment_frequency ?? 'monthly',
-            capital_repayment: loan.capitalRepayment ?? loan.capital_repayment ?? '',
-            flexible_payment: loan.flexiblePayment ?? loan.flexible_payment ?? '',
-
-            // Development loan parameters
-            day1_advance: loan.day1Advance ?? loan.day1_advance ?? '',
-            tranche_mode: loan.trancheMode ?? loan.tranche_mode ?? 'manual',
-
-            // Currency
-            currency: loan.currency ?? 'GBP'
-        };
-
-        // Derive additional parameters when not explicitly stored
-        if (!params.monthly_rate && params.annual_rate) {
-            const annual = parseFloat(params.annual_rate);
-            if (!isNaN(annual)) {
-                params.monthly_rate = formatRate(annual / 12);
-            }
-        }
-
-        if (!params.gross_amount_percentage && params.gross_amount && params.property_value) {
-            const gross = parseFloat(params.gross_amount);
-            const property = parseFloat(params.property_value);
-            if (!isNaN(gross) && !isNaN(property) && property !== 0) {
-                params.gross_amount_percentage = ((gross / property) * 100).toFixed(4);
-            }
-        }
-        
-        // Handle tranches for development loans (both development and development2)
-        if ((loan.loan_type === 'development' || loan.loan_type === 'development2') && loan.tranches && Array.isArray(loan.tranches)) {
-            loan.tranches.forEach((tranche, index) => {
-                params[`tranche_amounts[${index}]`] = tranche.amount ?? '';
-                params[`tranche_dates[${index}]`] = tranche.date ?? '';
-                params[`tranche_rates[${index}]`] = tranche.rate ?? '';
-                params[`tranche_descriptions[${index}]`] = tranche.description ?? '';
-            });
-        }
-        
-        console.log('Edit params built:', params);
-        return params;
     }
 
     showState(state) {

--- a/test_loan_history_edit_params.py
+++ b/test_loan_history_edit_params.py
@@ -3,44 +3,28 @@ import re
 import subprocess
 from pathlib import Path
 
-def _run_build_edit_params(loan_obj):
+
+def _run_edit_loan(current_id, loans):
     content = Path('templates/loan_history.html').read_text()
-    # Extract the body of buildEditParams function
-    match = re.search(r'buildEditParams\(loan\)\s*{([\s\S]*?)}\s*showState', content)
-    assert match, "buildEditParams function not found"
+    assert 'buildEditParams' not in content
+    match = re.search(r'editLoan\(\)\s*{([\s\S]*?)\n\s*}\s*\n\s*editLoanFromTable', content)
+    assert match, "editLoan function not found"
     body = match.group(1)
     node_script = f"""
-const loan = {json.dumps(loan_obj)};
-function buildEditParams(loan) {{{body}}}
-const result = buildEditParams(loan);
-console.log(JSON.stringify(result));
+const window = {{ notifications: {{ error: ()=>{{}} }}, location: {{ href: '' }} }};
+function alert(){{}};
+const loanHistory = {{
+    currentLoanId: {current_id},
+    loans: {json.dumps(loans)}
+}};
+loanHistory.editLoan = function() {{{body}}};
+loanHistory.editLoan();
+console.log(window.location.href);
 """
     output = subprocess.check_output(['node', '-e', node_script], text=True)
-    last_line = output.strip().splitlines()[-1]
-    return json.loads(last_line)
-
-def test_build_edit_params_includes_development2_tranches():
-    loan_obj = {
-        'loan_type': 'development2',
-        'tranches': [
-            {'amount': '10000', 'date': '2024-01-01', 'rate': '10', 'description': 'Phase 1'},
-            {'amount': '20000', 'date': '2024-06-01', 'rate': '11', 'description': 'Phase 2'},
-        ]
-    }
-    result = _run_build_edit_params(loan_obj)
-    assert result['tranche_amounts[0]'] == '10000'
-    assert result['tranche_dates[0]'] == '2024-01-01'
-    assert result['tranche_rates[0]'] == '10'
-    assert result['tranche_descriptions[0]'] == 'Phase 1'
-    assert result['tranche_amounts[1]'] == '20000'
-    assert result['tranche_dates[1]'] == '2024-06-01'
-    assert result['tranche_rates[1]'] == '11'
-    assert result['tranche_descriptions[1]'] == 'Phase 2'
+    return output.strip().splitlines()[-1]
 
 
-def test_build_edit_params_rounds_interest_rate():
-    loan_obj = {
-        'interest_rate': 9.9996
-    }
-    result = _run_build_edit_params(loan_obj)
-    assert result['annual_rate'] == '10'
+def test_edit_loan_redirects_with_basic_params():
+    url = _run_edit_loan(5, [{'id': 5, 'loan_name': 'Test Loan'}])
+    assert url == "/calculator?edit=true&loanId=5&loanName=Test+Loan"


### PR DESCRIPTION
## Summary
- Simplify loan editing by only passing loan ID and name to calculator
- Remove legacy `buildEditParams` logic
- Add test to ensure edit URL only contains basic identifiers

## Testing
- `pytest test_loan_history_edit_params.py test_calculator_editing_fields.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c139598cd48320aec4e171bcb34fb8