### PR TITLE
Improve loan type badge visibility

### DIFF
--- a/templates/loan_history_detail.html
+++ b/templates/loan_history_detail.html
@@ -94,14 +94,15 @@
     }
 
     .loan-highlight-badge {
-        background: rgba(180, 155, 92, 0.18);
-        border: 1px solid rgba(180, 155, 92, 0.4);
+        background: rgba(245, 233, 200, 0.18);
+        border: 1px solid rgba(245, 233, 200, 0.45);
         border-radius: 30px;
         padding: 0.25rem 0.75rem;
         font-size: 0.75rem;
         text-transform: uppercase;
         letter-spacing: 0.7px;
-        color: #000000;
+        color: #fdf1cf;
+        font-weight: 700;
     }
 
     .chart-card {


### PR DESCRIPTION
## Summary
- lighten the loan type badge styling in the loan history detail view so it remains readable on the dark header
- increase the badge font weight to make the loan type stand out more

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de999cd4408320bb0381100bf04cb6