### PR TITLE
Adjust loan history detail layout width

### DIFF
--- a/templates/loan_history_detail.html
+++ b/templates/loan_history_detail.html
@@ -31,11 +31,12 @@
         </div>
     </div>
 
-        <div class="col-12 col-xl-8">
-            <div class="row row-cols-1 row-cols-lg-2 g-4">
-                <div class="col">
-                    <div class="card border-0 shadow-sm h-100">
-                        <div class="card-header bg-light fw-bold"><i class="fas fa-list me-2"></i>Loan Parameters</div>
+        <div class="row justify-content-center">
+            <div class="col-12 col-lg-10 col-xl-8 col-xxl-7">
+                <div class="row row-cols-1 row-cols-lg-2 g-4">
+                    <div class="col">
+                        <div class="card border-0 shadow-sm h-100">
+                            <div class="card-header bg-light fw-bold"><i class="fas fa-list me-2"></i>Loan Parameters</div>
                         <div class="card-body p-0">
                             <table class="table mb-0">
                                 <tbody>


### PR DESCRIPTION
## Summary
- center the loan detail summary cards inside a narrower column to reduce the section width

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68de7e9a700c83209c0ac3c88a186a38