### PR TITLE
Adjust loan history header layout for large screens

### DIFF
--- a/templates/loan_history_detail.html
+++ b/templates/loan_history_detail.html
@@ -173,9 +173,9 @@
 
 {% block content %}
 <div class="mb-4">
-    <div class="row g-3 align-items-center">
+    <div class="row g-3 align-items-center flex-lg-row-reverse">
         <div class="col-lg-7 col-md-12">
-            <div class="d-flex flex-column flex-lg-row align-items-lg-center align-items-start gap-3">
+            <div class="d-flex flex-column flex-lg-row align-items-lg-center align-items-start justify-content-lg-end gap-3">
                 <div>
                     <a href="{{ url_for('loan_history') }}" class="btn btn-outline-light"><i class="fas fa-arrow-left me-2"></i>Back to Loan History</a>
                 </div>
@@ -192,7 +192,7 @@
                 </div>
             </div>
         </div>
-        <div class="col-lg-5 col-md-12 text-lg-end">
+        <div class="col-lg-5 col-md-12 text-lg-start">
             <h2 class="page-title mb-1">Loan: <span id="loanNameDisplay">{{ loan_name or 'Loading...' }}</span></h2>
             <div class="subtitle">
                 <span class="info-chip"><i class="fas fa-id-badge"></i>ID: {{ loan_id }}</span>


### PR DESCRIPTION
## Summary
- reverse the header row layout on large screens so the loan summary stays on the left
- align the action buttons container to the right on wide viewports while keeping the mobile stack intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de603148e08320960406ad85bc5302