### PR TITLE
Fix Development2 January period end and add coverage

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -1509,12 +1509,11 @@ class LoanCalculator:
                 _, last_day = monthrange(next_year, next_month)
                 target_day = current_date.day - 1
                 if target_day < 1:
-                    day = last_day
+                    current_month_last_day = monthrange(current_date.year, current_date.month)[1]
+                    period_end_date = datetime(current_date.year, current_date.month, current_month_last_day)
                 else:
                     day = min(target_day, last_day)
-                period_end_date = datetime(next_year, next_month, day)
-                if target_day < 1:
-                    period_end_date = period_end_date + relativedelta(months=-1)
+                    period_end_date = datetime(next_year, next_month, day)
             
             days_in_period = (period_end_date - period_start_date).days + 1
             

--- a/test_development2_payment_schedule_days.py
+++ b/test_development2_payment_schedule_days.py
@@ -28,6 +28,17 @@ def test_development2_first_period_for_start_on_first_matches_excel_days():
     assert '^30' in first_period['interest_calculation']
 
 
+def test_development2_first_period_for_january_start_spans_full_month():
+    calc = LoanCalculator()
+    result = calc.calculate_development2_loan(_base_params('2025-01-01'))
+    schedule = result['detailed_payment_schedule']
+    first_period = schedule[0]
+
+    assert first_period['days'] == 31
+    assert first_period['payment_date'].endswith('31/01/2025')
+    assert '^31' in first_period['interest_calculation']
+
+
 def test_development2_first_period_for_end_of_month_start_dates_match_excel_days():
     calc = LoanCalculator()
 


### PR DESCRIPTION
## Summary
- ensure the Development2 payment schedule uses the current month's last day when the previous-day calculation underflows
- add a regression test covering a January start date to confirm the full month is counted in both days and interest exponent

## Testing
- pytest test_development2_payment_schedule_days.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8716b4948320b94c2f5d6232efcd