### PR TITLE
Add sort order management for loan notes

### DIFF
--- a/migrations/versions/3c4d5e6f8a9b_add_sort_order_to_loan_notes.py
+++ b/migrations/versions/3c4d5e6f8a9b_add_sort_order_to_loan_notes.py
@@ -1,0 +1,47 @@
+"""add sort order to loan notes
+
+Revision ID: 3c4d5e6f8a9b
+Revises: 2b3c4d5e6f7a
+Create Date: 2024-08-01 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '3c4d5e6f8a9b'
+down_revision = '2b3c4d5e6f7a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'loan_notes',
+        sa.Column('sort_order', sa.Integer(), nullable=True, server_default='0'),
+    )
+
+    op.execute(
+        sa.text(
+            """
+            UPDATE loan_notes AS ln
+            SET sort_order = ordered.row_number - 1
+            FROM (
+                SELECT id, ROW_NUMBER() OVER (PARTITION BY "group" ORDER BY id) AS row_number
+                FROM loan_notes
+            ) AS ordered
+            WHERE ln.id = ordered.id
+            """
+        )
+    )
+
+    op.alter_column(
+        'loan_notes',
+        'sort_order',
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+
+
+def downgrade():
+    op.drop_column('loan_notes', 'sort_order')

--- a/models.py
+++ b/models.py
@@ -475,6 +475,7 @@ class LoanNote(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     group = db.Column('group', db.String(100), nullable=False)
+    sort_order = db.Column(db.Integer, nullable=False, default=0)
     name = db.Column(db.Text, nullable=False)
     placeholder_map = db.Column(db.JSON, default=dict)
     add_flag = db.Column(db.Boolean, default=False)
@@ -483,6 +484,16 @@ class LoanNote(db.Model):
 
     def __repr__(self) -> str:
         return f'<LoanNote {self.group}: {self.name[:20]}>'
+
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'group': self.group,
+            'name': self.name,
+            'placeholder_map': self.placeholder_map or {},
+            'add_flag': self.add_flag,
+            'sort_order': self.sort_order,
+        }
 
 
 class LoanSummaryNote(db.Model):

--- a/templates/loan_notes.html
+++ b/templates/loan_notes.html
@@ -32,7 +32,7 @@
             </thead>
             <tbody>
                 {% for note in notes %}
-                <tr data-note-id="{{ note.id }}" style="border:1px solid #000;">
+                <tr data-note-id="{{ note.id }}" data-group="{{ note.group }}" data-sort-order="{{ note.sort_order }}" style="border:1px solid #000;">
                     <td class="px-3" style="color:#000!important; border-right:1px solid #000;">
                         <span class="view">{{ note.group }}</span>
                         <input type="text" class="form-control edit d-none" name="group" form="edit-form-{{ note.id }}" value="{{ note.group }}" data-original="{{ note.group }}">
@@ -61,8 +61,12 @@
                             <input type="hidden" name="placeholder_map" form="edit-form-{{ note.id }}" value='{{ note.placeholder_map|tojson }}' data-original='{{ note.placeholder_map|tojson }}'>
                         </div>
                     </td>
-                    <td class="px-3 text-center" style="width:130px;">
+                    <td class="px-3 text-center" style="width:210px;">
                         <div class="view loan-note-actions">
+                            <div class="btn-group btn-group-sm mb-2" role="group" aria-label="Reorder">
+                                <button type="button" class="btn btn-outline-secondary move-note" data-direction="up">Move Up</button>
+                                <button type="button" class="btn btn-outline-secondary move-note" data-direction="down">Move Down</button>
+                            </div>
                             <button type="button" class="btn btn-sm btn-primary edit-note">Edit</button>
                             <form method="post" action="{{ url_for('delete_loan_note', note_id=note.id) }}" style="display:inline;" onsubmit="return confirm('Delete this note?');">
                                 <button type="submit" class="btn btn-sm btn-danger">Delete</button>
@@ -146,7 +150,18 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     initPlaceholderMaps();
     initRowEditing();
+    initReorderControls();
 });
+
+function showToast(message, level = 'success') {
+    if (Novellus?.utils?.showToast) {
+        Novellus.utils.showToast(message, level);
+    } else if (level === 'success') {
+        console.log(message);
+    } else {
+        console.error(message);
+    }
+}
 
 function initPlaceholderMap(wrapper) {
     const hiddenInput = wrapper.querySelector('input[type="hidden"]');
@@ -237,6 +252,151 @@ function initRowEditing() {
             viewEls.forEach(el => el.classList.remove('d-none'));
             editEls.forEach(el => el.classList.add('d-none'));
         });
+    });
+}
+
+function initReorderControls() {
+    document.querySelectorAll('tr[data-note-id]').forEach(row => {
+        row.querySelectorAll('.move-note').forEach(button => {
+            button.addEventListener('click', () => handleReorder(row, button));
+        });
+    });
+    updateMoveButtons();
+}
+
+async function handleReorder(row, button) {
+    const noteId = row.dataset.noteId;
+    if (!noteId) {
+        return;
+    }
+
+    const payload = {};
+    const direction = button.dataset.direction;
+    if (direction) {
+        payload.direction = direction;
+    }
+    if (!payload.direction && button.dataset.position) {
+        payload.position = parseInt(button.dataset.position, 10);
+    }
+
+    const controls = row.querySelectorAll('.move-note');
+    controls.forEach(btn => (btn.disabled = true));
+
+    try {
+        const response = await fetch(`/loan-notes/${noteId}/reorder`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        let data = null;
+        try {
+            data = await response.json();
+        } catch (err) {
+            data = null;
+        }
+
+        if (!response.ok || !data?.success) {
+            const message = data?.message || 'Failed to reorder note';
+            showToast(message, 'danger');
+            return;
+        }
+
+        applyReorderUpdate(data);
+        if (data.message) {
+            showToast(data.message, 'success');
+        }
+    } catch (error) {
+        console.error(error);
+        showToast('Failed to reorder note', 'danger');
+    } finally {
+        controls.forEach(btn => (btn.disabled = false));
+        updateMoveButtons();
+    }
+}
+
+function applyReorderUpdate(data) {
+    if (!data?.group || !Array.isArray(data.order)) {
+        updateMoveButtons();
+        return;
+    }
+
+    reorderGroupRows(data.group, data.order);
+    data.order.forEach(item => {
+        const row = document.querySelector(`tr[data-note-id="${item.id}"]`);
+        if (row) {
+            row.dataset.sortOrder = item.sort_order;
+        }
+    });
+}
+
+function reorderGroupRows(group, order) {
+    const tbody = document.querySelector('table tbody');
+    if (!tbody) {
+        return;
+    }
+
+    const groupRows = Array.from(tbody.querySelectorAll('tr[data-note-id]')).filter(
+        row => row.dataset.group === group
+    );
+    if (!groupRows.length) {
+        return;
+    }
+
+    let afterGroupNode = groupRows[groupRows.length - 1].nextElementSibling;
+    if (afterGroupNode && afterGroupNode.tagName === 'FORM') {
+        afterGroupNode = afterGroupNode.nextElementSibling;
+    }
+
+    const fragment = document.createDocumentFragment();
+    order.forEach(item => {
+        const row = tbody.querySelector(`tr[data-note-id="${item.id}"]`);
+        if (!row || row.dataset.group !== group) {
+            return;
+        }
+        const form = row.nextElementSibling && row.nextElementSibling.tagName === 'FORM'
+            ? row.nextElementSibling
+            : null;
+        fragment.appendChild(row);
+        if (form) {
+            fragment.appendChild(form);
+        }
+    });
+
+    tbody.insertBefore(fragment, afterGroupNode);
+}
+
+function updateMoveButtons() {
+    const groupMap = {};
+    document.querySelectorAll('tr[data-note-id]').forEach(row => {
+        const group = row.dataset.group || '';
+        if (!groupMap[group]) {
+            groupMap[group] = [];
+        }
+        groupMap[group].push(row);
+    });
+
+    Object.values(groupMap).forEach(rows => {
+        rows.forEach(row => {
+            row.querySelectorAll('.move-note').forEach(btn => {
+                btn.disabled = false;
+            });
+        });
+        if (!rows.length) {
+            return;
+        }
+        rows[0].querySelectorAll('.move-note[data-direction="up"]').forEach(btn => {
+            btn.disabled = true;
+        });
+        rows[rows.length - 1]
+            .querySelectorAll('.move-note[data-direction="down"]')
+            .forEach(btn => {
+                btn.disabled = true;
+            });
+        if (rows.length === 1) {
+            rows[0].querySelectorAll('.move-note[data-direction="down"]').forEach(btn => {
+                btn.disabled = true;
+            });
+        }
     });
 }
 </script>


### PR DESCRIPTION
## Summary
- add a `sort_order` column to `LoanNote` with an alembic migration to backfill existing data
- update loan note APIs, document generation, and add a reorder endpoint with UI controls to manage note ordering
- ensure selected notes respect the configured order and cover the behaviour with a DOCX summary test

## Testing
- pytest test_download_loan_summary_docx.py

------
https://chatgpt.com/codex/tasks/task_e_68dfa23aadfc8320934142cbb1abb0ea