### PR TITLE
enhance calculation breakdown modal

### DIFF
--- a/test_calculation_breakdown_details.py
+++ b/test_calculation_breakdown_details.py
@@ -39,3 +39,25 @@ def test_breakdown_shows_selected_details(live_server):
         assert "Loan Term (months): 12" in content
     finally:
         driver.quit()
+
+
+def test_breakdown_shows_tranche_setup(live_server):
+    driver = _get_chrome_driver()
+    try:
+        driver.get(live_server + "/calculator")
+        driver.find_element(By.ID, "loanTypeDevelopment").click()
+        driver.find_element(By.ID, "loanName").send_keys("Dev Loan")
+        driver.find_element(By.ID, "propertyValue").send_keys("500000")
+        driver.find_element(By.ID, "netAmountInput").send_keys("100000")
+        driver.find_element(By.ID, "loanTerm").send_keys("12")
+        driver.find_element(By.ID, "startDate").send_keys("2024-01-01")
+        driver.find_element(By.CSS_SELECTOR, "button.calculate-button").click()
+        WebDriverWait(driver, 10).until(
+            lambda d: d.find_element(By.ID, "resultsSection").is_displayed()
+        )
+        content = _open_breakdown(driver)
+        assert "Loan Type: Development" in content
+        assert "Tranche Setup" in content
+        assert "Total Interest = Σ" in content
+    finally:
+        driver.quit()


### PR DESCRIPTION
## Summary
- expand calculation breakdown modal with detailed loan info including tranche setup and interest formulas
- handle Development2 loans with summation-based interest formula in modal
- add selenium test to verify tranche details and interest formula visibility

## Testing
- `pytest test_calculation_breakdown_details.py -q` *(fails: No chrome executable found on PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68c5638e19e08320b89f011eed57556e