### PR TITLE
Update loan notes labels to use white text

### DIFF
--- a/templates/loan_history_detail.html
+++ b/templates/loan_history_detail.html
@@ -532,7 +532,7 @@
                     <form id="addLoanNoteForm" class="notes-form">
                         <div class="row g-2">
                             <div class="col-12">
-                                <label for="noteStatus" class="form-label small text-uppercase text-muted mb-1">Status</label>
+                                <label for="noteStatus" class="form-label small text-uppercase text-white mb-1">Status</label>
                                 <select id="noteStatus" class="form-select form-select-sm">
                                     <option value="General">General</option>
                                     <option value="Call">Call</option>
@@ -543,7 +543,7 @@
                                 </select>
                             </div>
                             <div class="col-12">
-                                <label for="noteText" class="form-label small text-uppercase text-muted mb-1">Add Note</label>
+                                <label for="noteText" class="form-label small text-uppercase text-white mb-1">Add Note</label>
                                 <textarea id="noteText" class="form-control" rows="3" placeholder="Capture loan updates, next actions or key observations..."></textarea>
                             </div>
                             <div class="col-12 text-end">


### PR DESCRIPTION
## Summary
- make the "Status" and "Add Note" labels on the loan history detail notes form render with white text for better contrast

## Testing
- python run.py *(fails: requires PostgreSQL database connection)*

------
https://chatgpt.com/codex/tasks/task_e_68de9a9da704832089c1b3fc1ba8274c