### PR TITLE
Remove gradient styling from loan history detail page

### DIFF
--- a/templates/loan_history_detail.html
+++ b/templates/loan_history_detail.html
@@ -49,6 +49,7 @@
 
     .loan-detail-card {
         background-color: rgba(15, 23, 42, 0.95);
+        background-image: none;
         border: 1px solid rgba(255, 255, 255, 0.05);
         border-radius: 16px;
         box-shadow: 0 18px 32px rgba(2, 8, 20, 0.55);
@@ -105,6 +106,7 @@
 
     .chart-card {
         background-color: rgba(14, 20, 34, 0.96);
+        background-image: none;
         border: 1px solid rgba(255, 255, 255, 0.05);
         border-radius: 18px;
         box-shadow: 0 22px 45px rgba(0, 0, 0, 0.5);
@@ -187,6 +189,46 @@
 
     .schedule-table tbody tr:hover {
         background: rgba(255,255,255,0.06);
+    }
+
+    .loan-detail-page .card,
+    .loan-detail-page .card-header,
+    .loan-detail-page .btn,
+    .loan-detail-page .loan-detail-loading,
+    .loan-detail-page .loan-detail-error,
+    .loan-detail-page .loan-highlight-badge,
+    .loan-detail-page .note-status-pill,
+    .loan-detail-page .info-chip,
+    .loan-detail-page .notes-form .form-select,
+    .loan-detail-page .notes-form .form-control,
+    body.gold-nav {
+        background-image: none !important;
+    }
+
+    .loan-detail-page .btn-primary {
+        background-color: #AD965F;
+        border-color: #AD965F;
+        color: #ffffff;
+    }
+
+    .loan-detail-page .btn-primary:hover,
+    .loan-detail-page .btn-primary:focus {
+        background-color: #9A7209;
+        border-color: #9A7209;
+        color: #ffffff;
+    }
+
+    .loan-detail-page .btn-novellus-gold {
+        background-color: #B8860B;
+        border-color: #B8860B;
+        color: #ffffff;
+    }
+
+    .loan-detail-page .btn-novellus-gold:hover,
+    .loan-detail-page .btn-novellus-gold:focus {
+        background-color: #9A7209;
+        border-color: #9A7209;
+        color: #ffffff;
     }
 
     .notes-card .card-body {


### PR DESCRIPTION
## Summary
- override loan history detail card and chart styles to eliminate gradient backgrounds
- update loan history detail buttons to use solid colours without gradient effects

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de82f6dcb48320942e39585e858ea4