### PR TITLE
Limit 360-day option by loan type and term

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -870,6 +870,11 @@ class LoanCalculator:
 
         params['loan_term_days'] = loan_term_days
 
+        # Restrict 360-day calculation to loans up to 12 months
+        if use_360_days and loan_term > 12:
+            logging.info("Term loan term exceeds 12 months; disabling 360-day calculation")
+            use_360_days = False
+
         # Determine gross amount based on input type
         if amount_input_type == 'net' and net_amount > 0:
             gross_amount = self._calculate_gross_from_net_bridge(
@@ -1066,9 +1071,12 @@ class LoanCalculator:
         from dateutil.relativedelta import relativedelta
         from calendar import monthrange
         import numpy as np
-        
+
         logging.info("🎯 DEVELOPMENT 2: Using attached Python code methodology")
-        
+
+        # 360-day calculation is not permitted for development2 loans
+        params['use_360_days'] = False
+
         # Extract parameters matching the Python code structure
         net_advance_day1 = float(params.get('day1_advance', 100000))
         legals = float(params.get('legal_fees', 7587.94))
@@ -1551,6 +1559,9 @@ class LoanCalculator:
         amount_input_type = params.get('amount_input_type', 'net')  # Default to net for development loans
         interest_type = params.get('interest_type', 'simple')
         use_360_days = params.get('use_360_days', False)  # Daily rate calculation method
+        if use_360_days and loan_term > 12:
+            logging.info("Development loan term exceeds 12 months; disabling 360-day calculation")
+            use_360_days = False
         
         # Fee parameters
         arrangement_fee_rate = Decimal(str(params.get('arrangement_fee_rate', 0)))

--- a/routes.py
+++ b/routes.py
@@ -574,9 +574,9 @@ def api_calculate():
             use_360_days = False
         app.logger.info(f"ROUTES.PY DEBUG: use_360_days parameter = {use_360_days} (from {data.get('use_360_days')}, type: {type(use_360_days_value)})")
 
-        # Restrict 360-day calculation to bridge loans with terms up to 12 months
-        if loan_type == 'bridge' and loan_term > 12 and use_360_days:
-            app.logger.info("ROUTES.PY: disabling 360-day calculation for bridge term over 12 months")
+        # Restrict 360-day calculation to non-development2 loans with terms up to 12 months
+        if use_360_days and (loan_term > 12 or loan_type == 'development2'):
+            app.logger.info("ROUTES.PY: disabling 360-day calculation for loan term over 12 months or development2 loan")
             use_360_days = False
         
         # Build parameters dictionary

--- a/static/js/calculator.js
+++ b/static/js/calculator.js
@@ -335,12 +335,14 @@ class LoanCalculator {
         document.getElementById('startDate').addEventListener('change', () => {
             calculateEndDate();
             toggleCalculate();
+            this.update360DayVisibility();
         });
         const endDateField = document.getElementById('endDate');
         if (endDateField) {
             endDateField.addEventListener('change', () => {
                 calculateEndDate();
                 toggleCalculate();
+                this.update360DayVisibility();
             });
         }
         const loanTermField = document.getElementById('loanTerm');
@@ -348,6 +350,7 @@ class LoanCalculator {
             loanTermField.addEventListener('input', () => {
                 calculateEndDate();
                 toggleCalculate();
+                this.update360DayVisibility();
             });
         }
         const loanEndRadios = document.querySelectorAll('input[name="loan_end_type"]');
@@ -1679,8 +1682,17 @@ class LoanCalculator {
             const use360DaysSection = document.getElementById('use360DaysSection');
             const startDateEl = document.getElementById('startDate');
             const endDateEl = document.getElementById('endDate');
+            const loanTypeEl = document.getElementById('loanType');
+            const loanType = loanTypeEl ? loanTypeEl.value : '';
 
             if (!use360DaysSection || !startDateEl || !endDateEl) {
+                return;
+            }
+
+            if (loanType === 'development2') {
+                use360DaysSection.style.display = 'none';
+                const checkbox = document.getElementById('use360Days');
+                if (checkbox) checkbox.checked = false;
                 return;
             }
 

--- a/test_term_and_development2_360_day_limit.py
+++ b/test_term_and_development2_360_day_limit.py
@@ -1,0 +1,20 @@
+import pytest
+from calculations import LoanCalculator
+
+
+def test_development2_disables_360_day_calculation():
+    calc = LoanCalculator()
+    params = {
+        'day1_advance': 100000,
+        'legal_fees': 0,
+        'annual_rate': 12.0,
+        'arrangement_fee_rate': 2.0,
+        'title_insurance_rate': 0.01,
+        'site_visit_fee': 0,
+        'net_amount': 200000,
+        'loan_term': 12,
+        'start_date': '2025-01-01',
+    }
+    res_360 = calc.calculate_development2_loan({**params, 'use_360_days': True})
+    res_365 = calc.calculate_development2_loan({**params, 'use_360_days': False})
+    assert res_360['totalInterest'] == pytest.approx(res_365['totalInterest'])


### PR DESCRIPTION
## Summary
- Hide 360-day checkbox for development2 loans
- Disable 360-day calculations when loan term exceeds 12 months
- Add test confirming development2 ignores 360-day flag

## Testing
- `pytest` *(fails: No chrome executable found on PATH; FlaskClient attribute error)*


------
https://chatgpt.com/codex/tasks/task_e_68c738c336608320aa4c1f89d0938733