### PR TITLE
Align Development2 solver day counts with schedule

### DIFF
--- a/calculations.py
+++ b/calculations.py
@@ -1196,10 +1196,13 @@ class LoanCalculator:
                         next_year += 1
 
                     _, last_day = monthrange(next_year, next_month)
-                    day = min(current_date.day - 1, last_day)
-                    if day < 1:
-                        day = 1
-                    period_end = datetime(next_year, next_month, day)
+                    target_day = current_date.day - 1
+                    if target_day < 1:
+                        current_month_last_day = monthrange(current_date.year, current_date.month)[1]
+                        period_end = datetime(current_date.year, current_date.month, current_month_last_day)
+                    else:
+                        day = min(target_day, last_day)
+                        period_end = datetime(next_year, next_month, day)
 
                 days_in_period = (period_end - current_date).days + 1
                 
@@ -1509,12 +1512,11 @@ class LoanCalculator:
                 _, last_day = monthrange(next_year, next_month)
                 target_day = current_date.day - 1
                 if target_day < 1:
-                    day = last_day
+                    current_month_last_day = monthrange(current_date.year, current_date.month)[1]
+                    period_end_date = datetime(current_date.year, current_date.month, current_month_last_day)
                 else:
                     day = min(target_day, last_day)
-                period_end_date = datetime(next_year, next_month, day)
-                if target_day < 1:
-                    period_end_date = period_end_date + relativedelta(months=-1)
+                    period_end_date = datetime(next_year, next_month, day)
             
             days_in_period = (period_end_date - period_start_date).days + 1
             

--- a/test_development2_payment_schedule_days.py
+++ b/test_development2_payment_schedule_days.py
@@ -1,3 +1,5 @@
+import pytest
+
 from calculations import LoanCalculator
 
 
@@ -17,6 +19,22 @@ def _base_params(start_date: str) -> dict:
     }
 
 
+def _scenario_params(start_date: str) -> dict:
+    params = _base_params(start_date)
+    params.update({
+        'loan_term': 24,
+        'day1_advance': 356123.564,
+        'net_amount': 856123.564,
+        'annual_rate': 10.9865,
+        'legal_fees': 0,
+        'tranches': [
+            {'amount': 100000, 'month': month}
+            for month in range(2, 7)
+        ],
+    })
+    return params
+
+
 def test_development2_first_period_for_start_on_first_matches_excel_days():
     calc = LoanCalculator()
     result = calc.calculate_development2_loan(_base_params('2025-11-01'))
@@ -26,6 +44,17 @@ def test_development2_first_period_for_start_on_first_matches_excel_days():
     assert first_period['days'] == 30
     assert first_period['payment_date'].endswith('30/11/2025')
     assert '^30' in first_period['interest_calculation']
+
+
+def test_development2_first_period_for_january_start_spans_full_month():
+    calc = LoanCalculator()
+    result = calc.calculate_development2_loan(_base_params('2025-01-01'))
+    schedule = result['detailed_payment_schedule']
+    first_period = schedule[0]
+
+    assert first_period['days'] == 31
+    assert first_period['payment_date'].endswith('31/01/2025')
+    assert '^31' in first_period['interest_calculation']
 
 
 def test_development2_first_period_for_end_of_month_start_dates_match_excel_days():
@@ -45,3 +74,28 @@ def test_development2_first_period_for_end_of_month_start_dates_match_excel_days
         assert first_period['days'] == expected_days
         assert first_period['payment_date'].endswith(expected_end)
         assert f'^{expected_days}' in first_period['interest_calculation']
+
+
+def test_development2_scenario_start_dates_align_interest_and_closing_balance():
+    calc = LoanCalculator()
+
+    scenario_one = calc.calculate_development2_loan(_scenario_params('2025-11-01'))
+    scenario_two = calc.calculate_development2_loan(_scenario_params('2025-11-02'))
+
+    total_interest_one = scenario_one['totalInterest']
+    total_interest_two = scenario_two['totalInterest']
+
+    assert total_interest_one == pytest.approx(total_interest_two, abs=1e-6)
+
+    closing_one = float(
+        scenario_one['detailed_payment_schedule'][-1]['closing_balance']
+        .replace('£', '')
+        .replace(',', '')
+    )
+    closing_two = float(
+        scenario_two['detailed_payment_schedule'][-1]['closing_balance']
+        .replace('£', '')
+        .replace(',', '')
+    )
+
+    assert closing_one == pytest.approx(closing_two, abs=1e-9)


### PR DESCRIPTION
## Summary
- mirror the payment schedule month-end behaviour in the Development2 solver so underflowed target days use the current month’s final day
- add scenario-based coverage comparing 1 November and 2 November start dates to confirm interest and closing balances stay aligned

## Testing
- pytest test_development2_payment_schedule_days.py

------
https://chatgpt.com/codex/tasks/task_e_68dd8716b4948320b94c2f5d6232efcd