### PR TITLE
Improve loan detail info chip readability

### DIFF
--- a/templates/loan_history_detail.html
+++ b/templates/loan_history_detail.html
@@ -101,7 +101,7 @@
         font-size: 0.75rem;
         text-transform: uppercase;
         letter-spacing: 0.7px;
-        color: var(--surface-light, #f8f9fa);
+        color: #000000;
     }
 
     .chart-card {
@@ -146,15 +146,19 @@
     }
 
     .loan-detail-page .info-chip {
-        background: rgba(255, 255, 255, 0.08);
-        border: 1px solid rgba(255, 255, 255, 0.12);
+        background: rgba(255, 255, 255, 0.92);
+        border: 1px solid rgba(0, 0, 0, 0.08);
         border-radius: 50px;
         padding: 0.35rem 0.75rem;
         font-size: 0.8rem;
-        color: rgba(255,255,255,0.78);
+        color: #000;
         display: inline-flex;
         align-items: center;
         gap: 0.35rem;
+    }
+
+    .loan-detail-page .info-chip i {
+        color: inherit;
     }
 
     .chart-grid {


### PR DESCRIPTION
## Summary
- adjust the loan history detail info chip styling to use a light background with black text and icons for better contrast

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de96bf67548320922277de1ce7289d