### PR TITLE
Add loan summary comparison columns

### DIFF
--- a/scenario_comparison.py
+++ b/scenario_comparison.py
@@ -23,7 +23,12 @@ class ScenarioComparison:
     # These aliases ensure the comparison table can find the relevant
     # value regardless of which variant is present.
     METRIC_ALIASES = {
+        'propertyValue': ['propertyValue', 'property_value'],
         'grossAmount': ['grossAmount', 'gross_amount'],
+        'startDate': ['start_date', 'startDate'],
+        'endDate': ['end_date', 'endDate'],
+        'loanTerm': ['loanTerm', 'loan_term'],
+        'loanTermDays': ['loanTermDays', 'loan_term_days'],
         'netAdvance': ['netAdvance', 'net_advance'],
         'totalNetAdvance': [
             'totalNetAdvance',
@@ -36,6 +41,7 @@ class ScenarioComparison:
         'legalCosts': ['legalCosts', 'legalFees', 'totalLegalFees', 'legal_costs'],
         'siteVisitFee': ['siteVisitFee', 'site_visit_fee'],
         'titleInsurance': ['titleInsurance', 'title_insurance'],
+        'ltv': ['ltv', 'ltv_ratio'],
         'endLTV': ['endLTV', 'end_ltv', 'endLtv'],
         'interestSavings': ['interestSavings', 'interest_savings'],
         'savingsPercentage': ['savingsPercentage', 'savings_percent'],
@@ -148,17 +154,23 @@ class ScenarioComparison:
         if not self.scenarios:
             return []
         
-        # Define key metrics to compare
+        # Define key metrics to compare (mirroring calculator summary)
         key_metrics = [
+            'propertyValue',
             'grossAmount',
-            'netAdvance',
-            'totalNetAdvance',
-            'totalInterest',
+            'startDate',
+            'endDate',
+            'loanTerm',
+            'loanTermDays',
             'arrangementFee',
             'legalCosts',
             'siteVisitFee',
             'titleInsurance',
+            'totalInterest',
+            'netAdvance',
+            'ltv',
             'endLTV',
+            'totalNetAdvance',
             'interestSavings',
             'savingsPercentage'
         ]
@@ -306,15 +318,21 @@ class ScenarioComparison:
     def _format_metric_name(self, metric):
         """Format metric name for display"""
         name_map = {
+            'propertyValue': 'Valuation',
             'grossAmount': 'Gross Amount',
-            'netAdvance': 'Net Advance',
-            'totalNetAdvance': 'Total Net Advance',
-            'totalInterest': 'Total Interest',
+            'startDate': 'Date of First Drawdown',
+            'endDate': 'End Date',
+            'loanTerm': 'Term (Months)',
+            'loanTermDays': 'Term (Days)',
             'arrangementFee': 'Arrangement Fee',
             'legalCosts': 'Legal Costs',
             'siteVisitFee': 'Site Visit Fee',
             'titleInsurance': 'Title Insurance',
+            'totalInterest': 'Interest',
+            'netAdvance': 'Net Day 1 Advance',
+            'ltv': 'LTV Ratio',
             'endLTV': 'End LTV',
+            'totalNetAdvance': 'Total Net Advance',
             'interestSavings': 'Interest Savings',
             'savingsPercentage': 'Savings %'
         }
@@ -326,9 +344,13 @@ class ScenarioComparison:
             return 'N/A'
         
         try:
-            if metric in ['endLTV', 'savingsPercentage']:
-                return str(value)  # Already formatted as percentage
-            elif metric in ['grossAmount', 'netAdvance', 'totalNetAdvance', 'totalInterest', 
+            if metric in ['endLTV', 'ltv', 'savingsPercentage']:
+                return f"{float(value):.2f}%"
+            elif metric in ['startDate', 'endDate']:
+                return str(value)
+            elif metric in ['loanTerm', 'loanTermDays']:
+                return f"{int(float(value))}"
+            elif metric in ['propertyValue', 'grossAmount', 'netAdvance', 'totalNetAdvance', 'totalInterest',
                           'arrangementFee', 'legalCosts', 'siteVisitFee', 'titleInsurance', 'interestSavings']:
                 return f"£{float(value):,.2f}"
             else:

--- a/templates/scenario_comparison.html
+++ b/templates/scenario_comparison.html
@@ -360,6 +360,18 @@
 
     <!-- Comparison Results -->
     <div class="row" id="comparisonResults" style="display: none;">
+                <!-- Loan Summary Comparison -->
+                <div class="col-12 mb-4">
+                    <div class="card">
+                        <div class="card-header">
+                            <h3 class="mb-0"><i class="fas fa-file-alt me-2"></i>Loan Summary Comparison</h3>
+                        </div>
+                        <div class="card-body" id="loanSummaryComparison">
+                            <!-- Loan summaries will be populated here -->
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Best Scenario Analysis -->
                 <div class="col-12 mb-4">
                     <div class="card">
@@ -1008,6 +1020,7 @@
 
         function displayComparisonResults(data) {
             displayBestScenarioAnalysis(data.best_scenario_analysis);
+            displayLoanSummaryColumns(data.comparison_table);
             displayComparisonTable(data.comparison_table);
             document.getElementById('comparisonResults').style.display = 'block';
         }
@@ -1124,6 +1137,31 @@
                 tableRow.innerHTML = rowHtml;
                 tbody.appendChild(tableRow);
             });
+        }
+
+        function displayLoanSummaryColumns(comparisonTable) {
+            const container = document.getElementById('loanSummaryComparison');
+            if (!container) return;
+            container.innerHTML = '';
+
+            if (comparisonTable.length === 0) return;
+
+            const scenarios = comparisonTable[0].scenarios.map(s => s.name);
+            const colWidth = Math.floor(12 / scenarios.length);
+            let html = '<div class="row">';
+
+            scenarios.forEach((name, index) => {
+                html += `<div class="col-md-${colWidth} mb-3">`;
+                html += `<table class="table table-bordered table-sm"><thead><tr><th colspan="2" class="text-center">${name}</th></tr></thead><tbody>`;
+                comparisonTable.forEach(row => {
+                    const value = row.scenarios[index].value;
+                    html += `<tr><td>${row.metric}</td><td class="text-end">${value}</td></tr>`;
+                });
+                html += '</tbody></table></div>';
+            });
+
+            html += '</div>';
+            container.innerHTML = html;
         }
 
         async function exportComparison() {


### PR DESCRIPTION
## Summary
- Mirror calculator metrics in scenario comparisons
- Display loan summaries side-by-side for each scenario

## Testing
- `pytest test_scenario_comparison_session_size.py -q` *(fails: AttributeError: 'FlaskClient' object has no attribute 'cookie_jar')*

------
https://chatgpt.com/codex/tasks/task_e_68c5eac6cd108320b84ed1e14ae8d362