### PR TITLE
Reduce loan history detail layout width

### DIFF
--- a/templates/loan_history_detail.html
+++ b/templates/loan_history_detail.html
@@ -295,7 +295,7 @@
 </style>
 {% endblock %}
 
-{% block main_class %}container-fluid loan-detail-page py-4{% endblock %}
+{% block main_class %}container-xl loan-detail-page py-4 px-4{% endblock %}
 
 {% block content %}
 <div class="mb-4">


### PR DESCRIPTION
## Summary
- limit the loan history detail page to a narrower container so the content is not full-width on large screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de82772ac0832097fc760bfabcb46f