### PR TITLE
Align loan history details with calculator visualisations

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -2693,18 +2693,73 @@ def get_loan_details(loan_id):
         # Convert payment schedule to list
         schedule_data = []
         for payment in payment_schedule:
-            schedule_data.append({
-                'period_number': payment.period_number,
-                'payment_date': payment.payment_date.strftime('%d/%m/%Y') if payment.payment_date else '',
-                'opening_balance': f"£{payment.opening_balance:,.2f}" if payment.opening_balance else '£0.00',
-                'closing_balance': f"£{payment.closing_balance:,.2f}" if payment.closing_balance else '£0.00',
-                'balance_change': payment.balance_change or '',
-                'total_payment': f"£{payment.total_payment:,.2f}" if payment.total_payment else '£0.00',
-                'interest_amount': f"£{payment.interest_amount:,.2f}" if payment.interest_amount else '£0.00',
-                'principal_payment': f"£{payment.principal_payment:,.2f}" if payment.principal_payment else '£0.00',
-                'tranche_release': f"£{payment.tranche_release:,.2f}" if payment.tranche_release else '£0.00',
-                'interest_calculation': payment.interest_calculation or ''
-            })
+            raw_schedule = {}
+            if payment.schedule_data:
+                try:
+                    raw_schedule = json.loads(payment.schedule_data)
+                except (TypeError, ValueError) as exc:
+                    app.logger.warning(
+                        "Failed to parse stored schedule_data for payment %s: %s",
+                        payment.id,
+                        exc,
+                    )
+
+            entry = {}
+            if isinstance(raw_schedule, dict):
+                entry.update(raw_schedule)
+
+            entry.update(
+                {
+                    'period_number': payment.period_number,
+                    'payment_date': payment.payment_date.strftime('%d/%m/%Y')
+                    if payment.payment_date
+                    else entry.get('payment_date', ''),
+                    'opening_balance': (
+                        f"£{payment.opening_balance:,.2f}"
+                        if payment.opening_balance is not None
+                        else entry.get('opening_balance', '£0.00')
+                    ),
+                    'closing_balance': (
+                        f"£{payment.closing_balance:,.2f}"
+                        if payment.closing_balance is not None
+                        else entry.get('closing_balance', '£0.00')
+                    ),
+                    'balance_change': payment.balance_change
+                    if payment.balance_change is not None
+                    else entry.get('balance_change', ''),
+                    'total_payment': (
+                        f"£{payment.total_payment:,.2f}"
+                        if payment.total_payment is not None
+                        else entry.get('total_payment', '£0.00')
+                    ),
+                    'interest_amount': (
+                        f"£{payment.interest_amount:,.2f}"
+                        if payment.interest_amount is not None
+                        else entry.get('interest_amount', '£0.00')
+                    ),
+                    'principal_payment': (
+                        f"£{payment.principal_payment:,.2f}"
+                        if payment.principal_payment is not None
+                        else entry.get('principal_payment', '£0.00')
+                    ),
+                    'tranche_release': (
+                        f"£{payment.tranche_release:,.2f}"
+                        if payment.tranche_release is not None
+                        else entry.get('tranche_release', '£0.00')
+                    ),
+                    'interest_calculation': payment.interest_calculation
+                    if payment.interest_calculation
+                    else entry.get('interest_calculation', ''),
+                }
+            )
+
+            # Ensure any derived schedule metadata is present for UI rendering
+            if 'start_period' not in entry and payment.payment_date:
+                entry['start_period'] = entry.get('start_period', entry['payment_date'])
+            if 'end_period' not in entry and payment.payment_date:
+                entry['end_period'] = entry.get('end_period', entry['payment_date'])
+
+            schedule_data.append(entry)
         
         # Parse original input data for use in tranche schedules
         try:

--- a/templates/loan_history.html
+++ b/templates/loan_history.html
@@ -135,6 +135,121 @@
 </div>
 
 <!-- Bootstrap JS already loaded in base template -->
