### PR TITLE
Align loan notes styling with payment schedule

### DIFF
--- a/templates/loan_history_detail.html
+++ b/templates/loan_history_detail.html
@@ -163,20 +163,23 @@
         gap: 1.5rem;
     }
 
-    .schedule-card.loan-detail-card {
+    .schedule-card.loan-detail-card,
+    .notes-card.loan-detail-card {
         background: #ffffff;
         border: 1px solid #000;
         box-shadow: 0 18px 32px rgba(2, 8, 20, 0.35);
         color: #000;
     }
 
-    .schedule-card.loan-detail-card .card-header {
-        background: #1E2B3A;
-        color: #ffffff;
+    .schedule-card.loan-detail-card .card-header,
+    .notes-card.loan-detail-card .card-header {
+        background: #f1f5f9;
+        color: #000;
         border-bottom: 1px solid #000;
     }
 
-    .schedule-card .card-body {
+    .schedule-card .card-body,
+    .notes-card .card-body {
         padding: 1.25rem;
         background: #ffffff;
     }
@@ -271,15 +274,20 @@
     }
 
     .notes-card .card-body {
-        padding: 1.25rem;
         display: flex;
         flex-direction: column;
         gap: 1rem;
     }
 
+    .notes-card .loan-highlight-badge {
+        background: #e2e8f0;
+        border: 1px solid #cbd5f5;
+        color: #1e293b;
+    }
+
     .loan-note-item {
-        background: rgba(0,0,0,0.2);
-        border: 1px solid rgba(255,255,255,0.08);
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
         border-radius: 12px;
         padding: 0.85rem 1rem;
     }
@@ -291,11 +299,11 @@
         gap: 0.75rem;
         margin-bottom: 0.5rem;
         font-size: 0.8rem;
-        color: rgba(255,255,255,0.75);
+        color: #475569;
     }
 
     .loan-note-text {
-        color: rgba(255,255,255,0.9);
+        color: #0f172a;
         font-size: 0.9rem;
         line-height: 1.45;
         margin-bottom: 0;
@@ -313,34 +321,35 @@
         gap: 0.35rem;
     }
 
-    .note-status-general { background: rgba(255,255,255,0.08); color: #fff; }
-    .note-status-call { background: rgba(13,110,253,0.2); color: #69b0ff; }
-    .note-status-email { background: rgba(56,189,248,0.2); color: #8bdfff; }
-    .note-status-underwriting { background: rgba(148,163,184,0.25); color: #cbd5f5; }
-    .note-status-legal { background: rgba(220, 38, 38, 0.22); color: #feb2b2; }
-    .note-status-completed { background: rgba(34,197,94,0.22); color: #86efac; }
+    .note-status-general { background: #e2e8f0; color: #1e293b; }
+    .note-status-call { background: rgba(59,130,246,0.18); color: #1d4ed8; }
+    .note-status-email { background: rgba(14,165,233,0.18); color: #0c4a6e; }
+    .note-status-underwriting { background: rgba(148,163,184,0.25); color: #1f2937; }
+    .note-status-legal { background: rgba(248,113,113,0.2); color: #b91c1c; }
+    .note-status-completed { background: rgba(74,222,128,0.22); color: #047857; }
 
     .notes-empty-state {
         text-align: center;
         padding: 1.5rem 1rem;
-        color: rgba(255,255,255,0.65);
-        border: 1px dashed rgba(255,255,255,0.1);
+        color: #475569;
+        border: 1px dashed #cbd5f5;
         border-radius: 12px;
+        background: #f8fafc;
     }
 
     .notes-form .form-select,
     .notes-form .form-control {
-        background-color: rgba(8,12,24,0.7);
-        border: 1px solid rgba(255,255,255,0.15);
-        color: #fff;
+        background-color: #ffffff;
+        border: 1px solid #cbd5f5;
+        color: #0f172a;
     }
 
     .notes-form .form-select:focus,
     .notes-form .form-control:focus {
-        background-color: rgba(8,12,24,0.9);
-        border-color: var(--primary-color, #AD965F);
+        background-color: #ffffff;
+        border-color: var(--primary-color, #1E2B3A);
         box-shadow: none;
-        color: #fff;
+        color: #0f172a;
     }
 
     @media (max-width: 1199.98px) {


### PR DESCRIPTION
## Summary
- update the Detailed Payment Schedule and Loan Notes card headers to use a light background with dark text for better readability
- restyle the Loan Notes card elements so the card matches the payment schedule theme, including badges, note entries, status pills, empty state, and inputs

## Testing
- python run.py *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68de90ddc03483209c1d2dc55f0b542d