### PR TITLE
Improve landing page contrast and button visibility

### DIFF
--- a/static/css/novellus-theme.css
+++ b/static/css/novellus-theme.css
@@ -360,9 +360,26 @@
     color: white;
 }
 
-.btn-outline-secondary {
-    border-color: var(--novellus-navy);
+.btn-outline-primary {
+    border: 2px solid var(--novellus-gold);
     color: var(--novellus-navy);
+    background-color: #fff;
+    font-weight: 600;
+}
+
+.btn-outline-primary:hover,
+.btn-outline-primary:focus {
+    background-color: var(--novellus-gold);
+    border-color: var(--novellus-gold);
+    color: #fff;
+    box-shadow: 0 4px 12px rgba(173, 150, 95, 0.35);
+}
+
+.btn-outline-secondary {
+    border: 2px solid var(--novellus-navy);
+    color: var(--novellus-navy);
+    background-color: #fff;
+    font-weight: 600;
 }
 
 .btn-outline-secondary:hover,
@@ -370,7 +387,7 @@
     background-color: var(--novellus-navy);
     border-color: var(--novellus-navy);
     color: white;
-    box-shadow: none;
+    box-shadow: 0 4px 12px rgba(30, 43, 58, 0.3);
 }
 
 /* Alert styling */
@@ -507,9 +524,26 @@ button[type="submit"] {
     color: white;
 }
 
-.btn-outline-secondary {
-    border-color: var(--novellus-navy-lighter);
+.btn-outline-primary {
+    border: 2px solid var(--novellus-gold);
     color: var(--novellus-navy);
+    background-color: #fff;
+    font-weight: 600;
+}
+
+.btn-outline-primary:hover,
+.btn-outline-primary:focus {
+    background-color: var(--novellus-gold);
+    border-color: var(--novellus-gold);
+    color: #fff;
+    box-shadow: 0 4px 12px rgba(173, 150, 95, 0.35);
+}
+
+.btn-outline-secondary {
+    border: 2px solid var(--novellus-navy);
+    color: var(--novellus-navy);
+    background-color: #fff;
+    font-weight: 600;
 }
 
 .btn-outline-secondary:hover,
@@ -517,7 +551,7 @@ button[type="submit"] {
     background-color: var(--novellus-navy);
     border-color: var(--novellus-navy);
     color: white;
-    box-shadow: none;
+    box-shadow: 0 4px 12px rgba(30, 43, 58, 0.3);
 }
 
 .btn-outline-secondary.active {
@@ -624,7 +658,7 @@ h4, h5, h6 {
 }
 
 .text-primary {
-    color: var(--novellus-gold) !important;
+    color: var(--novellus-gold-dark) !important;
 }
 
 /* User dropdown and badges */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -107,10 +107,16 @@ body {
 
 /* Buttons - Novellus Theme */
 .btn {
-    font-weight: 500;
+    font-weight: 600;
     border-radius: 0.375rem;
     transition: all 0.15s ease-in-out;
     font-family: var(--font-family);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.btn:hover,
+.btn:focus {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
 }
 
 .btn-primary {
@@ -141,11 +147,13 @@ body {
 }
 
 .btn-outline-primary {
-    color: var(--primary-color);
-    border-color: var(--primary-color);
+    color: var(--dark-color);
+    border: 2px solid var(--primary-color);
+    background-color: white;
 }
 
-.btn-outline-primary:hover {
+.btn-outline-primary:hover,
+.btn-outline-primary:focus {
     background-color: var(--primary-color);
     border-color: var(--primary-color);
     color: white;
@@ -153,18 +161,26 @@ body {
 
 .btn-check:focus + .btn-outline-primary,
 .btn-outline-primary:focus {
-    box-shadow: 0 0 0 0.25rem var(--primary-color) !important;
+    box-shadow: 0 0 0 0.25rem rgba(173, 150, 95, 0.35) !important;
+    outline: none;
+}
+
+.btn-check:focus + .btn-outline-secondary,
+.btn-outline-secondary:focus {
+    box-shadow: 0 0 0 0.25rem rgba(30, 43, 58, 0.35) !important;
     outline: none;
 }
 
 .btn-outline-secondary {
-    color: var(--secondary-color);
-    border-color: var(--secondary-color);
+    color: var(--dark-color);
+    border: 2px solid var(--dark-color);
+    background-color: white;
 }
 
-.btn-outline-secondary:hover {
-    background-color: var(--secondary-color);
-    border-color: var(--secondary-color);
+.btn-outline-secondary:hover,
+.btn-outline-secondary:focus {
+    background-color: var(--dark-color);
+    border-color: var(--dark-color);
     color: white;
 }
 

--- a/templates/landing.html
+++ b/templates/landing.html
@@ -23,12 +23,14 @@
             right: 0;
             bottom: 0;
             z-index: 1;
+            background: linear-gradient(135deg, rgba(30, 43, 58, 0.75), rgba(30, 43, 58, 0.35));
         }
         .hero-content {
             position: relative;
             z-index: 2;
-            color: white;
+            color: #fff;
             text-align: center;
+            text-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
         }
         .logo-container {
             margin-bottom: 2rem;
@@ -42,15 +44,15 @@
             font-size: 3.5rem;
             font-weight: 700;
             margin-bottom: 1rem;
-            text-shadow: 2px 2px 4px rgba(51,51,51,0.5);
-            color: rgb(51,51,51);
+            color: #ffffff;
+            text-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
         }
         .hero-subtitle {
             font-size: 1.5rem;
             margin-bottom: 3rem;
-            text-shadow: 1px 1px 2px rgba(51,51,51,0.5);
-            color: rgb(51,51,51);
+            color: rgba(255, 255, 255, 0.92);
             font-weight: 300;
+            text-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
         }
         .navigation-cards {
             display: grid;
@@ -98,22 +100,25 @@
             line-height: 1.6;
         }
         .nav-card-button {
-            background-color: #AD965F;
+            background: linear-gradient(135deg, #AD965F 0%, #8B6914 100%);
             color: white;
             border: none;
             padding: 12px 30px;
             border-radius: 25px;
-            font-weight: 600;
+            font-weight: 700;
             text-decoration: none;
             display: inline-block;
             transition: all 0.3s ease;
             margin-top: auto;
+            box-shadow: 0 12px 24px rgba(173, 150, 95, 0.4);
         }
-        .nav-card-button:hover {
-            background-color: #977c4d;
+        .nav-card-button:hover,
+        .nav-card-button:focus {
+            background: linear-gradient(135deg, #8B6914 0%, #5D4409 100%);
             color: white;
-            transform: scale(1.05);
+            transform: translateY(-2px);
             text-decoration: none;
+            box-shadow: 0 16px 30px rgba(93, 68, 9, 0.45);
         }
         .features-section {
             padding: 4rem 0;


### PR DESCRIPTION
## Summary
- enhance the shared button styles so outline actions have darker text, stronger borders, and visible focus states
- align the Novellus theme with the new button treatments and darken primary text for better readability across dashboards
- add a contrast overlay and stronger call-to-action styling to the landing hero so copy and buttons remain legible

## Testing
- python run_server.py

------
https://chatgpt.com/codex/tasks/task_e_68de7d1211c4832092712c5ca06ecde9