### PR TITLE
Add interest calculation comparison templates

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -4108,6 +4108,8 @@ def get_scenario_templates(template_type):
         elif template_type == 'loan_amounts':
             amounts = [500000, 750000, 1000000, 1500000]
             scenarios = ScenarioTemplates.loan_amount_comparison(base_params, amounts)
+        elif template_type == 'interest_types':
+            scenarios = ScenarioTemplates.interest_type_comparison(base_params)
         else:
             return jsonify({
                 'success': False,

--- a/scenario_comparison.py
+++ b/scenario_comparison.py
@@ -482,6 +482,30 @@ class ScenarioTemplates:
             })
         return scenarios
 
+    @staticmethod
+    def interest_type_comparison(
+        base_params,
+        interest_types=['simple', 'compound_daily', 'compound_monthly', 'compound_quarterly']
+    ):
+        """Create scenarios comparing different interest calculation methods"""
+        scenarios = []
+        name_map = {
+            'simple': 'Simple Interest',
+            'compound_daily': 'Compound Daily',
+            'compound_monthly': 'Compound Monthly',
+            'compound_quarterly': 'Compound Quarterly'
+        }
+
+        for interest_type in interest_types:
+            params = ScenarioTemplates._get_complete_params(base_params)
+            params['interest_type'] = interest_type
+            scenarios.append({
+                'name': name_map.get(interest_type, interest_type.replace('_', ' ').title()),
+                'parameters': params
+            })
+
+        return scenarios
+
 # Flask integration helper
 def create_scenario_comparison_from_request(request_data):
     """Create scenario comparison from Flask request data"""

--- a/templates/scenario_comparison.html
+++ b/templates/scenario_comparison.html
@@ -335,6 +335,9 @@
                                         <button class="btn btn-outline-primary template-btn" onclick="openLoanAmountModal()">
                                             <i class="fas fa-pound-sign me-2"></i>Compare Loan Amounts
                                         </button>
+                                        <button class="btn btn-outline-primary template-btn" onclick="openInterestTypeModal()">
+                                            <i class="fas fa-calculator me-2"></i>Compare Interest Methods
+                                        </button>
                                         <button class="btn btn-success template-btn" onclick="openCustomScenarioModal()">
                                             <i class="fas fa-plus me-2"></i>Create Custom 4-Scenario Comparison
                                         </button>
@@ -500,6 +503,63 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                     <button type="button" class="btn btn-primary" onclick="generateLoanAmountComparison()">Generate Comparison</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Interest Type Comparison Modal -->
+    <div class="modal fade" id="interestTypeModal" tabindex="-1">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title"><i class="fas fa-calculator me-2"></i>Interest Calculation Comparison</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="text-muted">Select four interest calculation methods to compare:</p>
+                    <div class="row">
+                        <div class="col-6 mb-3">
+                            <label class="form-label">Type 1</label>
+                            <select id="interestType1" class="form-select">
+                                <option value="simple">Simple</option>
+                                <option value="compound_daily">Compound Daily</option>
+                                <option value="compound_monthly">Compound Monthly</option>
+                                <option value="compound_quarterly">Compound Quarterly</option>
+                            </select>
+                        </div>
+                        <div class="col-6 mb-3">
+                            <label class="form-label">Type 2</label>
+                            <select id="interestType2" class="form-select">
+                                <option value="compound_daily">Compound Daily</option>
+                                <option value="simple">Simple</option>
+                                <option value="compound_monthly">Compound Monthly</option>
+                                <option value="compound_quarterly">Compound Quarterly</option>
+                            </select>
+                        </div>
+                        <div class="col-6 mb-3">
+                            <label class="form-label">Type 3</label>
+                            <select id="interestType3" class="form-select">
+                                <option value="compound_monthly">Compound Monthly</option>
+                                <option value="simple">Simple</option>
+                                <option value="compound_daily">Compound Daily</option>
+                                <option value="compound_quarterly">Compound Quarterly</option>
+                            </select>
+                        </div>
+                        <div class="col-6 mb-3">
+                            <label class="form-label">Type 4</label>
+                            <select id="interestType4" class="form-select">
+                                <option value="compound_quarterly">Compound Quarterly</option>
+                                <option value="simple">Simple</option>
+                                <option value="compound_daily">Compound Daily</option>
+                                <option value="compound_monthly">Compound Monthly</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" onclick="generateInterestTypeComparison()">Generate Comparison</button>
                 </div>
             </div>
         </div>
@@ -777,6 +837,11 @@
             modal.show();
         }
 
+        function openInterestTypeModal() {
+            const modal = new bootstrap.Modal(document.getElementById('interestTypeModal'));
+            modal.show();
+        }
+
         function openRepaymentModal() {
             const modal = new bootstrap.Modal(document.getElementById('repaymentModal'));
             modal.show();
@@ -825,9 +890,22 @@
                 parseFloat(document.getElementById('amount3').value),
                 parseFloat(document.getElementById('amount4').value)
             ];
-            
+
             await generateCustomTemplate('loan_amounts', amounts);
             bootstrap.Modal.getInstance(document.getElementById('loanAmountModal')).hide();
+        }
+
+        // Generate Interest Type Comparison
+        async function generateInterestTypeComparison() {
+            const types = [
+                document.getElementById('interestType1').value,
+                document.getElementById('interestType2').value,
+                document.getElementById('interestType3').value,
+                document.getElementById('interestType4').value
+            ];
+
+            await generateCustomTemplate('interest_types', types);
+            bootstrap.Modal.getInstance(document.getElementById('interestTypeModal')).hide();
         }
 
         // Generate Repayment Options Comparison
@@ -867,6 +945,17 @@
                     scenarios = values.map((amount, index) => ({
                         name: `£${(amount/1000000).toFixed(1)}M Loan`,
                         parameters: { ...baseParams, gross_amount: amount }
+                    }));
+                } else if (templateType === 'interest_types') {
+                    const interestNames = {
+                        'simple': 'Simple Interest',
+                        'compound_daily': 'Compound Daily',
+                        'compound_monthly': 'Compound Monthly',
+                        'compound_quarterly': 'Compound Quarterly'
+                    };
+                    scenarios = values.map((type, index) => ({
+                        name: interestNames[type],
+                        parameters: { ...baseParams, interest_type: type }
                     }));
                 } else if (templateType === 'repayment_options') {
                     const repaymentNames = {

--- a/test_interest_type_template.py
+++ b/test_interest_type_template.py
@@ -1,0 +1,19 @@
+import pytest
+from app import app
+
+def test_interest_type_template():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        response = client.get('/api/scenario-comparison/templates/interest_types', query_string={
+            'loan_type': 'bridge',
+            'gross_amount': 1000000,
+            'loan_term': 12,
+            'property_value': 2000000
+        })
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['success'] is True
+        scenarios = data['scenarios']
+        assert len(scenarios) == 4
+        types = [s['parameters']['interest_type'] for s in scenarios]
+        assert types == ['simple', 'compound_daily', 'compound_monthly', 'compound_quarterly']


### PR DESCRIPTION
## Summary
- support interest calculation comparison scenarios
- expose new `interest_types` template API
- add UI for comparing interest calculation methods

## Testing
- `pytest` *(fails: No chrome executable, AttributeError in scenario comparison session test)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e85b637c8320ad4aadc0d44d0d86