### PR TITLE
Fix calculate button for development2 loan

### DIFF
--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -1956,7 +1956,11 @@ class LoanCalculator {
                 // Enable interest calculation type selection for non-development loans
                 interestTypeRadios.forEach(r => r.disabled = false);
             }
-            
+
+            // Ensure required attributes align with the selected amount input
+            // so validation and calculate button state are updated correctly
+            this.toggleAmountInputSections();
+
             // Show/hide additional params container
             if (additionalParamsContainer) {
                 if (showAdditionalParams || loanType === 'development' || loanType === 'development2') {

--- a/test_calculator_page.py
+++ b/test_calculator_page.py
@@ -72,3 +72,26 @@ def test_development_loan_disables_gross_amount(live_server):
         assert not driver.find_element(By.ID, "grossAmount").is_enabled()
     finally:
         driver.quit()
+
+
+def test_development2_calculate_button(live_server):
+    driver = _get_chrome_driver()
+    try:
+        driver.get(live_server + "/calculator")
+        driver.find_element(By.ID, "loanTypeDevelopment").click()
+        driver.find_element(By.ID, "loanName").send_keys("Dev Loan")
+        driver.find_element(By.ID, "propertyValue").send_keys("500000")
+        driver.find_element(By.ID, "netAmountInput").send_keys("100000")
+        driver.find_element(By.ID, "loanTerm").send_keys("12")
+        today = date.today().strftime("%Y-%m-%d")
+        driver.find_element(By.ID, "startDate").send_keys(today)
+
+        WebDriverWait(driver, 10).until(
+            lambda d: d.find_element(By.CSS_SELECTOR, "button.calculate-button").is_enabled()
+        )
+        driver.find_element(By.CSS_SELECTOR, "button.calculate-button").click()
+        WebDriverWait(driver, 10).until(
+            lambda d: d.find_element(By.ID, "resultsSection").is_displayed()
+        )
+    finally:
+        driver.quit()


### PR DESCRIPTION
## Summary
- Fix validation for Development 2 loans by updating required field handling
- Add Selenium test ensuring calculate button works for Development 2 loans

## Testing
- `pytest test_calculator_page.py::test_development2_calculate_button -q` *(fails: No chrome executable found on PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e1550624832099101e2d4e69784d