+
+<!-- Visualization Modals -->
+<div class="modal fade modal-edge-to-edge" id="paymentScheduleModal" tabindex="-1" aria-labelledby="paymentScheduleLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header bg-novellus-navy text-white">
+        <h5 class="modal-title" id="paymentScheduleLabel">Detailed Payment Schedule</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div id="detailedPaymentScheduleCard">
+          <div>
+            <table class="table table-sm" style="width: 100%; border: 1px solid #000; border-collapse: collapse; font-size: 0.875rem;">
+              <thead>
+                <tr style="background: #f8f9fa; border: 1px solid #000;">
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Period</th>
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Start of Period</th>
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">End of Period</th>
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Days Held</th>
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Capital Outstanding</th>
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Annual Interest %</th>
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Factor P.D.</th>
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Scheduled Repayment</th>
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Total Repayment</th>
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Accrued</th>
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Retained</th>
+                  <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Refund</th>
+                  <th class="px-2 text-center" style="color: #000; font-weight: bold; font-size: 0.875rem;">Running LTV</th>
+                </tr>
+              </thead>
+              <tbody id="detailedPaymentScheduleBody"></tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" id="exportPaymentScheduleBtn" style="display: none;">Export</button>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade modal-edge-to-edge" id="trancheScheduleModal" tabindex="-1" aria-labelledby="trancheScheduleLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header bg-novellus-navy text-white">
+        <h5 class="modal-title" id="trancheScheduleLabel">Calculation Breakdown</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <div>
+          <table class="table table-sm" style="width: 100%; border: 1px solid #000; border-collapse: collapse; font-size: 0.875rem;">
+            <thead>
+              <tr style="background: #f8f9fa; border: 1px solid #000;">
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Start of Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">End of Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Days Held</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Opening Balance</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Tranche Release</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Calculation</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Principal</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Total Payment</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Closing Balance</th>
+                <th class="px-2 text-center" style="color: #000; font-weight: bold; font-size: 0.875rem;">Running LTV</th>
+              </tr>
+            </thead>
+            <tbody id="trancheScheduleBody"></tbody>
+          </table>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" id="exportTrancheScheduleBtn" style="display: none;">Export</button>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade modal-edge-to-edge" id="loanBreakdownModal" tabindex="-1" aria-labelledby="loanBreakdownLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header bg-novellus-navy text-white">
+        <h5 class="modal-title" id="loanBreakdownLabel">Loan Breakdown</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <canvas id="loanBreakdownChart" class="w-100" style="height:80vh;"></canvas>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade modal-edge-to-edge" id="balanceModal" tabindex="-1" aria-labelledby="balanceLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header bg-novellus-navy text-white">
+        <h5 class="modal-title" id="balanceLabel">Balance Over Time</h5>
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <canvas id="balanceOverTimeChart" class="w-100" style="height:80vh;"></canvas>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script>
 class LoanHistoryManager {
     constructor() {
@@ -143,6 +258,11 @@ class LoanHistoryManager {
         this.currentLoanId = null;
         this.powerBIReports = {};
         this.loanBreakdownChart = null;
+        this.balanceOverTimeChart = null;
+        this.defaultScheduleHeader = null;
+        this.scheduleVisible = false;
+        this.trancheVisible = false;
+        this.balanceChartAvailable = false;
         this.noteStatuses = ['General', 'Call', 'Email', 'Underwriting', 'Legal', 'Completed'];
         this.noteStatusClasses = {
             'General': 'bg-secondary',
@@ -157,6 +277,7 @@ class LoanHistoryManager {
 
     async init() {
         this.bindEvents();
+        this.setupModalChartHandlers();
         await this.loadPowerBIReports();
         this.loadLoans();
         // BIRT status check removed for simplified deployment
@@ -538,7 +659,11 @@ class LoanHistoryManager {
         const content = document.getElementById('loanDetailsContent');
         const currencySymbol = loan.currency_symbol || (loan.currency === 'EUR' ? '€' : '£');
         const formatMoney = (val) => `${currencySymbol}${(Number(val) || 0).toLocaleString('en-GB', {minimumFractionDigits: 2, maximumFractionDigits: 2})}`;
-        
+
+        this.scheduleVisible = false;
+        this.trancheVisible = false;
+        this.balanceChartAvailable = false;
+
         content.innerHTML = `
             <!-- User Input Values Section -->
             <div class="card mb-4">
@@ -716,104 +841,27 @@ class LoanHistoryManager {
                 </div>
             </div>
             
-            ${
-                (loan.loan_type === 'development' || loan.loan_type === 'development2') && loan.detailed_tranche_schedule && loan.detailed_tranche_schedule.length > 0
-                ? `
             <div class="card border-0 mt-4">
-                <div class="card-header bg-novellus-navy text-white">
-                    <h6 class="mb-0"><i class="fas fa-layer-group me-2"></i>Tranche Schedule</h6>
+                <div class="card-header bg-novellus-navy text-white d-flex align-items-center">
+                    <h6 class="mb-0"><i class="fas fa-chart-area me-2"></i>Visualisations</h6>
                 </div>
                 <div class="card-body">
-                    <div class="table-responsive">
-                        <table class="table table-sm table-striped mb-0" style="font-size: 0.8rem;">
-                            <thead class="table-light sticky-top">
-                                <tr>
-                                    <th style="min-width:80px;">Period</th>
-                                    <th style="min-width:120px;">Start</th>
-                                    <th style="min-width:120px;">End</th>
-                                    <th style="min-width:80px;">Days Held</th>
-                                    <th style="min-width:140px;">Opening Balance</th>
-                                    <th style="min-width:140px;">Calculation</th>
-                                    <th style="min-width:140px;">Tranche Release</th>
-                                    <th style="min-width:120px;">Interest</th>
-                                    <th style="min-width:120px;">Principal</th>
-                                    <th style="min-width:140px;">Total Payment</th>
-                                    <th style="min-width:140px;">Closing Balance</th>
-                                    <th style="min-width:120px;">Running LTV</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                ${loan.detailed_tranche_schedule.map((row, index) => {
-                                    const closing = Number(String(row.closing_balance).replace(/[^0-9.-]/g,'')) || 0;
-                                    const propertyVal = Number(loan.propertyValue || 0);
-                                    const runningLtv = propertyVal ? ((closing / propertyVal) * 100).toFixed(2) + '%' : '';
-                                    return `
-                                    <tr>
-                                        <td>${row.period || index + 1}</td>
-                                        <td>${row.start_period || ''}</td>
-                                        <td>${row.end_period || ''}</td>
-                                        <td>${row.days_held ?? ''}</td>
-                                        <td class="text-end">${formatMoney(row.opening_balance)}</td>
-                                        <td>${row.interest_calculation || ''}</td>
-                                        <td class="text-end">${formatMoney(row.tranche_release)}</td>
-                                        <td class="text-end text-danger">${formatMoney(row.interest)}</td>
-                                        <td class="text-end text-primary">${formatMoney(row.principal)}</td>
-                                        <td class="text-end fw-bold text-success">${formatMoney(row.total_payment)}</td>
-                                        <td class="text-end">${formatMoney(row.closing_balance)}</td>
-                                        <td class="text-end">${runningLtv}</td>
-                                    </tr>
-                                    `;
-                                }).join('')}
-                            </tbody>
-                        </table>
+                    <div class="d-flex flex-wrap gap-2" id="loanVisualizationButtons">
+                        <button class="btn btn-outline-primary" id="loanHistoryScheduleBtn" data-bs-toggle="modal" data-bs-target="#paymentScheduleModal">
+                            <i class="fas fa-calendar-alt me-1"></i>Detailed Payment Schedule
+                        </button>
+                        <button class="btn btn-outline-primary" id="loanHistoryTrancheBtn" data-bs-toggle="modal" data-bs-target="#trancheScheduleModal">
+                            <i class="fas fa-layer-group me-1"></i>Calculation Breakdown
+                        </button>
+                        <button class="btn btn-outline-primary" id="loanHistoryBreakdownBtn" data-bs-toggle="modal" data-bs-target="#loanBreakdownModal">
+                            <i class="fas fa-chart-pie me-1"></i>Loan Breakdown
+                        </button>
+                        <button class="btn btn-outline-primary" id="loanHistoryBalanceBtn" data-bs-toggle="modal" data-bs-target="#balanceModal">
+                            <i class="fas fa-chart-line me-1"></i>Balance Over Time
+                        </button>
                     </div>
                 </div>
             </div>
-            `
-                : `
-            <div class="card border-0 mt-4">
-                <div class="card-header bg-novellus-navy text-white">
-                    <h6 class="mb-0"><i class="fas fa-calendar-alt me-2"></i>Detailed Payment Schedule</h6>
-                </div>
-                <div class="card-body">
-                    <div class="table-responsive">
-                        <table class="table table-sm table-striped mb-0" style="font-size: 0.8rem;">
-                            <thead class="table-light sticky-top">
-                                <tr>
-                                    <th style="min-width: 80px;">Period</th>
-                                    <th style="min-width: 120px;">Payment Date</th>
-                                    <th style="min-width: 140px;">Opening Balance</th>
-                                    <th style="min-width: 140px;">Tranche Release</th>
-                                    <th style="min-width: 160px;">Interest Calculation</th>
-                                    <th style="min-width: 120px;">Interest</th>
-                                    <th style="min-width: 120px;">Principal</th>
-                                    <th style="min-width: 140px;">Total Payment</th>
-                                    <th style="min-width: 140px;">Closing Balance</th>
-                                    <th style="min-width: 140px;">Balance Change</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                ${loan.detailed_payment_schedule.map((payment, index) => `
-                                    <tr>
-                                        <td>${payment.period_number || index + 1}</td>
-                                        <td>${payment.payment_date}</td>
-                                        <td>${payment.opening_balance}</td>
-                                        <td>${payment.tranche_release}</td>
-                                        <td>${payment.interest_calculation}</td>
-                                        <td class="text-danger">${payment.interest_amount}</td>
-                                        <td class="text-primary">${payment.principal_payment}</td>
-                                        <td class="fw-bold text-success">${payment.total_payment}</td>
-                                        <td>${payment.closing_balance}</td>
-                                        <td><small class="text-muted">${payment.balance_change}</small></td>
-                                    </tr>
-                                `).join('')}
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
-            `
-            }
 
             <div class="card border-0 mt-4" id="loanNotesCard">
                 <div class="card-header bg-novellus-navy text-white d-flex justify-content-between align-items-center">
@@ -851,17 +899,699 @@ class LoanHistoryManager {
                 </div>
             </div>
 
-            <div class="card border-0 mt-4">
-                <div class="card-header bg-novellus-navy text-white">
-                    <h6 class="mb-0"><i class="fas fa-chart-pie me-2"></i>Loan Breakdown</h6>
-                </div>
-                <div class="card-body">
-                    <canvas id="loanBreakdownChart" style="height:400px;"></canvas>
-                </div>
-            </div>
         `;
         this.setupLoanNotesSection(loan);
+        this.populateDetailedPaymentSchedule(loan);
+        this.populateTrancheSchedule(loan);
         this.createLoanBreakdownChart(loan);
+        this.createBalanceOverTimeChart(loan);
+        this.setupVisualizationButtons(loan);
+    }
+
+    getCurrencySymbol(currency) {
+        if (!currency) {
+            return '£';
+        }
+        const code = String(currency).trim().toUpperCase();
+        switch (code) {
+            case 'EUR':
+            case '€':
+                return '€';
+            case 'USD':
+            case 'US$':
+            case '$':
+                return '$';
+            case 'GBP':
+            case '£':
+            default:
+                return '£';
+        }
+    }
+
+    populateDetailedPaymentSchedule(loan) {
+        const container = document.getElementById('detailedPaymentScheduleCard');
+        const scheduleBody = document.getElementById('detailedPaymentScheduleBody');
+        const exportBtn = document.getElementById('exportPaymentScheduleBtn');
+
+        if (!container || !scheduleBody) {
+            this.scheduleVisible = false;
+            return;
+        }
+
+        const schedule = Array.isArray(loan.detailed_payment_schedule) ? loan.detailed_payment_schedule : [];
+        const loanType = (loan.loan_type || '').toLowerCase();
+        const repaymentOption = loan.repaymentOption || loan.repayment_option || '';
+        const hideSchedule = loanType === 'development' || ((loanType === 'term' || loanType === 'bridge') && repaymentOption === 'none');
+
+        if (hideSchedule || schedule.length === 0) {
+            container.style.display = 'none';
+            if (exportBtn) { exportBtn.style.display = 'none'; }
+            this.scheduleVisible = false;
+            return;
+        }
+
+        container.style.display = 'block';
+        if (exportBtn) { exportBtn.style.display = 'none'; }
+        scheduleBody.innerHTML = '';
+
+        const headerRow = container.querySelector('thead tr');
+        if (headerRow && !this.defaultScheduleHeader) {
+            this.defaultScheduleHeader = headerRow.innerHTML;
+        }
+
+        const currentSymbol = this.getCurrencySymbol(loan.currency_symbol || loan.currency || 'GBP');
+
+        const parseNumber = (value) => {
+            if (typeof value === 'number') {
+                return value;
+            }
+            if (typeof value === 'string') {
+                const cleaned = value.replace(/[^0-9.-]/g, '');
+                const parsed = parseFloat(cleaned);
+                return Number.isFinite(parsed) ? parsed : 0;
+            }
+            return 0;
+        };
+
+        const formatCurrency = (value) => {
+            if (value === null || value === undefined) {
+                return `${currentSymbol}0.00`;
+            }
+            if (typeof value === 'number') {
+                return `${currentSymbol}${value.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+            }
+            const stringValue = String(value).trim();
+            if (stringValue === '' || stringValue === '—') {
+                return stringValue || `${currentSymbol}0.00`;
+            }
+            return stringValue.replace(/[£€$]/g, currentSymbol);
+        };
+
+        const formatText = (value) => {
+            if (value === null || value === undefined) {
+                return '';
+            }
+            return String(value).replace(/[£€$]/g, currentSymbol);
+        };
+
+        const headers = {
+            servicedOnly: `
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Start of Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">End of Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Days Held</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Opening Balance</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Calculation</th>
+                <th class="px-2 text-center" style="color: #000; font-weight: bold; font-size: 0.875rem;">Interest Serviced</th>
+            `,
+            servicedCapital: `
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Start of Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">End of Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Days Held</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Capital Outstanding</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Annual Interest %</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Factor P.D.</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Scheduled Repayment</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Total Repayment</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Accrued</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Retained</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Refund</th>
+                <th class="px-2 text-center" style="color: #000; font-weight: bold; font-size: 0.875rem;">Running LTV</th>
+            `,
+            flexible: `
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Start of Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">End of Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Days Held</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Capital Outstanding</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Annual Interest %</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Factor P.D.</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Total Repayment</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Capital Repayment</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Accrued</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Retained</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Refund</th>
+                <th class="px-2 text-center" style="color: #000; font-weight: bold; font-size: 0.875rem;">Running LTV</th>
+            `,
+            capitalOnly: `
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Start of Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">End of Period</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Days Held</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Capital Outstanding</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Annual Interest %</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Factor P.D.</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Scheduled Repayment</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Accrued</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Retained</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Refund</th>
+                <th class="px-2 text-center" style="color: #000; font-weight: bold; font-size: 0.875rem;">Running LTV</th>
+            `,
+            default: `
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Payment Date</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Opening Balance</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Tranche Release</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Calculation</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Interest Saving</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Principal</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Total Payment</th>
+                <th class="px-2 text-center" style="border-right: 1px solid #000; color: #000; font-weight: bold; font-size: 0.875rem;">Closing Balance</th>
+                <th class="px-2 text-center" style="color: #000; font-weight: bold; font-size: 0.875rem;">Balance Change</th>
+            `
+        };
+
+        const setHeader = (key) => {
+            if (headerRow && headers[key]) {
+                headerRow.innerHTML = headers[key];
+            }
+        };
+
+        if (repaymentOption === 'service_only') {
+            setHeader('servicedOnly');
+            let totalInterest = 0;
+            let totalDays = 0;
+
+            schedule.forEach((row, index) => {
+                const tr = document.createElement('tr');
+                tr.style.border = '1px solid #000';
+                tr.style.background = index % 2 === 0 ? '#f8f9fa' : 'white';
+
+                const startPeriod = row.start_period || '';
+                const endPeriod = row.end_period || '';
+                const daysHeld = row.days_held ?? '';
+                const openingBalance = formatCurrency(row.opening_balance);
+                const interestCalculation = formatText(row.interest_calculation);
+                const interestAmount = formatCurrency(row.interest_amount);
+
+                totalInterest += parseNumber(row.interest_amount);
+                totalDays += parseNumber(daysHeld);
+
+                tr.innerHTML = `
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${startPeriod}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${endPeriod}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${daysHeld}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${openingBalance}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${interestCalculation}</td>
+                    <td class="py-1 px-2 text-end" style="color: #000; font-size: 0.875rem;">${interestAmount}</td>
+                `;
+
+                scheduleBody.appendChild(tr);
+            });
+
+            const totalRow = document.createElement('tr');
+            totalRow.style.border = '1px solid #000';
+            totalRow.style.background = '#f8f9fa';
+            totalRow.innerHTML = `
+                <td colspan="2" class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size:0.875rem;">Total</td>
+                <td class="py-1 px-2 text-center fw-bold" style="border-right: 1px solid #000; color: #000; font-size:0.875rem;">${totalDays}</td>
+                <td class="py-1 px-2" style="border-right: 1px solid #000;"></td>
+                <td class="py-1 px-2" style="border-right: 1px solid #000;"></td>
+                <td class="py-1 px-2 text-end fw-bold" style="color: #000; font-size: 0.875rem;">${currentSymbol}${totalInterest.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+            `;
+            scheduleBody.appendChild(totalRow);
+
+            this.scheduleVisible = true;
+            return;
+        }
+
+        if (repaymentOption === 'service_and_capital') {
+            setHeader('servicedCapital');
+            let totalScheduled = 0;
+            let totalRepayment = 0;
+            let totalAccrued = 0;
+            let totalRetained = 0;
+            let totalRefund = 0;
+            let totalDays = 0;
+
+            schedule.forEach((row, index) => {
+                const tr = document.createElement('tr');
+                tr.style.border = '1px solid #000';
+                tr.style.background = index % 2 === 0 ? '#f8f9fa' : 'white';
+
+                const capitalOutstanding = row.capital_outstanding !== undefined ? formatCurrency(row.capital_outstanding) : '';
+                const scheduledRepayment = formatCurrency(row.scheduled_repayment);
+                const totalRepaymentValue = formatCurrency(row.total_repayment);
+                const interestAccrued = formatCurrency(row.interest_accrued);
+                const interestRetained = formatCurrency(row.interest_retained);
+                const interestRefund = formatCurrency(row.interest_refund);
+
+                totalScheduled += parseNumber(row.scheduled_repayment);
+                totalRepayment += parseNumber(row.total_repayment);
+                totalAccrued += parseNumber(row.interest_accrued);
+                totalRetained += parseNumber(row.interest_retained);
+                totalRefund += parseNumber(row.interest_refund);
+                totalDays += parseNumber(row.days_held);
+
+                tr.innerHTML = `
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${index + 1}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.start_period || ''}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.end_period || ''}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.days_held ?? ''}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${capitalOutstanding}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.annual_interest_rate ?? ''}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.interest_pa ?? ''}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${scheduledRepayment}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${totalRepaymentValue}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${interestAccrued}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${interestRetained}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${interestRefund}</td>
+                    <td class="py-1 px-2 text-center" style="color: #000; font-size: 0.875rem;">${row.running_ltv ?? ''}</td>
+                `;
+
+                scheduleBody.appendChild(tr);
+            });
+
+            const totalRow = document.createElement('tr');
+            totalRow.style.border = '1px solid #000';
+            totalRow.style.background = '#f8f9fa';
+            totalRow.innerHTML = `
+                <td colspan="3" class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size:0.875rem;">Total</td>
+                <td class="py-1 px-2 text-center fw-bold" style="border-right: 1px solid #000; color: #000; font-size:0.875rem;">${totalDays}</td>
+                <td colspan="3" class="py-1 px-2" style="border-right: 1px solid #000;"></td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalScheduled.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalRepayment.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalAccrued.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalRetained.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalRefund.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2"></td>
+            `;
+            scheduleBody.appendChild(totalRow);
+
+            this.scheduleVisible = true;
+            return;
+        }
+
+        if (repaymentOption === 'flexible_payment') {
+            setHeader('flexible');
+            let totalRepayment = 0;
+            let totalCapital = 0;
+            let totalAccrued = 0;
+            let totalRetained = 0;
+            let totalRefund = 0;
+            let totalDays = 0;
+
+            schedule.forEach((row, index) => {
+                const tr = document.createElement('tr');
+                tr.style.border = '1px solid #000';
+                tr.style.background = index % 2 === 0 ? '#f8f9fa' : 'white';
+
+                const capitalOutstanding = row.capital_outstanding !== undefined ? formatCurrency(row.capital_outstanding) : '';
+                const totalRepaymentVal = formatCurrency(row.total_repayment);
+                const capitalRepayment = formatCurrency(row.capital_repayment);
+                const interestAccrued = formatCurrency(row.interest_accrued);
+                const interestRetained = formatCurrency(row.interest_retained);
+                const interestRefund = formatCurrency(row.interest_refund);
+
+                totalRepayment += parseNumber(row.total_repayment);
+                totalCapital += parseNumber(row.capital_repayment);
+                totalAccrued += parseNumber(row.interest_accrued);
+                totalRetained += parseNumber(row.interest_retained);
+                totalRefund += parseNumber(row.interest_refund);
+                totalDays += parseNumber(row.days_held);
+
+                tr.innerHTML = `
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${index + 1}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.start_period || ''}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.end_period || ''}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.days_held ?? ''}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${capitalOutstanding}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.annual_interest_rate ?? ''}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.interest_pa ?? ''}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${totalRepaymentVal}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${capitalRepayment}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${interestAccrued}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${interestRetained}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${interestRefund}</td>
+                    <td class="py-1 px-2 text-center" style="color: #000; font-size: 0.875rem;">${row.running_ltv ?? ''}</td>
+                `;
+
+                scheduleBody.appendChild(tr);
+            });
+
+            const totalRow = document.createElement('tr');
+            totalRow.style.border = '1px solid #000';
+            totalRow.style.background = '#f8f9fa';
+            totalRow.innerHTML = `
+                <td colspan="3" class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size:0.875rem;">Total</td>
+                <td class="py-1 px-2 text-center fw-bold" style="border-right: 1px solid #000; color: #000; font-size:0.875rem;">${totalDays}</td>
+                <td colspan="3" class="py-1 px-2" style="border-right: 1px solid #000;"></td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalRepayment.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalCapital.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalAccrued.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalRetained.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalRefund.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2"></td>
+            `;
+            scheduleBody.appendChild(totalRow);
+
+            this.scheduleVisible = true;
+            return;
+        }
+
+        if (repaymentOption === 'capital_payment_only') {
+            setHeader('capitalOnly');
+            let totalScheduled = 0;
+            let totalAccrued = 0;
+            let totalRetained = 0;
+            let totalRefund = 0;
+            let totalDays = 0;
+
+            schedule.forEach((row, index) => {
+                const tr = document.createElement('tr');
+                tr.style.border = '1px solid #000';
+                tr.style.background = index % 2 === 0 ? '#f8f9fa' : 'white';
+
+                const capitalOutstanding = row.capital_outstanding !== undefined ? formatCurrency(row.capital_outstanding) : '';
+                const scheduledRepayment = formatCurrency(row.scheduled_repayment);
+                const interestAccrued = formatCurrency(row.interest_accrued);
+                const interestRetained = formatCurrency(row.interest_retained);
+                const interestRefund = formatCurrency(row.interest_refund);
+
+                totalScheduled += parseNumber(row.scheduled_repayment);
+                totalAccrued += parseNumber(row.interest_accrued);
+                totalRetained += parseNumber(row.interest_retained);
+                totalRefund += parseNumber(row.interest_refund);
+                totalDays += parseNumber(row.days_held);
+
+                tr.innerHTML = `
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${index + 1}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.start_period || ''}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.end_period || ''}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.days_held ?? ''}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${capitalOutstanding}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.annual_interest_rate ?? ''}</td>
+                    <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.interest_pa ?? ''}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${scheduledRepayment}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${interestAccrued}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${interestRetained}</td>
+                    <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${interestRefund}</td>
+                    <td class="py-1 px-2 text-center" style="color: #000; font-size: 0.875rem;">${row.running_ltv ?? ''}</td>
+                `;
+
+                scheduleBody.appendChild(tr);
+            });
+
+            const totalRow = document.createElement('tr');
+            totalRow.style.border = '1px solid #000';
+            totalRow.style.background = '#f8f9fa';
+            totalRow.innerHTML = `
+                <td colspan="3" class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size:0.875rem;">Total</td>
+                <td class="py-1 px-2 text-center fw-bold" style="border-right: 1px solid #000; color: #000; font-size:0.875rem;">${totalDays}</td>
+                <td colspan="3" class="py-1 px-2" style="border-right: 1px solid #000;"></td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalScheduled.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalAccrued.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalRetained.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2 text-end fw-bold" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${currentSymbol}${totalRefund.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</td>
+                <td class="py-1 px-2"></td>
+            `;
+            scheduleBody.appendChild(totalRow);
+
+            this.scheduleVisible = true;
+            return;
+        }
+
+        setHeader('default');
+
+        schedule.forEach((row, index) => {
+            const tr = document.createElement('tr');
+            tr.style.border = '1px solid #000';
+            tr.style.background = index % 2 === 0 ? '#f8f9fa' : 'white';
+
+            const fixedRow = {
+                payment_date: row.payment_date || row.start_period || '',
+                opening_balance: formatCurrency(row.opening_balance),
+                tranche_release: formatCurrency(row.tranche_release),
+                interest_calculation: formatText(row.interest_calculation),
+                interest_amount: formatCurrency(row.interest_amount),
+                interest_saving: formatCurrency(row.interest_saving || row.interest_refund || ''),
+                principal_payment: formatCurrency(row.principal_payment),
+                total_payment: formatCurrency(row.total_payment),
+                closing_balance: formatCurrency(row.closing_balance),
+                balance_change: row.balance_change || ''
+            };
+
+            tr.innerHTML = `
+                <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.payment_date}</td>
+                <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.opening_balance}</td>
+                <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.tranche_release}</td>
+                <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.interest_calculation}</td>
+                <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.interest_amount}</td>
+                <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.interest_saving}</td>
+                <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.principal_payment}</td>
+                <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.total_payment}</td>
+                <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${fixedRow.closing_balance}</td>
+                <td class="py-1 px-2 text-center" style="color: #000; font-size: 0.875rem;">${fixedRow.balance_change}</td>
+            `;
+
+            scheduleBody.appendChild(tr);
+        });
+
+        this.scheduleVisible = true;
+    }
+
+    populateTrancheSchedule(loan) {
+        const body = document.getElementById('trancheScheduleBody');
+        const exportBtn = document.getElementById('exportTrancheScheduleBtn');
+        if (!body) {
+            this.trancheVisible = false;
+            return;
+        }
+
+        body.innerHTML = '';
+        if (exportBtn) { exportBtn.style.display = 'none'; }
+
+        const schedule = Array.isArray(loan.detailed_tranche_schedule) ? loan.detailed_tranche_schedule : [];
+        if (!schedule.length) {
+            this.trancheVisible = false;
+            return;
+        }
+
+        const currencySymbol = this.getCurrencySymbol(loan.currency_symbol || loan.currency || 'GBP');
+        const formatCurrency = (value) => {
+            if (value === null || value === undefined) {
+                return `${currencySymbol}0.00`;
+            }
+            if (typeof value === 'number') {
+                return `${currencySymbol}${value.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+            }
+            const stringValue = String(value).trim();
+            if (stringValue === '' || stringValue === '—') {
+                return stringValue || `${currencySymbol}0.00`;
+            }
+            return stringValue.replace(/[£€$]/g, currencySymbol);
+        };
+        const parseNumber = (value) => {
+            if (typeof value === 'number') { return value; }
+            if (typeof value === 'string') {
+                const parsed = parseFloat(value.replace(/[^0-9.-]/g, ''));
+                return Number.isFinite(parsed) ? parsed : 0;
+            }
+            return 0;
+        };
+
+        const propertyValue = Number(loan.propertyValue || loan.property_value || 0);
+
+        schedule.forEach((row, index) => {
+            const tr = document.createElement('tr');
+            tr.style.border = '1px solid #000';
+            tr.style.background = index % 2 === 0 ? '#f8f9fa' : 'white';
+
+            const closingBalanceNumeric = parseNumber(row.closing_balance);
+            const runningLtv = row.running_ltv || (propertyValue ? `${((closingBalanceNumeric / propertyValue) * 100).toFixed(2)}%` : '');
+
+            tr.innerHTML = `
+                <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.period || index + 1}</td>
+                <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.start_period || ''}</td>
+                <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.end_period || ''}</td>
+                <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.days_held ?? ''}</td>
+                <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${formatCurrency(row.opening_balance)}</td>
+                <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${formatCurrency(row.tranche_release)}</td>
+                <td class="py-1 px-2 text-center" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${row.interest_calculation || ''}</td>
+                <td class="py-1 px-2 text-end text-danger" style="border-right: 1px solid #000; font-size: 0.875rem;">${formatCurrency(row.interest ?? row.interest_amount)}</td>
+                <td class="py-1 px-2 text-end text-primary" style="border-right: 1px solid #000; font-size: 0.875rem;">${formatCurrency(row.principal ?? row.principal_payment)}</td>
+                <td class="py-1 px-2 text-end fw-bold text-success" style="border-right: 1px solid #000; font-size: 0.875rem;">${formatCurrency(row.total_payment ?? row.total_repayment)}</td>
+                <td class="py-1 px-2 text-end" style="border-right: 1px solid #000; color: #000; font-size: 0.875rem;">${formatCurrency(row.closing_balance)}</td>
+                <td class="py-1 px-2 text-center" style="color: #000; font-size: 0.875rem;">${runningLtv}</td>
+            `;
+
+            body.appendChild(tr);
+        });
+
+        this.trancheVisible = true;
+    }
+
+    createBalanceOverTimeChart(loan) {
+        const ctx = document.getElementById('balanceOverTimeChart');
+        if (!ctx) {
+            this.balanceChartAvailable = false;
+            return;
+        }
+
+        if (this.balanceOverTimeChart) {
+            try { this.balanceOverTimeChart.destroy(); } catch (e) {}
+            this.balanceOverTimeChart = null;
+        }
+
+        const schedule = Array.isArray(loan.detailed_payment_schedule) ? loan.detailed_payment_schedule : [];
+        const loanType = (loan.loan_type || '').toLowerCase();
+        const repaymentOption = loan.repaymentOption || loan.repayment_option || '';
+        const hideAll = loanType === 'bridge' && repaymentOption === 'none';
+        const isServicedOnly = repaymentOption === 'service_only';
+
+        if (!schedule.length || hideAll || isServicedOnly) {
+            this.balanceChartAvailable = false;
+            return;
+        }
+
+        const parseValue = (val) => {
+            if (typeof val === 'number') {
+                return val;
+            }
+            if (typeof val === 'string') {
+                const parsed = parseFloat(val.replace(/[^0-9.-]/g, ''));
+                return Number.isFinite(parsed) ? parsed : 0;
+            }
+            return 0;
+        };
+
+        const labels = schedule.map((_, index) => index + 1);
+        const balanceData = schedule.map(entry => {
+            if (entry.closing_balance !== undefined && entry.closing_balance !== null && entry.closing_balance !== '') {
+                return parseValue(entry.closing_balance);
+            }
+            if (entry.capital_outstanding !== undefined) {
+                return parseValue(entry.capital_outstanding);
+            }
+            return 0;
+        });
+
+        let cumulativeAccrued = 0;
+        const interestAccruedData = schedule.map(entry => {
+            const raw = entry.interest_accrued_raw ?? entry.interest_accrued ?? entry.interest_amount ?? entry.interest;
+            const value = parseValue(raw);
+            cumulativeAccrued += value;
+            return cumulativeAccrued;
+        });
+
+        const currencySymbol = this.getCurrencySymbol(loan.currency_symbol || loan.currency || 'GBP');
+
+        const data = {
+            labels,
+            datasets: [
+                {
+                    label: 'Remaining Balance',
+                    data: balanceData,
+                    type: 'bar',
+                    backgroundColor: 'rgba(184, 134, 11, 0.6)',
+                    borderColor: 'rgba(184, 134, 11, 1)',
+                    borderWidth: 1,
+                    yAxisID: 'y'
+                },
+                {
+                    label: 'Interest Accrued',
+                    data: interestAccruedData,
+                    type: 'line',
+                    borderColor: 'rgba(70, 130, 180, 1)',
+                    backgroundColor: 'rgba(70, 130, 180, 0.1)',
+                    borderWidth: 2,
+                    fill: false,
+                    tension: 0.1,
+                    pointRadius: 3,
+                    pointHoverRadius: 6,
+                    pointBackgroundColor: 'rgba(70, 130, 180, 1)',
+                    pointBorderColor: '#fff',
+                    pointBorderWidth: 2,
+                    yAxisID: 'y1'
+                }
+            ]
+        };
+
+        const chartConfig = {
+            type: 'bar',
+            data,
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                animation: { duration: 0 },
+                scales: {
+                    x: {
+                        title: { display: true, text: 'Payment Period' }
+                    },
+                    y: {
+                        title: { display: true, text: `Balance (${currencySymbol})` },
+                        beginAtZero: true
+                    },
+                    y1: {
+                        title: { display: true, text: `Interest (${currencySymbol})` },
+                        position: 'right',
+                        beginAtZero: true,
+                        grid: { drawOnChartArea: false }
+                    }
+                },
+                plugins: {
+                    title: {
+                        display: true,
+                        text: 'Loan Balance & Interest Over Time',
+                        font: { size: 14, weight: 'bold' }
+                    },
+                    tooltip: {
+                        callbacks: {
+                            label: function(context) {
+                                return `${context.dataset.label}: ${currencySymbol}${context.parsed.y.toLocaleString('en-GB')}`;
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        this.balanceOverTimeChart = new Chart(ctx, chartConfig);
+        this.balanceChartAvailable = true;
+    }
+
+    setupVisualizationButtons(loan) {
+        const scheduleBtn = document.getElementById('loanHistoryScheduleBtn');
+        const trancheBtn = document.getElementById('loanHistoryTrancheBtn');
+        const breakdownBtn = document.getElementById('loanHistoryBreakdownBtn');
+        const balanceBtn = document.getElementById('loanHistoryBalanceBtn');
+
+        const loanType = (loan.loan_type || '').toLowerCase();
+        const repaymentOption = loan.repaymentOption || loan.repayment_option || '';
+        const hideAll = loanType === 'bridge' && repaymentOption === 'none';
+        const isServicedOnly = repaymentOption === 'service_only';
+
+        if (scheduleBtn) {
+            scheduleBtn.style.display = (!hideAll && this.scheduleVisible) ? 'inline-flex' : 'none';
+        }
+        if (trancheBtn) {
+            trancheBtn.style.display = this.trancheVisible ? 'inline-flex' : 'none';
+        }
+        if (breakdownBtn) {
+            breakdownBtn.style.display = 'inline-flex';
+        }
+        if (balanceBtn) {
+            balanceBtn.style.display = (!hideAll && !isServicedOnly && this.balanceChartAvailable) ? 'inline-flex' : 'none';
+        }
+    }
+
+    setupModalChartHandlers() {
+        const mappings = [
+            { modalId: 'loanBreakdownModal', chartGetter: () => this.loanBreakdownChart },
+            { modalId: 'balanceModal', chartGetter: () => this.balanceOverTimeChart }
+        ];
+
+        mappings.forEach(({ modalId, chartGetter }) => {
+            const modalEl = document.getElementById(modalId);
+            if (modalEl) {
+                modalEl.addEventListener('shown.bs.modal', () => {
+                    const chart = chartGetter();
+                    if (chart) {
+                        chart.resize();
+                    }
+                });
+            }
+        });
     }
 
 
@@ -871,9 +1601,10 @@ class LoanHistoryManager {
 
         if (this.loanBreakdownChart) {
             try { this.loanBreakdownChart.destroy(); } catch (e) {}
+            this.loanBreakdownChart = null;
         }
 
-        const currency = loan.currency_symbol || (loan.currency === 'EUR' ? '€' : '£');
+        const currency = this.getCurrencySymbol(loan.currency_symbol || loan.currency || 'GBP');
         const data = {
             labels: ['Total Net Advance', 'Arrangement Fee', 'Legal Costs', 'Site Visit Fee', 'Title Insurance', 'Total Interest'],
             datasets: [{


### PR DESCRIPTION
## Summary
- Parse stored payment schedule JSON in the loan details API so the history view has the same data that powers the calculator schedule.
- Rebuild the loan history details modal to reuse the calculator's visualisation modals, styling, and schedule formatting, including buttons for schedule, tranche breakdown, loan breakdown, and balance charts.
- Add JavaScript helpers that populate the calculator-format schedule, tranche table, and Chart.js visuals within the loan history modal while respecting the currency theme.

## Testing
- pytest test_payment_schedule_consistency.py

------
https://chatgpt.com/codex/tasks/task_e_68de42b05d70832081cd689c8469fdc7